### PR TITLE
講座削除機能（講師側）条件分岐（杉原）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -140,7 +140,6 @@ class CourseController extends Controller
     {
         $course = Course::findOrFail($request->course_id);
         $attendance = Attendance::where('course_id', $request->course_id)
-            ->whereNull('deleted_at')
             ->exists();
         $result = false;
         if(!$attendance){

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -140,17 +140,15 @@ class CourseController extends Controller
     {
         $course = Course::findOrFail($request->course_id);
         $attendance = Attendance::where('course_id', $request->course_id)
-        ->whereNull('deleted_at')
-        ->exists();
+            ->whereNull('deleted_at')
+            ->exists();
+        $result = false;
         if(!$attendance){
             $course->delete();
-            return response()->json([
-                "result" => true
-            ]);
-        }else{
-            return response()->json([
-                "result" => false
-            ]);
+            $result = true;
         }
+        return response()->json([
+            "result" => $result
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Model\Course;
+use App\Model\Attendance;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\CourseDeleteRequest;
 use App\Http\Requests\Instructor\CourseUpdateRequest;
@@ -138,9 +139,18 @@ class CourseController extends Controller
     public function delete(CourseDeleteRequest $request)
     {
         $course = Course::findOrFail($request->course_id);
-        $course->delete();
-        return response()->json([
-
-        ]);
+        $attendance = Attendance::where('course_id', $request->course_id)
+        ->whereNull('deleted_at')
+        ->exists();
+        if(!$attendance){
+            $course->delete();
+            return response()->json([
+                "result" => true
+            ]);
+        }else{
+            return response()->json([
+                "result" => false
+            ]);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -139,15 +139,15 @@ class CourseController extends Controller
     public function delete(CourseDeleteRequest $request)
     {
         $course = Course::findOrFail($request->course_id);
-        $attendance = Attendance::where('course_id', $request->course_id)
-            ->exists();
-        $result = false;
-        if(!$attendance){
-            $course->delete();
-            $result = true;
+        if (Attendance::where('course_id', $request->course_id)->exists()) {
+            return response()->json([
+                "result" => false,
+                "message" => "This course has already been taken by students."
+            ]);
         }
+        $course->delete();
         return response()->json([
-            "result" => $result
+            "result" => true,
         ]);
     }
 }

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -3,9 +3,12 @@
 namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Attendance extends Model
 {
+    use SoftDeletes;
+
     /**
      * モデルと関連しているテーブル
      *


### PR DESCRIPTION
## 概要
- 講座削除機能（講師側）受講中の生徒がいた場合は削除しない　条件分岐
## 動作確認手順
- attendancesテーブルにcourse_id = 1のデータとcoursesテーブルのid=1、id=2のデータを作成しておく。
- postマン DELTEメソッドでhttp://localhost:8080/api/v1/instructor/course/1　send　ボタン押下
- adminerにてcoursesテーブルのid = 1 のデータは削除されていない事を確認　※ポストマン　(result = false)確認 
- postマン DELTEメソッドでhttp://localhost:8080/api/v1/instructor/course/2　send　ボタン押下
- adminerにてcoursesテーブルのid = 2 のデータは論理削除されている事を確認　※ポストマン　(result = true)確認






