### PR TITLE
認証のためのCORS修正 #247

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -40,7 +40,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:60,1',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/app/Http/Middleware/CorsMiddleware.php
+++ b/app/Http/Middleware/CorsMiddleware.php
@@ -11,6 +11,7 @@ class CorsMiddleware
         return $next($request)
         ->header('Access-Control-Allow-Origin', 'http://localhost:3000')
         ->header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
-        ->header('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With, X-XSRF-TOKEN');
+        ->header('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With, X-XSRF-TOKEN')
+        ->header('Access-Control-Allow-Credentials', 'true');
     }
 }


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-247

## やったこと
- Sanctumの認証ミドルウェアのコメントアウトを解除
- CORSミドルウェアにおいて、Credentialsをtrueに設定。

## テスト方法
.envを環境に合わせて設定

````.env
SESSION_DOMAIN=localhost
SANCTUM_STATEFUL_DOMAINS=localhost:3000
````
