### PR TITLE
講師認証機能実装(﨑園)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -127,11 +127,17 @@ class ChapterController extends Controller
                         'order' => $chapter['order']
                     ]);
                 }
+                DB::commit();
+                return response()->json([
+                    'result' => true,
+                ]);
+            } else {
+                DB::rollBack();
+                return response()->json([
+                    'result' => false,
+                    'message' => 'You are not authorized to perform this action',
+                ], 403);
             }
-            DB::commit();
-            return response()->json([
-                'result' => true,
-            ]);
         } catch (ModelNotFoundException $e) {
             DB::rollBack();
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
+use App\Model\Instructor;
+use App\Model\Course;
 use App\Model\Chapter;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
@@ -112,17 +114,19 @@ class ChapterController extends Controller
     {
         try {
             DB::beginTransaction();
-
+            $user = Instructor::find(1);
             $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');
-
-            foreach ($chapters as $chapter) {
-                Chapter::where('id',$chapter['chapter_id'])
-                ->where('course_id', $courseId)
-                ->firstOrFail()
-                ->update([
-                    'order' => $chapter['order']
-                ]);
+            $course = Course::findOrFail($courseId);
+            if ($user->id === $course->instructor_id) {
+                foreach ($chapters as $chapter) {
+                    Chapter::where('id',$chapter['chapter_id'])
+                    ->where('course_id', $courseId)
+                    ->firstOrFail()
+                    ->update([
+                        'order' => $chapter['order']
+                    ]);
+                }
             }
             DB::commit();
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -118,26 +118,25 @@ class ChapterController extends Controller
             $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');
             $course = Course::findOrFail($courseId);
-            if ($user->id === $course->instructor_id) {
-                foreach ($chapters as $chapter) {
-                    Chapter::where('id',$chapter['chapter_id'])
-                    ->where('course_id', $courseId)
-                    ->firstOrFail()
-                    ->update([
-                        'order' => $chapter['order']
-                    ]);
-                }
-                DB::commit();
-                return response()->json([
-                    'result' => true,
-                ]);
-            } else {
+            if ($user->id !== $course->instructor_id) {
                 DB::rollBack();
                 return response()->json([
                     'result' => false,
                     'message' => 'You are not authorized to perform this action',
                 ], 403);
             }
+            foreach ($chapters as $chapter) {
+                Chapter::where('id',$chapter['chapter_id'])
+                ->where('course_id', $courseId)
+                ->firstOrFail()
+                ->update([
+                    'order' => $chapter['order']
+                ]);
+            }
+            DB::commit();
+            return response()->json([
+                'result' => true,
+            ]);
         } catch (ModelNotFoundException $e) {
             DB::rollBack();
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -112,8 +112,8 @@ class ChapterController extends Controller
      */
     public function sort(ChapterSortRequest $request)
     {
+        DB::beginTransaction();
         try {
-            DB::beginTransaction();
             $user = Instructor::find(1);
             $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -119,7 +119,6 @@ class ChapterController extends Controller
             $chapters = $request->input('chapters');
             $course = Course::findOrFail($courseId);
             if ($user->id !== $course->instructor_id) {
-                DB::rollBack();
                 return response()->json([
                     'result' => false,
                     'message' => 'You are not authorized to perform this action',


### PR DESCRIPTION
## 実施内容
- 講師認証機能の実装とトランザクション修正

## 動作確認方法
- アドマイナーにてcoursesテーブルのid1(PHP)のinstructor_idを仮に2に修正。
- PostmanにてリクエストをSend。
  'result' => false,
  'message' => 'You are not authorized to perform this action'
- 上記内容が返ってくることを確認。
- アドマイナーにて最初の変更内容を戻す。
- 再度リクエストをSendするとtrueが返ってくることを確認。
- URLのcourseIDを2に変更。->falseが返ってくることを確認。
- 他エラーが出力されることも確認。

## 備考
- プルリクエスト#125と内容同じ