### PR TITLE
講座削除機能（画像削除）(杉原)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -96,7 +96,7 @@ class CourseController extends Controller
     public function update(CourseUpdateRequest $request)
     {
         $file = $request->file('image');
-
+        
         try {
             $course = Course::FindOrFail($request->course_id);
             $imagePath = $course->image;
@@ -144,6 +144,9 @@ class CourseController extends Controller
                 "result" => false,
                 "message" => "This course has already been taken by students."
             ]);
+        }
+        if (Storage::exists($course->image)) {
+            Storage::delete($course->image);
         }
         $course->delete();
         return response()->json([


### PR DESCRIPTION
## 概要
- 講座削除機能（講師側）サムネイルがあった場合画像削除
## 動作確認手順
- postmanにてDeleteメソッド
- http://localhost:8080/api/v1/instructor/course/任意のコースID→send
- ララベルプロジェクト内に保存されている削除対象で指定した任意のコースIDに紐づいているcorsesテーブルのimageカラムに格納されているパスの画像ファイルが削除されている事を確認

## 確認して欲しいこと
- corsesテーブルのimageカラムに格納されているファイル格納パスが存在すればサムネイルが存在するという認識で問題なかったのでしょうか？
よろしくお願いいたします。
