### PR TITLE
リクエストの講座IDとチャプターIDが、更新対象のレッスンの講座IDとチャプターIDと一致するか検証

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -50,9 +50,18 @@ class ChapterController extends Controller
      */
     public function show(ChapterShowRequest $request)
     {
-        $chapter = Chapter::with(['lessons.chapter'])
-            ->findOrFail($request->chapter_id);
-        return new ChapterShowResource($chapter);
+        $chapter = Chapter::with('lessons')->findOrFail($request->chapter_id);
+        if ((int) $request->course_id !== $chapter->course->id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'invalid lesson_id or chapter_id.',
+            ], 500);
+        }
+
+        return response()->json([
+            'result' => true,
+            'data' => new ChapterShowResource($chapter)
+        ]);
     }
 
     /**
@@ -70,7 +79,7 @@ class ChapterController extends Controller
 
         return response()->json([
             'result' => true,
-            'data' => new ChapterPatchResource($chapter),
+            'data' => new ChapterPatchResource($chapter)
         ]);
     }
 

--- a/app/Http/Requests/Instructor/ChapterShowRequest.php
+++ b/app/Http/Requests/Instructor/ChapterShowRequest.php
@@ -11,6 +11,7 @@ class ChapterShowRequest extends FormRequest
         $this->merge([
             'course_id' => $this->route('course_id'),
             'chapter_id' => $this->route('chapter_id'),
+            'lesson_id' => $this->route('lesson_id'),
         ]);
     }
     /**


### PR DESCRIPTION
# 概要
リクエストの講座IDとチャプターIDが、更新対象のレッスンの講座IDとチャプターIDと一致するか (認可実装)

# 動作確認手順
app/Http/Controllers/Api/Instructor/ChapterController.php
app/Http/Requests/Instructor/ChapterShowRequest.php


# 確認して欲しいこと
kouさんとペアプロをやったので動作で問題はなさそうですがコードで何か修正点あればお願いします。



<img width="929" alt="スクリーンショット 2023-06-22 0 13 38" src="https://github.com/yukihiroLaravel/juko_laravel/assets/73786052/7aa609a9-eb0e-43bf-8c3c-bde1ed3b6dc2">


<img width="888" alt="スクリーンショット 2023-06-22 0 15 03" src="https://github.com/yukihiroLaravel/juko_laravel/assets/73786052/5087124d-aa20-496a-ac8b-80507629ceb6">

