### PR TITLE
チャプター名前変更（講師側）データ取得ロジック

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -11,16 +11,16 @@ class ChapterController extends Controller
     /**
      * チャプター名前変更API
      *
-     * @param $chapter_id
+     * @param ChapterPatchRequest $request
      * @return array
      */
     public function update(ChapterPatchRequest $request, $chapter_id)
     {
         
-            $chapter = Chapter::findOrFail($chapter_id);
+           $chapter = Chapter::findOrFail($chapter_id);
             // $chapter->chapter_id = $request->chapter_id;
             $chapter->title = $request->title;
-            $chapter->save();
+            $chapter->update();
         
         return response()->json($chapter);
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\ChapterPatchRequest;
+use App\Model\Chapter;
 
 class ChapterController extends Controller
 {
@@ -12,11 +14,15 @@ class ChapterController extends Controller
      * @param $chapter_id
      * @return array
      */
-    public function update($chapter_id)
+    public function update(ChapterPatchRequest $request, $chapter_id)
     {
-        return response()->json([
-            "result" => true,
-        ]);
+        
+            $chapter = Chapter::findOrFail($chapter_id);
+            // $chapter->chapter_id = $request->chapter_id;
+            $chapter->title = $request->title;
+            $chapter->save();
+        
+        return response()->json($chapter);
 
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -14,13 +14,12 @@ class ChapterController extends Controller
      * @param ChapterPatchRequest $request
      * @return array
      */
-    public function update(ChapterPatchRequest $request, $chapter_id)
+    public function update(ChapterPatchRequest $request)
     {
-        
-           $chapter = Chapter::findOrFail($chapter_id);
-            // $chapter->chapter_id = $request->chapter_id;
-            $chapter->title = $request->title;
-            $chapter->update();
+           $chapter = Chapter::findOrFail($request->chapter_id);
+            $chapter->update([
+                'title' => $request->title
+            ]);
         
         return response()->json($chapter);
 

--- a/app/Http/Requests/Instructor/ChapterPatchRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPatchRequest.php
@@ -32,6 +32,7 @@ class ChapterPatchRequest extends FormRequest
     public function rules()
     {
         return [
+            'course_id' => ['required', 'integer'],
             'chapter_id' => ['required', 'integer'],
             'title' => ['required', 'string'],
         ];

--- a/app/Http/Requests/Instructor/ChapterPatchRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPatchRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChapterPatchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'chapter_id' => ['required', 'integer'],
+            'title' => ['required', 'string'],
+        ];
+    }
+
+}

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -14,7 +14,7 @@ class Chapter extends Model
     protected $table = 'chapters';
 
     /**
-     * 複数代入可能な属性
+     * 
      *
      * @var array
      */

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -14,6 +14,13 @@ class Chapter extends Model
     protected $table = 'chapters';
 
     /**
+     * 複数代入可能な属性
+     *
+     * @var array
+     */
+    protected $fillable = ['chapter_id','title'];
+
+    /**
      * 講座を取得
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,7 @@ Route::prefix('v1')->group(function () {
     });
     Route::prefix('instructor')->group(function () {
         Route::prefix('course')->group(function () {
-            Route::patch('{course_id}/chapter', 'Api\Instructor\ChapterController@update');
+            Route::patch('{course_id}/chapter/{chapter_id}', 'Api\Instructor\ChapterController@update');
         });
     });
     Route::prefix('course')->group(function () {


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-157?atlOrigin=eyJpIjoiN2U2OTMwZTQ1OTZiNDAzNTg5YzgwZmJiMzNhOGRiNjUiLCJwIjoiaiJ9

## 概要
- チャプター名を変更する機能の実装

## 動作確認手順
- Postmanにて、メソッドをPATCHに、URLをlocalhost:8080/api/v1/instructor/course/1/chapter/1にして、
Bodyのrawで、下記を入力して、アクセスして、チャプターIDとコースIDと入力したタイトルのデータが返ってきたことを確認。データベースの方も、変更したタイトルのデータが反映されていることを確認。
{
    "title": "名前変更後のチャプター名"
}

## 考慮してほしいこと
- リソースファイルはまだ、作っていません。

## 確認してほしいこと
- 他に動作確認するべき事項があるのかご確認をよろしくお願いいたします。
