### PR TITLE
削除機能（講師側）コースに紐づくチャプターとレッスンも削除（杉原）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Model\Course;
 use App\Model\Attendance;
-use App\Model\Chapter;
-use App\Model\Lesson;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\CourseDeleteRequest;
 use App\Http\Requests\Instructor\CourseUpdateRequest;
@@ -141,7 +139,6 @@ class CourseController extends Controller
     public function delete(CourseDeleteRequest $request)
     {
         $course = Course::findOrFail($request->course_id);
-        
         if (Attendance::where('course_id', $request->course_id)->exists()) {
             return response()->json([
                 "result" => false,

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Model\Course;
 use App\Model\Attendance;
+use App\Model\Chapter;
+use App\Model\Lesson;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\CourseDeleteRequest;
 use App\Http\Requests\Instructor\CourseUpdateRequest;
@@ -139,6 +141,7 @@ class CourseController extends Controller
     public function delete(CourseDeleteRequest $request)
     {
         $course = Course::findOrFail($request->course_id);
+        
         if (Attendance::where('course_id', $request->course_id)->exists()) {
             return response()->json([
                 "result" => false,

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -46,11 +46,11 @@ class Chapter extends Model
 
     protected static function boot() 
     {
-    parent::boot();
-    static::deleting(function($chapter) {
-        foreach ($chapter->lessons()->get() as $child) {
+        parent::boot();
+        static::deleting(function($chapter) {
+            foreach ($chapter->lessons()->get() as $child) {
             $child->delete();
-        }
-    });
+            }
+        });
     }
 }

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -3,9 +3,11 @@
 namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Chapter extends Model
 {
+    use SoftDeletes;
     /**
      * モデルと関連しているテーブル
      *
@@ -40,5 +42,15 @@ class Chapter extends Model
     public function lessons()
     {
         return $this->hasMany(Lesson::class);
+    }
+
+    protected static function boot() 
+    {
+    parent::boot();
+    static::deleting(function($chapter) {
+        foreach ($chapter->lessons()->get() as $child) {
+            $child->delete();
+        }
+    });
     }
 }

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -55,11 +55,11 @@ class Course extends Model
 
     protected static function boot() 
     {
-    parent::boot();
-    static::deleting(function($course) {
-        foreach ($course->chapters()->get() as $child) {
+        parent::boot();
+        static::deleting(function($course) {
+            foreach ($course->chapters()->get() as $child) {
             $child->delete();
-        }
-    });
+            }
+        });
     }
 }

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -52,4 +52,14 @@ class Course extends Model
     {
         return $this->hasMany(Chapter::class);
     }
+
+    protected static function boot() 
+    {
+    parent::boot();
+    static::deleting(function($course) {
+        foreach ($course->chapters()->get() as $child) {
+            $child->delete();
+        }
+    });
+    }
 }

--- a/app/Model/Lesson.php
+++ b/app/Model/Lesson.php
@@ -3,9 +3,11 @@
 namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Lesson extends Model
 {
+    use SoftDeletes;
     /**
      * モデルと関連しているテーブル
      *


### PR DESCRIPTION
## 概要
- 削除機能（講師側）コースに紐づくチャプターとレッスンも削除
## 動作確認
- seederをリフレッシュする。
- attendancesテーブルのdeleted_atに適当な日付を入力しておく
- ポストマンdeleteメソッドでhttp://localhost:8080/api/v1/instructor/course/1にseed
- result :true確認
- admainerを開き　(courses,chapter,lesson)table３つのテーブル のデータを確認する
-  coursesのid=1に紐づくデータが全て論理削除されている事を確認
- ## 確認してほしいこと
- 当初イメージしていたロジックではいけるとおもっていましたが、子までは消えるが孫まで消えず想定していた完了よりもかなり時間がかかってしまいました。
- 一度指摘を受けたソースを可読性よく簡略化した処理を心掛けて書くようにはしていますができていないきがするので他の記述方法等があれば教えていただきたいです。よろしくお願いいたします。