### PR TITLE
チャプター並べ替え機能:追加分_courseIdバリデーション(﨑園)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
+use App\Model\Course;
 use App\Model\Chapter;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
@@ -88,10 +89,13 @@ class ChapterController extends Controller
         try {
             DB::beginTransaction();
 
+            $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');
 
             foreach ($chapters as $chapter) {
-                Chapter::findOrFail($chapter['chapter_id'])->update([
+                Chapter::where('id',$chapter['chapter_id'])
+                ->where('course_id', $courseId)
+                ->firstOrFail()->update([
                     'order' => $chapter['order']
                 ]);
             }
@@ -106,7 +110,8 @@ class ChapterController extends Controller
             Log::error($e);
 
             return response()->json([
-                'result' => false
+                'result' => false,
+                'error_message' => $e->getMessage()
             ], 500);
         }
     }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -13,6 +13,7 @@ use App\Http\Resources\Instructor\ChapterPatchResource;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Exception;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ChapterController extends Controller
 {
@@ -92,25 +93,26 @@ class ChapterController extends Controller
             $chapters = $request->input('chapters');
 
             foreach ($chapters as $chapter) {
-                Chapter::where('id',$chapter['chapter_id'])
-                ->where('course_id', $courseId)
-                ->firstOrFail()->update([
+                Chapter::where('id',$chapter['chapter_id'])->where('course_id', $courseId)->firstOrFail()
+                ->update([
                     'order' => $chapter['order']
                 ]);
             }
-
             DB::commit();
-
             return response()->json([
                 'result' => true,
             ]);
-        } catch (Exception $e) {
+        } catch (ModelNotFoundException $e) {
             DB::rollBack();
-            Log::error($e);
-
             return response()->json([
                 'result' => false,
                 'message' => 'Not found course.'
+            ], 500);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
             ], 500);
         }
     }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -93,7 +93,9 @@ class ChapterController extends Controller
             $chapters = $request->input('chapters');
 
             foreach ($chapters as $chapter) {
-                Chapter::where('id',$chapter['chapter_id'])->where('course_id', $courseId)->firstOrFail()
+                Chapter::where('id',$chapter['chapter_id'])
+                ->where('course_id', $courseId)
+                ->firstOrFail()
                 ->update([
                     'order' => $chapter['order']
                 ]);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use App\Model\Course;
 use App\Model\Chapter;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
@@ -111,7 +110,7 @@ class ChapterController extends Controller
 
             return response()->json([
                 'result' => false,
-                'error_message' => $e->getMessage()
+                'message' => 'Not found course.'
             ], 500);
         }
     }

--- a/app/Http/Requests/Instructor/ChapterSortRequest.php
+++ b/app/Http/Requests/Instructor/ChapterSortRequest.php
@@ -26,13 +26,9 @@ class ChapterSortRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id'],
+            'course_id' => ['required', 'integer'],
             'chapters' => ['required', 'array'],
-            'chapters.*.chapter_id' => ['required', 'integer',
-            Rule::exists('chapters', 'id')->where(function ($query) {
-                $query->where('course_id', $this->input('course_id'));
-                }),
-            ],
+            'chapters.*.chapter_id' => ['required', 'integer'],
             'chapters.*.order' => ['required', 'integer'],
         ];
     }

--- a/app/Http/Requests/Instructor/ChapterSortRequest.php
+++ b/app/Http/Requests/Instructor/ChapterSortRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class ChapterSortRequest extends FormRequest
 {
@@ -25,9 +26,13 @@ class ChapterSortRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer'],
+            'course_id' => ['required', 'integer', 'exists:courses,id'],
             'chapters' => ['required', 'array'],
-            'chapters.*.chapter_id' => ['required', 'integer'],
+            'chapters.*.chapter_id' => ['required', 'integer',
+            Rule::exists('chapters', 'id')->where(function ($query) {
+                $query->where('course_id', $this->input('course_id'));
+                }),
+            ],
             'chapters.*.order' => ['required', 'integer'],
         ];
     }

--- a/app/Http/Requests/Instructor/ChapterSortRequest.php
+++ b/app/Http/Requests/Instructor/ChapterSortRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class ChapterSortRequest extends FormRequest
 {

--- a/database/seeds/ChapterSeeder.php
+++ b/database/seeds/ChapterSeeder.php
@@ -35,6 +35,20 @@ class ChapterSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'course_id' => 2,
+                'order' => 1,
+                'title' => 'Laravelとは？',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'course_id' => 2,
+                'order' => 2,
+                'title' => 'Laravelの基礎を学ぼう',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-228

## 実施内容
- ChapterSortRequest.phpを編集

## 確認方法
- Postmanにてapiのcourse_idを変更してリクエストを送信
- バリデーションにてエラーが表示される

## 確認してほしいこと
- チャプターテーブルにテストデータを追記し、course_idの違いも確認したのですがどうでしょうか？
- 他の記述方法や整合性確認の仕方があればご教示頂きたいです。
![スクリーンショット 2023-06-20 14 42 57](https://github.com/yukihiroLaravel/juko_laravel/assets/123532464/2162a988-67c2-4286-a6c7
![スクリーンショット 2023-06-20 14 44 25](https://github.com/yukihiroLaravel/juko_laravel/assets/123532464/e91bd1d8-092f-4a10-ae98-6a301a11fedb)
-f148495b3191)
![スクリーンショット 2023-06-20 14 45 10](https://github.com/yukihiroLaravel/juko_laravel/assets/123532464/7807cfc3-efa6-446f-b09a-e87cbd35f9d3)