### PR TITLE
受講者Idのバリデーション追加#67

### DIFF
--- a/app/Http/Controllers/Api/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/LessonAttendanceController.php
@@ -15,21 +15,23 @@ class LessonAttendanceController extends Controller
         $authId = 1;
         try {
             //ログインユーザーとレッスン受講者idが一致するか検証
-            $lessonAttendance = LessonAttendance::where('id', '=', $request->lesson_attendance_id)->first();
+            $lessonAttendance =  LessonAttendance::with('attendance')
+                ->where('id', '=', $request->lesson_attendance_id)
+                ->first();
+            if ($lessonAttendance === null) {
+                return response()->json([
+                    "result" => false,
+                    "error_code" => 404,
+                    "error_message" => "Not found lesson attendance status."
+                ]);
+            }
             if ($authId !== $lessonAttendance->attendance->student_id) {
                 return response()->json([
                     "result" => false,
-                    "error_code" => 403
-                ]);
-            } else if ($authId === null) {
-                return response()->json([
-                    "result" => false,
-                    "error_code" => 404
+                    "error_code" => 403,
+                    "error_message" => "Forbidden."
                 ]);
             }
-            return response()->json([
-                "result" => true
-            ]);
 
             $lessonAttendance->update([
                 'status' => $request->status,
@@ -37,14 +39,11 @@ class LessonAttendanceController extends Controller
 
             return response()->json([
                 "result" => true,
-                "student_id" => $lessonAttendance->attendance->student_id
             ]);
-        } catch (\Exception $e) {
-            $errorMessage = 'update_error.';
-            Log::error($errorMessage);
+        } catch (\RuntimeException $e) {
+            Log::error($e->getMessage());
             return response()->json([
                 "result" => false,
-                "error_log" => $errorMessage //←エラーログに残す※例外のメッセージは要らない。理由対処しきれない。メッセージを出したところでフロントでは処理しようがない。
             ]);
         }
     }

--- a/app/Http/Controllers/Api/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/LessonAttendanceController.php
@@ -10,15 +10,34 @@ class LessonAttendanceController extends Controller
 {
     public function update(LessonAttendancePatchRequest $request)
     {
-        //　ToDo　ログインユーザーとレッスン受講状態の受講者が一致するか検証が必要
+        // ToDo 認証ユーザーを一時的にid=1とする。
+        $authId = 1;
+        try {
 
-        LessonAttendance::where('id', '=', $request->lesson_attendance_id)
-            ->update([
+            //　ToDo　ログインユーザーとレッスン受講者idが一致するか検証が必要
+            $lessonAttendance = LessonAttendance::where('id', '=', $request->lesson_attendance_id)->first();
+            if ($authId !== $lessonAttendance->attendance->student_id) {
+                return response()->json([
+                    "result" => false
+                ]);
+            }
+            //error code 403
+            //null は404　
+
+            $lessonAttendance->update([
                 'status' => $request->status,
             ]);
 
-        return response()->json([
-            "result" => true,
-        ]);
+            return response()->json([
+                "result" => true,
+                //"lessonAttendance" => $lessonAttendance,
+                //"studen_id" => $lessonAttendance->attendance->student_id
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                "result" => false,
+                "message" => $e->getMessage() //←エラーログに残す※例外のメッセージは要らない。理由対処しきれない。メッセージを出したところでフロントでは処理しようがない。
+            ]);
+        }
     }
 }

--- a/app/Http/Controllers/Api/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/LessonAttendanceController.php
@@ -13,9 +13,8 @@ class LessonAttendanceController extends Controller
     {
         // ToDo 認証ユーザーを一時的にid=1とする。
         $authId = 1;
-        try { throw new \Exception("aa");
-
-            //　ToDo　ログインユーザーとレッスン受講者idが一致するか検証
+        try {
+            //ログインユーザーとレッスン受講者idが一致するか検証
             $lessonAttendance = LessonAttendance::where('id', '=', $request->lesson_attendance_id)->first();
             if ($authId !== $lessonAttendance->attendance->student_id) {
                 return response()->json([

--- a/app/Http/Controllers/Api/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/LessonAttendanceController.php
@@ -38,7 +38,6 @@ class LessonAttendanceController extends Controller
 
             return response()->json([
                 "result" => true,
-                //"lessonAttendance" => $lessonAttendance,
                 "student_id" => $lessonAttendance->attendance->student_id
             ]);
         } catch (\Exception $e) {

--- a/app/Http/Controllers/Api/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/LessonAttendanceController.php
@@ -13,7 +13,7 @@ class LessonAttendanceController extends Controller
     {
         // ToDo 認証ユーザーを一時的にid=1とする。
         $authId = 1;
-        try { //throw new \Exception("aa");
+        try { throw new \Exception("aa");
 
             //　ToDo　ログインユーザーとレッスン受講者idが一致するか検証
             $lessonAttendance = LessonAttendance::where('id', '=', $request->lesson_attendance_id)->first();
@@ -32,10 +32,6 @@ class LessonAttendanceController extends Controller
                 "result" => true
             ]);
 
-
-            //error code 403
-            //null は404　
-
             $lessonAttendance->update([
                 'status' => $request->status,
             ]);
@@ -46,9 +42,11 @@ class LessonAttendanceController extends Controller
                 "student_id" => $lessonAttendance->attendance->student_id
             ]);
         } catch (\Exception $e) {
+            $errorMessage = 'update_error.';
+            Log::error($errorMessage);
             return response()->json([
                 "result" => false,
-                Log::debug('An informational message.') //←エラーログに残す※例外のメッセージは要らない。理由対処しきれない。メッセージを出したところでフロントでは処理しようがない。
+                "error_log" => $errorMessage //←エラーログに残す※例外のメッセージは要らない。理由対処しきれない。メッセージを出したところでフロントでは処理しようがない。
             ]);
         }
     }

--- a/app/Http/Controllers/Api/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/LessonAttendanceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\LessonAttendancePatchRequest;
 use App\Model\LessonAttendance;
+use Illuminate\Support\Facades\Log;
 
 class LessonAttendanceController extends Controller
 {
@@ -12,15 +13,26 @@ class LessonAttendanceController extends Controller
     {
         // ToDo 認証ユーザーを一時的にid=1とする。
         $authId = 1;
-        try {
+        try { //throw new \Exception("aa");
 
-            //　ToDo　ログインユーザーとレッスン受講者idが一致するか検証が必要
+            //　ToDo　ログインユーザーとレッスン受講者idが一致するか検証
             $lessonAttendance = LessonAttendance::where('id', '=', $request->lesson_attendance_id)->first();
             if ($authId !== $lessonAttendance->attendance->student_id) {
                 return response()->json([
-                    "result" => false
+                    "result" => false,
+                    "error_code" => 403
+                ]);
+            } else if ($authId === null) {
+                return response()->json([
+                    "result" => false,
+                    "error_code" => 404
                 ]);
             }
+            return response()->json([
+                "result" => true
+            ]);
+
+
             //error code 403
             //null は404　
 
@@ -31,12 +43,12 @@ class LessonAttendanceController extends Controller
             return response()->json([
                 "result" => true,
                 //"lessonAttendance" => $lessonAttendance,
-                //"studen_id" => $lessonAttendance->attendance->student_id
+                "student_id" => $lessonAttendance->attendance->student_id
             ]);
         } catch (\Exception $e) {
             return response()->json([
                 "result" => false,
-                "message" => $e->getMessage() //←エラーログに残す※例外のメッセージは要らない。理由対処しきれない。メッセージを出したところでフロントでは処理しようがない。
+                Log::debug('An informational message.') //←エラーログに残す※例外のメッセージは要らない。理由対処しきれない。メッセージを出したところでフロントでは処理しようがない。
             ]);
         }
     }

--- a/app/Model/LessonAttendance.php
+++ b/app/Model/LessonAttendance.php
@@ -13,6 +13,10 @@ class LessonAttendance extends Model
      */
     protected $table = 'lesson_attendances';
 
+    protected $fillable = [
+        'status',
+    ];
+    
     // ToDo ステータス定数
     const STATUS_BEFORE_ATTENDANCE = 'before_attendance';
     const STATUS_IN_ATTENDANCE = 'in_attendance';


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/browse/JKA-67?atlOrigin=eyJpIjoiZGU5M2M3OGQ0OTBjNGFhNTgwNTllMjJjYTAwMTdmNjgiLCJwIjoiaiJ9
## やったこと
- ログインユーザーとレッスン受講者idが一致するか検証(nullはfalse)
- try catchの　chatchの処理をエラーログに変更。
## 確認方法
try chatch のchatchの確認は
16行目に` throw new \Exception("AA"); `を追加してください