### PR TITLE
講座新規登録。ローカルに画像を登録するまで＃87

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -62,23 +62,23 @@ class CourseController extends Controller
      */
     public function store(CourseStoreRequest $request)
     {
-        $courses = new Course;
-        $courses->instructor_id = $request->instructor_id;
-        $courses->title = $request->title;
+        
         $file = $request->file('image');
         $extension = $file->getClientOriginalExtension();
+        //Todo バリデーションをフォームリクエストに移す
         if (!in_array($extension, ['jpg', 'png'])) {
             return response()->json(['error' => 'Only jpg and png files are allowed.']);
         }
         $filename = date('YmdHis') . '.' . $extension;
-        Storage::putFileAs('courese', $file, $filename);
-        $courses->image = $request->image;
-        $courses->save();
+        $filePath = Storage::putFileAs('courese', $file, $filename);
+        
+        $course = new Course;
+        $course->instructor_id = $request->instructor_id;
+        $course->title = $request->title;
+        $course->image = $filePath;
+        $course->save();
         return response()->json([
             "result" => true,
         ]);
-    }//バイナリデータ　受け取りデータ　リクエストでファイルを受けとるメソッド　ファイルパスを保存する　フォームリクエストを作る　りくえすとのいめーじファイルを受け取って保存
-}
-//いったんDBではなく、ローカルに保存されるところまでを目指す
-//storage\app\public\courseに保存YmdHisを使ってファイルを区別する
-//jpgとpngのみ受け入れる。
+    }
+

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -4,10 +4,13 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CourseGetRequest;
+use App\Http\Requests\CourseMakeRequest;
 use App\Http\Requests\CoursesGetRequest;
 use App\Http\Resources\CoursesGetResponse;
 use App\Http\Resources\CourseGetResponse;
 use App\Model\Attendance;
+use App\Model\Course;
+use Illuminate\Support\Facades\Storage;
 
 class CourseController extends Controller
 {
@@ -51,4 +54,32 @@ class CourseController extends Controller
 
         return new CourseGetResponse($attendance);
     }
+    /**
+     * 講座登録API
+     *
+     * @param CourseGetRequest $request
+     * @return CourseGetResponse
+     */
+    public function store(CourseMakeRequest $request)
+    {
+        // $courses = new Course;
+        // $courses->instructor_id = $request->instructor_id;
+        // $courses->title = $request->title;
+        // $courses->image = $request->file('image')->get();
+        $file = $request->file('image');
+        $extension = $file->getClientOriginalExtension();
+        
+        if (!in_array($extension, ['jpg', 'png'])) {
+            return response()->json(['error' => 'Only jpg and png files are allowed.']);
+        }
+        $filename = date('YmdHis') . '.' . $extension;
+        Storage::putFileAs('courese', $file, $filename);
+        //$courses->save();
+        return response()->json([
+            "result" => true,
+        ]);
+    }//バイナリデータ　受け取りデータ　リクエストでファイルを受けとるメソッド　ファイルパスを保存する　フォームリクエストを作る　りくえすとのいめーじファイルを受け取って保存
 }
+//いったんDBではなく、ローカルに保存されるところまでを目指す
+//storage\app\public\courseに保存YmdHisを使ってファイルを区別する
+//jpgとpngのみ受け入れる。

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -62,10 +62,9 @@ class CourseController extends Controller
      */
     public function store(CourseStoreRequest $request)
     {
-        // $courses = new Course;
-        // $courses->instructor_id = $request->instructor_id;
-        // $courses->title = $request->title;
-        // $courses->image = $request->file('image')->get();
+        $courses = new Course;
+        $courses->instructor_id = $request->instructor_id;
+        $courses->title = $request->title;
         $file = $request->file('image');
         $extension = $file->getClientOriginalExtension();
         if (!in_array($extension, ['jpg', 'png'])) {
@@ -73,7 +72,8 @@ class CourseController extends Controller
         }
         $filename = date('YmdHis') . '.' . $extension;
         Storage::putFileAs('courese', $file, $filename);
-        //$courses->save();
+        $courses->image = $request->image;
+        $courses->save();
         return response()->json([
             "result" => true,
         ]);

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CourseGetRequest;
-use App\Http\Requests\CourseMakeRequest;
+use App\Http\Requests\CourseStoreRequest;
 use App\Http\Requests\CoursesGetRequest;
 use App\Http\Resources\CoursesGetResponse;
 use App\Http\Resources\CourseGetResponse;
@@ -60,7 +60,7 @@ class CourseController extends Controller
      * @param CourseGetRequest $request
      * @return CourseGetResponse
      */
-    public function store(CourseMakeRequest $request)
+    public function store(CourseStoreRequest $request)
     {
         // $courses = new Course;
         // $courses->instructor_id = $request->instructor_id;
@@ -68,7 +68,6 @@ class CourseController extends Controller
         // $courses->image = $request->file('image')->get();
         $file = $request->file('image');
         $extension = $file->getClientOriginalExtension();
-        
         if (!in_array($extension, ['jpg', 'png'])) {
             return response()->json(['error' => 'Only jpg and png files are allowed.']);
         }

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -62,7 +62,7 @@ class CourseController extends Controller
      */
     public function store(CourseStoreRequest $request)
     {
-        
+
         $file = $request->file('image');
         $extension = $file->getClientOriginalExtension();
         //Todo バリデーションをフォームリクエストに移す
@@ -71,7 +71,7 @@ class CourseController extends Controller
         }
         $filename = date('YmdHis') . '.' . $extension;
         $filePath = Storage::putFileAs('courese', $file, $filename);
-        
+
         $course = new Course;
         $course->instructor_id = $request->instructor_id;
         $course->title = $request->title;
@@ -81,4 +81,4 @@ class CourseController extends Controller
             "result" => true,
         ]);
     }
-
+}

--- a/app/Http/Requests/CourseMakeRequest.php
+++ b/app/Http/Requests/CourseMakeRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CourseMakeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'instructor_id' => 'required',
+            'title' => 'required'
+        ];
+    }
+}

--- a/app/Http/Requests/CourseStoreRequest.php
+++ b/app/Http/Requests/CourseStoreRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class CourseMakeRequest extends FormRequest
+class CourseStoreRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function () {
     Route::prefix('courses')->group(function () {
         Route::get('/', 'Api\CourseController@index');
+        Route::post('register', 'Api\CourseController@store');
     });
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/browse/JKA-87?atlOrigin=eyJpIjoiNjk0NDM5NDFlNjllNGY1Y2JlY2QzODUzZjU0MjZiN2IiLCJwIjoiaiJ9

## やったこと
講座新規登録でサムネイル画像をローカルに保存するメソッドを追加しました。
Jpgとpngのみ保存できるように条件付けをしています。

## 動作確認方法
POSTmanにて
POSTメソッド http://localhost:8080/api/v1/courses/register
Bodyのform-data
KEY　　　　　　　VALUE
image  (File)　　　任意の画像ファイル
instructor_id          　　　1
title                       　　　　　　 任意のタイトル