### PR TITLE
チャプター名前変更（講師側）その他（レスポンス追加）修正して完成（そばた）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
+use App\Http\Resources\Instructor\ChapterPatchResponse;
 use App\Model\Chapter;
 
 class ChapterController extends Controller
@@ -12,7 +13,8 @@ class ChapterController extends Controller
      * チャプター名前変更API
      *
      * @param ChapterPatchRequest $request
-     * @return array
+     * @return @return \Illuminate\Http\JsonResponse
+
      */
     public function update(ChapterPatchRequest $request)
     {
@@ -21,7 +23,10 @@ class ChapterController extends Controller
                 'title' => $request->title
             ]);
         
-        return response()->json($chapter);
+        return response()->json([
+            'result' => true,
+            'data' => new ChapterPatchResponse($chapter),
+        ]);
 
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -13,15 +13,14 @@ class ChapterController extends Controller
      * チャプター名前変更API
      *
      * @param ChapterPatchRequest $request
-     * @return @return \Illuminate\Http\JsonResponse
-
+     * @return \Illuminate\Http\JsonResponse
      */
     public function update(ChapterPatchRequest $request)
     {
-           $chapter = Chapter::findOrFail($request->chapter_id);
-            $chapter->update([
-                'title' => $request->title
-            ]);
+        $chapter = Chapter::findOrFail($request->chapter_id);
+        $chapter->update([
+            'title' => $request->title
+        ]);
         
         return response()->json([
             'result' => true,

--- a/app/Http/Resources/Instructor/ChapterPatchResponse.php
+++ b/app/Http/Resources/Instructor/ChapterPatchResponse.php
@@ -15,8 +15,8 @@ class ChapterPatchResponse extends JsonResource
     public function toArray($request)
     {
         return [
-                'chapter_id' => $this->id,
-                'title' => $this->title,
+            'chapter_id' => $this->id,
+            'title' => $this->title,
         ];
     }
 }

--- a/app/Http/Resources/Instructor/ChapterPatchResponse.php
+++ b/app/Http/Resources/Instructor/ChapterPatchResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\Instructor;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ChapterPatchResponse extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+                'chapter_id' => $this->id,
+                'title' => $this->title,
+        ];
+    }
+}


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-163?atlOrigin=eyJpIjoiYjZjODcwODI0ZGM1NDgzYzg3ZGRmZDRiOWRhNTVkOTEiLCJwIjoiaiJ9

## 概要
- コントローラファイルのコードを少し修正
- リソースファイルを作成して、その中に、レスポンスの内容を記述

## 動作確認手順
- Postmanにて、メソッドをPATCHに、URLをlocalhost:8080/api/v1/instructor/course/1/chapter/1　にして、
Bodyのrawで、変更するタイトルを下記のように入力して、アクセスするとチャプターID１と入力したタイトルのデータが返ってきたことを確認。
データベースの方も、id１のカラムデータが、入力したタイトルのデータなって、反映されていることを確認。
{
"title": "PHPとは？2"
}

- また、通信設定をURLだけ、localhost:8080/api/v1/instructor/course/1/chapter/2　に変更して、変更するタイトルを下記のように入力して、アクセスするとチャプターID２と入力したタイトルのデータが返ってきたことを確認。
データベースの方も、id2のカラムデータが、入力したタイトルのデータなって、反映されていることを確認。
{
    "title": "PHPの基礎を学ぼう2"
}

## 考慮してほしいこと
- 特にありません。

## 確認してほしいこと
- 動作確認手順は、他にすることはないか、ご確認お願い致します。

- コードに不備がないか、ご確認お願い致します。