### PR TITLE
空の配列を返すようにコントローラ＋ルーティング作成（そばた）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use App\Model\Attendance;
+
+class CourseController extends Controller
+{
+    /**
+     * 講座一覧取得API
+     *
+     * @param $instructor_id
+     * @return array
+     */
+    public function index($instructor_id)
+    {
+        return [];
+    }
+
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,10 @@ Route::prefix('v1')->group(function () {
     Route::prefix('courses')->group(function () {
         Route::get('/', 'Api\CourseController@index');
     });
+    Route::prefix('instructor')->group(function () {
+        Route::get('{instructor_id}/courses', 'Api\Instructor\CourseController@index');
+    });
+    
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');
         Route::prefix('chapter')->group(function () {


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1?selectedIssue=JKA-122

## 概要
- 講座一覧（講師側）空の配列を返すようにコントローラとルーティングを作成

## 動作確認手順
- postmanで、localhost:8080/api/v1/instructor/1/coursesのURLにアクセスして、空の配列と思われるものがレスポンスに表示されたのを確認。

## 確認してほしいこと
- postmanで、レスポンスのとこに、空の配列が返ってきているか、ご確認をお願いいたします。