### PR TITLE
swagger更新:Laravelの実装をv1/lesson-attendance のURLに直す

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -53,5 +53,5 @@ Route::prefix('v1')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });
     });
-    Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
+    Route::patch('lesson-attendance', 'Api\LessonAttendanceController@update');
 });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-232

## 実施内容
- api.phpを編集

## 確認してほしいこと
- 確認方法がわからなかったので、postmanにURLを”_”、"-"の２通り入力して"-"のほうはバリデーションエラーが返ってきました。
- 正確な確認方法をご教示頂きたいです。