### PR TITLE
受講者idごとに受講中講座のキーワード検索機能を実装する＃86

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -29,13 +29,12 @@ class CourseController extends Controller
      * @param CoursesGetRequest $request
      * @return CoursesGetResponse
      */
-    public function serch(CoursesGetRequest $request)//(CoursesGetRequest $request)   //入力文字がそのままリターンされるように実装する。
+    public function search(CoursesGetRequest $request)   //入力文字がそのままリターンされるように実装する。
     {
-        // return response()->json([
-        //     "title" => $request
-        // ]);
-        $attendance = Attendance::with(['course.instructor'])->where('student_id', $request->student_id)->get();
-        return new CoursesGetResponse($attendance);
+        
+        return response()->json([
+            "text" => $request->text
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\CoursesGetRequest;
 use App\Http\Resources\CoursesGetResponse;
 use App\Http\Resources\CourseGetResponse;
 use App\Model\Attendance;
+use App\Model\Course;
 
 class CourseController extends Controller
 {
@@ -23,17 +24,26 @@ class CourseController extends Controller
         return new CoursesGetResponse($attendance);
     }
 
-     /**
+    /**
      * 講座検索取得API
      *
      * @param CoursesGetRequest $request
      * @return CoursesGetResponse
      */
-    public function search(CoursesGetRequest $request)   //入力文字がそのままリターンされるように実装する。
+    public function search(CoursesGetRequest $request)
     {
+
+        $lessons = Attendance::whereHas('course', function ($q) use($request) {
+            $q->where('title', 'like', "%$request->text%");
+       })//クロージャ
+       ->where('id', '=', $request->student_id)
+       ->get();
+
+        //テキストがなかったら全件取得
+        //ToDo 最終的にurlを一緒にするので上のindexメソッドと一緒に実行できるようにする
         
         return response()->json([
-            "text" => $request->text
+            "text" => $lessons //変数名。キー名が何を示しているかを分かるようにする。
         ]);
     }
 
@@ -49,7 +59,7 @@ class CourseController extends Controller
             'course.chapters.lessons',
             'course.instructor',
             'lessonAttendances'
-            ])
+        ])
             ->where('id', $request->attendance_id)
             ->first();
 

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -23,6 +23,21 @@ class CourseController extends Controller
         return new CoursesGetResponse($attendance);
     }
 
+     /**
+     * 講座検索取得API
+     *
+     * @param CoursesGetRequest $request
+     * @return CoursesGetResponse
+     */
+    public function serch(CoursesGetRequest $request)//(CoursesGetRequest $request)   //入力文字がそのままリターンされるように実装する。
+    {
+        // return response()->json([
+        //     "title" => $request
+        // ]);
+        $attendance = Attendance::with(['course.instructor'])->where('student_id', $request->student_id)->get();
+        return new CoursesGetResponse($attendance);
+    }
+
     /**
      * 講座詳細取得API
      *

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -33,7 +33,7 @@ class CourseController extends Controller
     public function search(CoursesGetRequest $request)
     {
 
-        $searchLessonAttendance = Attendance::whereHas('course', function ($q) use ($request) {
+        $searchedCourseAttendance = Attendance::whereHas('course', function ($q) use ($request) {
             $q->where('title', 'like', "%$request->text%");
         })
             ->where('student_id', '=', $request->student_id)
@@ -43,7 +43,7 @@ class CourseController extends Controller
         //ToDo 最終的にurlを一緒にするので上のindexメソッドと一緒に実行できるようにする
 
         return response()->json([
-            "searchLessonAttendance" => $searchLessonAttendance //変数名。キー名が何を示しているかを分かるようにする。
+            "searchedCourseAttendance" => $searchedCourseAttendance //変数名。キー名が何を示しているかを分かるようにする。
         ]);
     }
 

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -33,17 +33,17 @@ class CourseController extends Controller
     public function search(CoursesGetRequest $request)
     {
 
-        $lessons = Attendance::whereHas('course', function ($q) use($request) {
+        $searchLessonAttendance = Attendance::whereHas('course', function ($q) use($request) {
             $q->where('title', 'like', "%$request->text%");
        })//クロージャ
-       ->where('id', '=', $request->student_id)
+       ->where('student_id', '=', $request->student_id)
        ->get();
 
         //テキストがなかったら全件取得
         //ToDo 最終的にurlを一緒にするので上のindexメソッドと一緒に実行できるようにする
         
         return response()->json([
-            "text" => $lessons //変数名。キー名が何を示しているかを分かるようにする。
+            "searchLessonAttendance" => $searchLessonAttendance //変数名。キー名が何を示しているかを分かるようにする。
         ]);
     }
 

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -33,15 +33,15 @@ class CourseController extends Controller
     public function search(CoursesGetRequest $request)
     {
 
-        $searchLessonAttendance = Attendance::whereHas('course', function ($q) use($request) {
+        $searchLessonAttendance = Attendance::whereHas('course', function ($q) use ($request) {
             $q->where('title', 'like', "%$request->text%");
-       })//クロージャ
-       ->where('student_id', '=', $request->student_id)
-       ->get();
+        })
+            ->where('student_id', '=', $request->student_id)
+            ->get();
 
         //テキストがなかったら全件取得
         //ToDo 最終的にurlを一緒にするので上のindexメソッドと一緒に実行できるようにする
-        
+
         return response()->json([
             "searchLessonAttendance" => $searchLessonAttendance //変数名。キー名が何を示しているかを分かるようにする。
         ]);

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -8,7 +8,6 @@ use App\Http\Requests\CoursesGetRequest;
 use App\Http\Resources\CoursesGetResponse;
 use App\Http\Resources\CourseGetResponse;
 use App\Model\Attendance;
-use App\Model\Course;
 
 class CourseController extends Controller
 {

--- a/app/Http/Requests/CoursesGetRequest.php
+++ b/app/Http/Requests/CoursesGetRequest.php
@@ -24,7 +24,8 @@ class CoursesGetRequest extends FormRequest
     public function rules()
     {
         return [
-            'student_id' => ['required', 'integer']
+            'student_id' => ['required', 'integer'],
+            'text' => ['string']
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,13 +18,16 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::prefix('v1')->group(function () {
-    Route::get('courses', 'Api\CourseController@index');
+    Route::prefix('courses')->group(function () {
+        Route::get('/', 'Api\CourseController@index');
+        Route::get('/serch', 'Api\CourseController@serch');
+    });
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');
         Route::prefix('chapter')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });
+        Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
     });
-    Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,14 +20,14 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function () {
     Route::prefix('courses')->group(function () {
         Route::get('/', 'Api\CourseController@index');
-        Route::get('/serch', 'Api\CourseController@serch');
+        Route::get('/search', 'Api\CourseController@search');
     });
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');
         Route::prefix('chapter')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });
-        Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
     });
+    Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
 });
 


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/browse/JKA-86?atlOrigin=eyJpIjoiYmI1YWU2MDg4YzVhNDJmNmI3MDcwNDRhNjNmY2M2ODEiLCJwIjoiaiJ9

## やったこと
受講者idごとに受講中講座をキーワード検索する機能を追加しました。

## 連絡事項
分かりやすいようにルーティングで`courses/search`として分けています。
次回`courese`と統合して実装します。

前回の作業会から、変数名とキー名を意味が分かりやすいように考えて変更しました。
もし、より適当なものがあれば教えてください。