### PR TITLE
講座一覧（講師側）空の配列ルーティング＋コントローラ作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Instructor\CoursesGetResponse;
+
+class CourseController extends Controller
+{
+    /**
+     * 講師側講座一覧取得API
+     *
+     * @param $instructor_id
+     * @return CoursesGetResponse
+     */
+    public function index($instructor_id)
+    {
+        return new CoursesGetResponse([]);
+    }
+}

--- a/app/Http/Resources/Instructor/CoursesGetResponse.php
+++ b/app/Http/Resources/Instructor/CoursesGetResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\Instructor;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CoursesGetResponse extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($instructor_id)
+    {
+            return [
+
+            ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,11 @@ Route::prefix('v1')->group(function () {
     Route::prefix('courses')->group(function () {
         Route::get('/', 'Api\CourseController@index');
     });
+
+    Route::prefix('instructor')->group(function () {
+        Route::get('{instructor_id}/courses', 'Api\Instructor\CourseController@index');
+    });
+
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');
         Route::prefix('chapter')->group(function () {
@@ -29,4 +34,3 @@ Route::prefix('v1')->group(function () {
     });
     Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
 });
-


### PR DESCRIPTION
# issue
https://gut-familie.atlassian.net/browse/JKA-104

# やったこと
講師側の講座一覧で空の配列を返すルーティングとコントローラを作成

# 動作確認方法
PostmanにてGETメソッド
http://localhost:8080/api/v1/instructor/{instructor_id}/courses
