### PR TITLE
レッスン編集画面DBからのデータ取得ロジック

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\LessonStoreRequest;
 use App\Http\Resources\Instructor\LessonStoreResource;
+use App\Http\Requests\Instructor\LessonEditRequest;
 use App\Model\Lesson;
 use Exception;
 use Illuminate\Support\Facades\Log;
@@ -54,8 +55,25 @@ class LessonController extends Controller
      * @param LessonEditRequest 
      * @return LessonEditResource
      */
-    public function edit()
-    {       
-        return response()->json([]);      
+    public function edit(LessonEditRequest $request, $lesson_id)
+    {   
+        $lesson = Lesson::findOrFail($lesson_id);
+        // レッスンのデータを編集画面に適した形式で返す
+        $data = [
+            'chapter_id' => $lesson->chapter_id,
+            'title' => 'チャプタータイトル',
+            'lessons' => [
+                [
+                    'lesson_id' => $lesson->id,
+                    'title' => $lesson->title,
+                    'url' => $lesson->url,
+                    'remarks' => $lesson->remarks,
+                    'order' => $lesson->order,
+                ],
+            ],
+        ];
+        return response()->json([
+            'data' => $data,
+        ]);
     }
 }

--- a/app/Http/Requests/Instructor/LessonEditRequest.php
+++ b/app/Http/Requests/Instructor/LessonEditRequest.php
@@ -24,7 +24,12 @@ class LessonEditRequest extends FormRequest
     public function rules()
     {
         return [
-            'lesson_id' => ['required','integer']
+                'lessons' => 'array',
+                'lessons.*.lesson_id' => 'required|integer',
+                'lessons.*.title' => 'required|string',
+                'lessons.*.url' => 'required|string',
+                'lessons.*.remark' => 'string',
+                'lessons.*.order' => 'integer',
         ];
     }
 }

--- a/app/Http/Resources/LessonEditResource.php
+++ b/app/Http/Resources/LessonEditResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class LessonEditResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'data' => [
+                'chapter_id' => $this->chapter_id,
+                'title' => $this->title,
+                'lesson' => [
+                    [
+                        'lesson_id' => $this->chapter_id,
+                        'title' => $this->title,
+                        'url' => $this->url,
+                        'remark' => $this->remark,
+                        'order' => $this->order,
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# 概要
レッスン編集画面DBからのデータ取得ロジック

# 動作確認手順
LessonRequest.phpに追記
LessonController.phpに追記
LesoonEditResource.phpを作成

# 確認して欲しいこと
岡田さんが以前作っていただいたロジック通りの取得はできました。
```
//     "data": {
        //         "chapter_id": 1,
        //         "title": "チャプタータイトル",
        //         "lessons":[
        //             {
        //             "lesson_id": 1,
        //             "title": "Lesson1",
        //             "url": "sVbEyFZKgqk",
        //             "remark": "備考",
        //             "order": 1
        //             }
        //         ]
        //     }
        //   }
```
orderは今現在nullですがまだ作っていないので今回はnullのままでいいみたいです。
昨日作業会でゆきひろさんに確認しました。


<img width="921" alt="スクリーンショット 2023-06-03 16 27 38" src="https://github.com/yukihiroLaravel/juko_laravel/assets/73786052/97434ceb-6a1f-4104-a418-030b63c1788b">
