### PR TITLE
講師認証追加　講座削除

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Model\Course;
 use App\Model\Attendance;
+use App\Model\instructor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\CourseDeleteRequest;
 use App\Http\Requests\Instructor\CourseUpdateRequest;
@@ -138,19 +139,27 @@ class CourseController extends Controller
      */
     public function delete(CourseDeleteRequest $request)
     {
+        $user = Instructor::find(1);
         $course = Course::findOrFail($request->course_id);
-        if (Attendance::where('course_id', $request->course_id)->exists()) {
+        if ($user->id === $course->instructor_id){
+            if (Attendance::where('course_id', $request->course_id)->exists()) {
+                return response()->json([
+                    "result" => false,
+                    "message" => "This course has already been taken by students."
+                ]);
+            }
+            if (Storage::exists($course->image)) {
+                Storage::delete($course->image);
+            }
+            $course->delete();
+            return response()->json([
+                "result" => true,
+            ]);
+        }else{
             return response()->json([
                 "result" => false,
-                "message" => "This course has already been taken by students."
+                "message" => "Lecturer (cannot be deleted because the creator does not match)"
             ]);
         }
-        if (Storage::exists($course->image)) {
-            Storage::delete($course->image);
-        }
-        $course->delete();
-        return response()->json([
-            "result" => true,
-        ]);
     }
 }


### PR DESCRIPTION
## 概要
- 削除機能（講師側）講師認証処理の追加
## 動作確認
- ①courseテーブルにinstracter_id = 2のデータを作成しておく
- ポストマンdeleteメソッドでhttp://localhost:8080/api/v1/instructor/course/2にseed
- result :false "message" => "Lecturer (cannot be deleted because the creator does not match)" 確認
- ②ポストマンdeleteメソッドでhttp://localhost:8080/api/v1/instructor/course/1にseed
-  coursesのid=1に紐づくデータが全て論理削除されている事を確認