### PR TITLE
チャプター詳細表示(講師側）データ取得ロジック

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -66,7 +66,7 @@ class ChapterController extends Controller
         $data = [
             'chapter_id' => $chapter->id,
             'title' => $chapter->title,
-            'lesson' => $lessons,
+            'lessons' => $lessons,
         ];
 
         return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -59,7 +59,7 @@ class ChapterController extends Controller
                 'lesson_id' => $lesson->id,
                 'title' => $lesson->title,
                 'url' => $lesson->url,
-                'remark' => $lesson-> remarks,
+                'remark' => $lesson->remarks,
                 'order' => $lesson->order,
             ];
         }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -48,30 +48,32 @@ class ChapterController extends Controller
      * @return ChapterShowResource
      */
 
-     public function show(ChapterShowRequest $request, $chapter_id)
-     {
-         $chapter = Chapter::with('lessons')
-             ->findOrFail($chapter_id);
- 
-         $data = [
-             'chapter_id' => $chapter->id, 
-             'title' => $chapter->title,
-             'lessons' => [
-                 [
-                     'lesson_id' => $chapter->lessons[0]->id, 
-                     'title' => $chapter->lessons[0]->title,
-                     'url' => $chapter->lessons[0]->url,
-                     'remarks' => $chapter->lessons[0]->remarks,
-                     'order' => $chapter->lessons[0]->order, 
-                 ]
-             ],
-         ];
- 
-         return response()->json([
-             'data' => $data,
-         ]); 
+    public function show(ChapterShowRequest $request, $chapter_id)
+    {
+        $chapter = Chapter::with('lessons')
+            ->findOrFail($chapter_id);
+        
+        $lessons = [];
+        foreach ($chapter->lessons as $lesson){
+            $lessons[] = [
+                'lesson_id' => $lesson->id,
+                'title' => $lesson->title,
+                'url' => $lesson->url,
+                'remark' => $lesson-> remarks,
+                'order' => $lesson->order,
+            ];
+        }
+        $data = [
+            'chapter_id' => $chapter->id,
+            'title' => $chapter->title,
+            'lesson' => $lessons,
+        ];
+
+        return response()->json([
+            'data' => $data,
+        ]); 
     }
- 
+
     /**
      * チャプター更新API
      *

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
 use App\Http\Requests\Instructor\ChapterStoreRequest;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
+use App\Http\Requests\Instructor\ChapterShowRequest;
 use App\Http\Resources\Instructor\ChapterStoreResource;
 use App\Http\Resources\Instructor\ChapterPatchResource;
 use Illuminate\Support\Facades\Log;
@@ -40,6 +41,37 @@ class ChapterController extends Controller
         }
     }
 
+    /**
+     * チャプター詳細情報を取得
+     *
+     * @param ChapterGetRequest $request
+     * @return ChapterShowResource
+     */
+
+     public function show(ChapterShowRequest $request, $chapter_id)
+     {
+         $chapter = Chapter::with('lessons')
+             ->findOrFail($chapter_id);
+ 
+         $data = [
+             'chapter_id' => $chapter->id, 
+             'title' => $chapter->title,
+             'lessons' => [
+                 [
+                     'lesson_id' => $chapter->lessons[0]->id, 
+                     'title' => $chapter->lessons[0]->title,
+                     'url' => $chapter->lessons[0]->url,
+                     'remarks' => $chapter->lessons[0]->remarks,
+                     'order' => $chapter->lessons[0]->order, 
+                 ]
+             ],
+         ];
+ 
+         return response()->json([
+             'data' => $data,
+         ]); 
+    }
+ 
     /**
      * チャプター更新API
      *

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -73,7 +73,6 @@ class ChapterController extends Controller
             'data' => $data,
         ]); 
     }
-
     /**
      * チャプター更新API
      *

--- a/app/Http/Requests/Instructor/ChapterShowRequest.php
+++ b/app/Http/Requests/Instructor/ChapterShowRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChapterShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+         return [
+            'chapters' => 'array',
+            'chapters.*.lesson_id' => 'required|integer',
+            'chapters.*.title' => 'required|string',
+            'chapters.*.url' => 'required|string',
+            'chapters.*.remarks' => 'string',
+            'chapters.*.order' => 'integer',
+        ];
+    }
+}

--- a/app/Http/Resources/Instructor/ChapterShowResource.php
+++ b/app/Http/Resources/Instructor/ChapterShowResource.php
@@ -29,6 +29,5 @@ class ChapterShowResource extends JsonResource
                 }),
             ],
         ];
-
     }
 }

--- a/app/Http/Resources/Instructor/ChapterShowResource.php
+++ b/app/Http/Resources/Instructor/ChapterShowResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources\Instructor;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ChapterShowResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'data' => [
+                'chapter_id' => $this->chapter_id,
+                'title' => $this->title,
+                'lessons' => $this->lessons->map(function ($lesson) {
+                    return [
+                        'lesson_id' => $lesson->lesson_id,
+                        'title' => $lesson->title,
+                        'url' => $lesson->url,
+                        'remark' => $lesson->remarks,
+                        'order' => $lesson->order,
+                    ];
+                }),
+            ],
+        ];
+
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,9 +30,9 @@ Route::prefix('v1')->group(function () {
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
-                    Route::get('/', 'Api\Instructor\ChapterController@show');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');
                     Route::prefix('{chapter_id}')->group(function () {
+                        Route::get('/', 'Api\Instructor\ChapterController@show');
                         Route::patch('/', 'Api\Instructor\ChapterController@update');
                         Route::delete('/', 'Api\Instructor\ChapterController@delete');
                         Route::prefix('lesson')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,6 +30,7 @@ Route::prefix('v1')->group(function () {
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
+                    Route::get('/', 'Api\Instructor\ChapterController@show');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');
                     Route::prefix('{chapter_id}')->group(function () {
                         Route::patch('/', 'Api\Instructor\ChapterController@update');


### PR DESCRIPTION
# 概要

チャプター詳細表示(講師側）データ取得ロジック

# 動作確認手順
api.php
Controllers/Api/Instructor/ChapterController.php
Requests/Instructor/ChapterShowRequest.php
Resources/Instructor/ChapterShowResource.php


# 考慮して欲しいこと
岡田さんが以前作ったロジックです。

```
"data": {
                 "chapter_id": 1,
                "title": "チャプタータイトル",
                "lessons":[
                   {
        　             "lesson_id": 1,
             　　     "title": "Lesson1",
        　             "url": "sVbEyFZKgqk",
       　　          "remark": "備考",
      　　          "order": 1
                    }
       　         ]
            }
         } （編集

```

# 確認して欲しいこと
想定通りに返ってきました。何かコードの修正点や挙動で不足している点をご確認お願いします。


<img width="894" alt="スクリーンショット 2023-06-08 0 07 45" src="https://github.com/yukihiroLaravel/juko_laravel/assets/73786052/5c4ecb3a-a5dc-442a-99b2-93f151108d7e">


