### PR TITLE
JKA-177 レッスン削除機能　(にしだ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -66,10 +66,13 @@ class LessonController extends Controller
             $lesson_id = $request->input('lesson_id');
             $lesson = Lesson::findOrFail($lesson_id);
 
+            $course = $lesson->chapter->course;
+            $instructor_id = $course->instructor_id;
+
             //$user = Auth::user();
             $user = Instructor::find(1);
 
-            if ($lesson->user_id !== $user->id) {
+            if ($instructor_id !== $user->id) {
                 return response()->json([
                     'result' => false,
                 ], 401);

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -63,16 +63,16 @@ class LessonController extends Controller
     {
 
         try {
-            $lesson_id = $request->input('lesson_id');
-            $lesson = Lesson::with('chapter.course')->findOrFail($lesson_id);
+            $lessonId = $request->input('lesson_id');
+            $lesson = Lesson::with('chapter.course')->findOrFail($lessonId);
 
             $course = $lesson->chapter->course;
-            $instructor_id = $course->instructor_id;
+            $instructorId = $course->instructor_id;
 
             //$user = Auth::user();
             $user = Instructor::find(1);
 
-            if ($instructor_id !== $user->id) {
+            if ($instructorId !== $user->id) {
                 return response()->json([
                     'result' => false,
                 ], 401);

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -7,10 +7,12 @@ use App\Http\Requests\Instructor\LessonStoreRequest;
 use App\Http\Resources\Instructor\LessonStoreResource;
 use App\Http\Requests\Instructor\LessonDeleteRequest;
 use App\Model\Lesson;
+use App\Model\Instructor;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class LessonController extends Controller
 {
@@ -59,9 +61,20 @@ class LessonController extends Controller
      */
     public function delete(LessonDeleteRequest $request)
     {
+
         try {
             $lesson_id = $request->input('lesson_id');
             $lesson = Lesson::findOrFail($lesson_id);
+
+            //$user = Auth::user();
+            $user = Instructor::find(1);
+
+            if ($lesson->user_id !== $user->id) {
+                return response()->json([
+                    'result' => false,
+                ], 401);
+            }
+
             $lesson->delete();
 
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -64,7 +64,7 @@ class LessonController extends Controller
 
         try {
             $lesson_id = $request->input('lesson_id');
-            $lesson = Lesson::findOrFail($lesson_id);
+            $lesson = Lesson::with('chapter.course')->findOrFail($lesson_id);
 
             $course = $lesson->chapter->course;
             $instructor_id = $course->instructor_id;


### PR DESCRIPTION
## 概要
レッスン削除機能

## 動作確認
- http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1
- http://localhost:8080/api/v1/instructor/course/1/chapter/2/lesson/2
両方のエンドポイントでポストマンにてtrueが返ってくるのを確認し
adminerでも削除されてるのを確認しました。

##確認したいこと
- //$user = Auth::user();
- use Illuminate\Support\Facades\Auth;
これらは不要なコードで削除したほうがよろしかったでしょうか？
