### PR TITLE
レッスン編集画面の空の配列を返す(コントローラーとルーティング修正)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -47,4 +47,16 @@ class LessonController extends Controller
     {
         return response()->json([]);
     }
+
+    /**
+     * レッスン編集
+     *
+     * @param LessonEditRequest 
+     * @return LessonEditResource
+     */
+    public function edit(Lesson $lesson)
+    {   
+        $lesson = Lesson::find($lesson);    
+        return response()->json([]);      
+    }
 }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -54,9 +54,8 @@ class LessonController extends Controller
      * @param LessonEditRequest 
      * @return LessonEditResource
      */
-    public function edit(Lesson $lesson)
-    {   
-        $lesson = Lesson::find($lesson);    
+    public function edit()
+    {       
         return response()->json([]);      
     }
 }

--- a/app/Http/Requests/Instructor/LessonEditRequest.php
+++ b/app/Http/Requests/Instructor/LessonEditRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonEditRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'lesson_id' => ['required','integer'],
+            'title' => ['required','string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/LessonEditRequest.php
+++ b/app/Http/Requests/Instructor/LessonEditRequest.php
@@ -24,8 +24,7 @@ class LessonEditRequest extends FormRequest
     public function rules()
     {
         return [
-            'lesson_id' => ['required','integer'],
-            'title' => ['required','string'],
+            'lesson_id' => ['required','integer']
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,7 @@ Route::prefix('v1')->group(function () {
                         Route::prefix('lesson')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
+                            Route::get('edit', 'Api\Instructor\LessonController@edit');
                         });
                     });
                 });


### PR DESCRIPTION
# 発行

https://gut-familie.atlassian.net/browse/JKA-191


# 概要
JKA191更新機能の空配列を返すコントローラーとルート作成

# 動作確認
api.phpを追記
LessonControllerに追記
LessonEditRequestを追加

# 確認して欲しいこと
postmanから空の配列が返ってきたことを確認しました。ご確認お願いします。

 GETの
http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/edit
がURLです。

余計なコードや不要なコードが入っていないかご確認お願いします。



