### PR TITLE
jka-177レッスン削除機能の空の配列を返すコントローラーとルート作成  (にしだ)

### DIFF
--- a/app/Http/Controllers/LessonController.php
+++ b/app/Http/Controllers/LessonController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 
 class LessonController extends Controller
 {
-    public function deleteLesson($lesson_id)
+    public function delete($lesson_id)
     {
         // レッスンの削除処理を行う
 
@@ -22,6 +22,6 @@ class LessonController extends Controller
             "error_code" => "400"
         ];
 
-        return $response;
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/LessonController.php
+++ b/app/Http/Controllers/LessonController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class LessonController extends Controller
+{
+    public function deleteLesson($lesson_id)
+    {
+        // レッスンの削除処理を行う
+
+        // レスポンス:正常
+        $response = [
+            "result" => true,
+        ];
+
+        // レスポンス:異常
+        $errorResponse = [
+            "result" => false,
+            "error_message" => "Invalid Request Body.",
+            "error_code" => "400"
+        ];
+
+        return $response;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,7 @@ Route::prefix('v1')->group(function () {
                         Route::prefix('lesson')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
-                            Route::delete('/lessons/{lesson_id}', 'LessonController@deleteLesson');
+                            Route::delete('/lessons/{lesson_id}', 'LessonController@delete');
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,7 @@ Route::prefix('v1')->group(function () {
                         Route::prefix('lesson')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
+                            Route::delete('/lessons/{lesson_id}', 'LessonController@deleteLesson');
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,7 @@ Route::prefix('v1')->group(function () {
                         Route::prefix('lesson')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');
                             Route::post('sort', 'Api\Instructor\LessonController@sort');
-                            Route::delete('/lessons/{lesson_id}', 'LessonController@delete');
+                            Route::delete('/{lesson_id}', 'LessonController@delete');
                         });
                     });
                 });


### PR DESCRIPTION
## 概要
- レッスン削除機能の空の配列を返すコントローラーとルート作成

## 動作確認
- ポストマンで空の配列が返ってくるのを確認しました。
-  DELETE　http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/lessons/1

