### PR TITLE
チャプター並べ替え機能フォームリクエスト作成(﨑園)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -84,7 +84,7 @@ class ChapterController extends Controller
      * @return \Illuminate\Http\JsonResponse
      * 
      */
-    public function sort(Request $request)
+    public function sort(ChapterSortRequest $request)
     {
         try {
             DB::beginTransaction();

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -12,7 +12,6 @@ use App\Http\Resources\Instructor\ChapterStoreResource;
 use App\Http\Resources\Instructor\ChapterPatchResource;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Http\Request;
 use Exception;
 
 class ChapterController extends Controller

--- a/app/Http/Requests/Instructor/ChapterSortRequest.php
+++ b/app/Http/Requests/Instructor/ChapterSortRequest.php
@@ -16,14 +16,6 @@ class ChapterSortRequest extends FormRequest
         return true;
     }
 
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'title' => ('title'),
-            'course_id' => ('course_id')
-        ]);
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *
@@ -36,7 +28,5 @@ class ChapterSortRequest extends FormRequest
             'chapters.*.chapter_id' => ['required', 'integer'],
             'chapters.*.order' => ['required', 'integer'],
         ];
-    }
-
-    
+    }    
 }

--- a/app/Http/Requests/Instructor/ChapterSortRequest.php
+++ b/app/Http/Requests/Instructor/ChapterSortRequest.php
@@ -28,5 +28,13 @@ class ChapterSortRequest extends FormRequest
             'chapters.*.chapter_id' => ['required', 'integer'],
             'chapters.*.order' => ['required', 'integer'],
         ];
-    }    
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
 }

--- a/app/Http/Requests/Instructor/ChapterSortRequest.php
+++ b/app/Http/Requests/Instructor/ChapterSortRequest.php
@@ -20,10 +20,12 @@ class ChapterSortRequest extends FormRequest
      * Get the validation rules that apply to the request.
      *
      * @return array
-     */    
+     */ 
+    
     public function rules()
     {
-        return [            
+        return [
+            'course_id' => ['required', 'integer'],
             'chapters' => ['required', 'array'],
             'chapters.*.chapter_id' => ['required', 'integer'],
             'chapters.*.order' => ['required', 'integer'],
@@ -34,7 +36,6 @@ class ChapterSortRequest extends FormRequest
     {
         $this->merge([
             'course_id' => $this->route('course_id'),
-            'chapter_id' => $this->route('chapter_id'),
         ]);
     }
 }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-202

## 実施内容
- チャプター並べ替え機能（講師側）フォームリクエスト作成

## 動作確認手順
- Postmanにてリクエストを送信
- trueが返ってくることを確認
- バリデーション内容で条件エラーが返ってくることを確認
![スクリーンショット 2023-06-12 11 54 03](https://github.com/yukihiroLaravel/juko_laravel/assets/123532464/30651ff2-25a0-4c16-8756-06e9a5813f6d)
![スクリーンショット 2023-06-12 11 54 15](https://github.com/yukihiroLaravel/juko_laravel/assets/123532464/7d91e021-71e4-4ff1-ad94-0185c7942c42)

## 確認してほしいこと
- 他のリクエストファイルにはprotected function prepareForValidation()があるのですが、chaptersortには要らないと判断しました。必要でしょうか？prepareForValidation()はどのような役割があるのでしょうか？