### PR TITLE
JKA192 更新機能の空配列を返すコントローラーとルート作成(平林）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -36,6 +36,13 @@ class LessonController extends Controller
                 "result" => false,
             ], 500);
         }
+        
+    }
+    public function update($id)
+    {
+        $lesson = lesson::find($id);
+        return response()->json([
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -23,7 +23,7 @@ class LessonController extends Controller
             $lesson = Lesson::create([
                 'chapter_id' => $request->input('chapter_id'),
                 'title' => $request->input('title'),
-                'status' => 'private',
+                'status' =>  Lesson::STATUS_PRIVATE,
             ]);
 
             return response()->json([
@@ -31,7 +31,7 @@ class LessonController extends Controller
                 "data" => new LessonStoreResource($lesson),
             ]);
         } catch (Exception $e) {
-            Log::error($e->getMessage());
+            Log::error($e);
             return response()->json([
                 "result" => false,
             ], 500);

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -38,10 +38,10 @@ class LessonController extends Controller
         }
         
     }
-    
-    public function update($Lesson_id)
+
+    public function update($lesson_id)
     {
-        $lesson = lesson::find($Lesson_id);
+        $lesson = lesson::find($lesson_id);
         return response()->json([
         ]);
     }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -38,9 +38,10 @@ class LessonController extends Controller
         }
         
     }
-    public function update($id)
+    
+    public function update($Lesson_id)
     {
-        $lesson = lesson::find($id);
+        $lesson = lesson::find($Lesson_id);
         return response()->json([
         ]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,7 +45,8 @@ Route::prefix('v1')->group(function () {
             });
         });
     });
-});  
+}); 
+ 
     // 受講生側API
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,10 +34,10 @@ Route::prefix('v1')->group(function () {
                     Route::prefix('{chapter_id}')->group(function () {
                         Route::patch('/', 'Api\Instructor\ChapterController@update');
                         Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                        Route::prefix('lesson')->group(function () {
+                        Route::prefix('lesson_id')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
-                            Route::patch('{id}','Api\Instructor\LessonController@update');
+                            Route::patch('/','Api\Instructor\LessonController@update');
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,14 +38,14 @@ Route::prefix('v1')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
                             Route::prefix('{lesson_id}')->group(function () {
-                                Route::patch('/','Api\Instructor\LessonController@update');
+                                Route::patch('/', 'Api\Instructor\LessonController@update');
+                            });
                         });
                     });
                 });
             });
         });
-    });
-}); 
+    }); 
  
     // 受講生側API
     Route::prefix('course')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,17 +34,18 @@ Route::prefix('v1')->group(function () {
                     Route::prefix('{chapter_id}')->group(function () {
                         Route::patch('/', 'Api\Instructor\ChapterController@update');
                         Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                        Route::prefix('lesson_id')->group(function () {
+                        Route::prefix('lesson')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
-                            Route::patch('/','Api\Instructor\LessonController@update');
+                            Route::prefix('{lesson_id}')->group(function () {
+                                Route::patch('/','Api\Instructor\LessonController@update');
                         });
                     });
                 });
             });
         });
     });
-    
+});  
     // 受講生側API
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,12 +37,14 @@ Route::prefix('v1')->group(function () {
                         Route::prefix('lesson')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
+                            Route::patch('{id}','Api\Instructor\LessonController@update');
                         });
                     });
                 });
             });
         });
     });
+    
 
     // 受講生側API
     Route::prefix('course')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,7 +45,6 @@ Route::prefix('v1')->group(function () {
         });
     });
     
-
     // 受講生側API
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');


### PR DESCRIPTION
## 発行
https://gut-familie.atlassian.net/browse/JKA-192

## 概要
- JKA192 更新機能の空配列を返すコントローラーとルート作成

## 動作確認
- 修正後再度ポストマンでから配列が返ってきたことを確認しました。