### PR TITLE
DBからのデータ取得ロジック

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -3,18 +3,20 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\CoursesGetRequest;
 use App\Http\Resources\Instructor\CoursesGetResponse;
+use App\Model\Course;
 
 class CourseController extends Controller
 {
     /**
      * 講師側講座一覧取得API
      *
-     * @param $instructor_id
+     * @param CoursesGetRequest $request
      * @return CoursesGetResponse
      */
-    public function index($instructor_id)
+    public function index(CoursesGetRequest $request)
     {
-        return new CoursesGetResponse([]);
+        $couses = Course::where('instructor_id', $request->instructor_id)->get();
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -17,6 +17,7 @@ class CourseController extends Controller
      */
     public function index(CoursesGetRequest $request)
     {
-        $couses = Course::where('instructor_id', $request->instructor_id)->get();
+        $courses = Course::where('instructor_id', $request->instructor_id)->get();
+        return response()->json($courses);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -18,6 +18,7 @@ class CourseController extends Controller
     public function index(CoursesGetRequest $request)
     {
         $courses = Course::where('instructor_id', $request->instructor_id)->get();
-        return response()->json($courses);
+
+        return new CoursesGetResponse($courses);
     }
 }

--- a/app/Http/Requests/Instructor/CoursesGetRequest.php
+++ b/app/Http/Requests/Instructor/CoursesGetRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CoursesGetRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'instructor_id' => ['required', 'integer'],
+            'text' => ['string']
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'instructor_id' => $this->route('instructor_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/CoursesGetRequest.php
+++ b/app/Http/Requests/Instructor/CoursesGetRequest.php
@@ -25,7 +25,6 @@ class CoursesGetRequest extends FormRequest
     {
         return [
             'instructor_id' => ['required', 'integer'],
-            'text' => ['string']
         ];
     }
 

--- a/app/Http/Resources/Instructor/CoursesGetResponse.php
+++ b/app/Http/Resources/Instructor/CoursesGetResponse.php
@@ -12,10 +12,14 @@ class CoursesGetResponse extends JsonResource
      * @param  \Illuminate\Http\Request  $request
      * @return array
      */
-    public function toArray($instructor_id)
+    public function toArray($request)
     {
+        return $this->resource->map(function($course){
             return [
-
+                'course_id' => $course->id,
+                'title' => $course->title,
+                'image' => $course->image,
             ];
+        });
     }
 }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1?selectedIssue=JKA-130

## 概要
- データベースから取得したデータで必要モノだけ取り出してJSONで返せる実装
- バリデーションの実装

- （追記）講師側のコントローラファイルで、return response()->json($courses)というデータ取得ロジックのコードをCoursesGetResponseクラスに返すようにコードを書き直し、講師側のリソースファイルのコードを、講座のIDとタイトルと画像のデータを取得するよう実装した。

## 動作確認手順
- postmanでlocalhost:8080/api/v1/instructor/1/coursesにGETリクエストでアクセス。
 
- その次に、localhost:8080/api/v1/instructor/a/coursesと、instructor_idのリクエストを数字以外の文字をいれ、バリデーションがかかるか確認。
- （追記） postmanでlocalhost:8080/api/v1/instructor/1/coursesのinstructor_idを１以外の数字でアクセスして空のデータが返ってきたことを確認。

## 考慮してほしいこと
- 上記で（追記）と表記しているとこが今回のタスクの内容です。

## 確認してほしいこと
- 上記概要の説明の認識に間違っていることはないかと、コードに不備がないか、ご確認お願い致します。