### PR TITLE
ユーザ情報更新(講師側) 空配列を返すコントローラ＋ルーティング(﨑園)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -127,11 +127,17 @@ class ChapterController extends Controller
                         'order' => $chapter['order']
                     ]);
                 }
+                DB::commit();
+                return response()->json([
+                    'result' => true,
+                ]);
+            } else {
+                DB::rollBack();
+                return response()->json([
+                    'result' => false,
+                    'message' => 'You are not authorized to perform this action',
+                ], 403);
             }
-            DB::commit();
-            return response()->json([
-                'result' => true,
-            ]);
         } catch (ModelNotFoundException $e) {
             DB::rollBack();
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
+use App\Model\Instructor;
+use App\Model\Course;
 use App\Model\Chapter;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
@@ -112,17 +114,19 @@ class ChapterController extends Controller
     {
         try {
             DB::beginTransaction();
-
+            $user = Instructor::find(1);
             $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');
-
-            foreach ($chapters as $chapter) {
-                Chapter::where('id',$chapter['chapter_id'])
-                ->where('course_id', $courseId)
-                ->firstOrFail()
-                ->update([
-                    'order' => $chapter['order']
-                ]);
+            $course = Course::findOrFail($courseId);
+            if ($user->id === $course->instructor_id) {
+                foreach ($chapters as $chapter) {
+                    Chapter::where('id',$chapter['chapter_id'])
+                    ->where('course_id', $courseId)
+                    ->firstOrFail()
+                    ->update([
+                        'order' => $chapter['order']
+                    ]);
+                }
             }
             DB::commit();
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -118,26 +118,25 @@ class ChapterController extends Controller
             $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');
             $course = Course::findOrFail($courseId);
-            if ($user->id === $course->instructor_id) {
-                foreach ($chapters as $chapter) {
-                    Chapter::where('id',$chapter['chapter_id'])
-                    ->where('course_id', $courseId)
-                    ->firstOrFail()
-                    ->update([
-                        'order' => $chapter['order']
-                    ]);
-                }
-                DB::commit();
-                return response()->json([
-                    'result' => true,
-                ]);
-            } else {
+            if ($user->id !== $course->instructor_id) {
                 DB::rollBack();
                 return response()->json([
                     'result' => false,
                     'message' => 'You are not authorized to perform this action',
                 ], 403);
             }
+            foreach ($chapters as $chapter) {
+                Chapter::where('id',$chapter['chapter_id'])
+                ->where('course_id', $courseId)
+                ->firstOrFail()
+                ->update([
+                    'order' => $chapter['order']
+                ]);
+            }
+            DB::commit();
+            return response()->json([
+                'result' => true,
+            ]);
         } catch (ModelNotFoundException $e) {
             DB::rollBack();
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -112,8 +112,8 @@ class ChapterController extends Controller
      */
     public function sort(ChapterSortRequest $request)
     {
+        DB::beginTransaction();
         try {
-            DB::beginTransaction();
             $user = Instructor::find(1);
             $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -119,7 +119,6 @@ class ChapterController extends Controller
             $chapters = $request->input('chapters');
             $course = Course::findOrFail($courseId);
             if ($user->id !== $course->instructor_id) {
-                DB::rollBack();
                 return response()->json([
                     'result' => false,
                     'message' => 'You are not authorized to perform this action',

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -14,8 +14,9 @@ class InstructorController extends Controller
      * @param InstructorPatchRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function update($request)
+    public function update(Request $request)
     {
-        return response()->json([]);
+        return response()->json([
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use Illuminate\Http\Request;
+use App\Model\Instructor;
+use App\Http\Controllers\Controller;
+
+class InstructorController extends Controller
+{
+    /**
+     * チャプター更新API
+     *
+     * @param InstructorPatchRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update($request)
+    {
+        return response()->json([]);
+    }
+}

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -14,16 +14,6 @@ class Instructor extends Model
     protected $table = 'instructors';
 
     /**
-     * @var array<string>
-     */
-    protected $fillable = [
-        'nick_name',
-        'last_name',
-        'first_name',
-        'email'
-    ];
-
-    /**
      * 講座を取得
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -14,6 +14,16 @@ class Instructor extends Model
     protected $table = 'instructors';
 
     /**
+     * @var array<string>
+     */
+    protected $fillable = [
+        'nick_name',
+        'last_name',
+        'first_name',
+        'email'
+    ];
+
+    /**
      * 講座を取得
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,26 +20,29 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
-        Route::prefix('course')->group(function () {
-            Route::get('index', 'Api\Instructor\CourseController@index');
-            Route::post('/', 'Api\Instructor\CourseController@store');
-            Route::prefix('{course_id}')->group(function () {
-                Route::get('/', 'Api\Instructor\CourseController@show');
-                Route::get('edit', 'Api\Instructor\CourseController@edit');
-                Route::post('/', 'Api\Instructor\CourseController@update');
-                Route::delete('/', 'Api\Instructor\CourseController@delete');
-                Route::prefix('chapter')->group(function () {
-                    Route::post('/', 'Api\Instructor\ChapterController@store');
-                    Route::post('sort', 'Api\Instructor\ChapterController@sort');
-                    Route::prefix('{chapter_id}')->group(function () {
-                        Route::get('/', 'Api\Instructor\ChapterController@show');
-                        Route::patch('/', 'Api\Instructor\ChapterController@update');
-                        Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                        Route::prefix('lesson')->group(function () {
-                            Route::post('/', 'Api\Instructor\LessonController@store');
-                            Route::post('sort', 'Api\Instructor\LessonController@sort');
-                            Route::prefix('{lesson_id}')->group(function () {
-                                Route::patch('/', 'Api\Instructor\LessonController@update');
+        Route::prefix('{instructor_id}')->group(function () {
+            Route::patch('/', 'Api\Instructor\InstructorController@update');
+            Route::prefix('course')->group(function () {
+                Route::get('index', 'Api\Instructor\CourseController@index');
+                Route::post('/', 'Api\Instructor\CourseController@store');
+                Route::prefix('{course_id}')->group(function () {
+                    Route::get('/', 'Api\Instructor\CourseController@show');
+                    Route::get('edit', 'Api\Instructor\CourseController@edit');
+                    Route::post('/', 'Api\Instructor\CourseController@update');
+                    Route::delete('/', 'Api\Instructor\CourseController@delete');
+                    Route::prefix('chapter')->group(function () {
+                        Route::post('/', 'Api\Instructor\ChapterController@store');
+                        Route::post('sort', 'Api\Instructor\ChapterController@sort');
+                        Route::prefix('{chapter_id}')->group(function () {
+                            Route::get('/', 'Api\Instructor\ChapterController@show');
+                            Route::patch('/', 'Api\Instructor\ChapterController@update');
+                            Route::delete('/', 'Api\Instructor\ChapterController@delete');
+                            Route::prefix('lesson')->group(function () {
+                                Route::post('/', 'Api\Instructor\LessonController@store');
+                                Route::post('sort', 'Api\Instructor\LessonController@sort');
+                                Route::prefix('{lesson_id}')->group(function () {
+                                    Route::patch('/', 'Api\Instructor\LessonController@update');
+                                });
                             });
                         });
                     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,7 +20,6 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
-        Route::prefix('{instructor_id}')->group(function () {
             Route::patch('/', 'Api\Instructor\InstructorController@update');
             Route::prefix('course')->group(function () {
                 Route::get('index', 'Api\Instructor\CourseController@index');
@@ -42,7 +41,6 @@ Route::prefix('v1')->group(function () {
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::patch('/', 'Api\Instructor\LessonController@update');
-                                });
                             });
                         });
                     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,27 +20,27 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
-            Route::patch('/', 'Api\Instructor\InstructorController@update');
-            Route::prefix('course')->group(function () {
-                Route::get('index', 'Api\Instructor\CourseController@index');
-                Route::post('/', 'Api\Instructor\CourseController@store');
-                Route::prefix('{course_id}')->group(function () {
-                    Route::get('/', 'Api\Instructor\CourseController@show');
-                    Route::get('edit', 'Api\Instructor\CourseController@edit');
-                    Route::post('/', 'Api\Instructor\CourseController@update');
-                    Route::delete('/', 'Api\Instructor\CourseController@delete');
-                    Route::prefix('chapter')->group(function () {
-                        Route::post('/', 'Api\Instructor\ChapterController@store');
-                        Route::post('sort', 'Api\Instructor\ChapterController@sort');
-                        Route::prefix('{chapter_id}')->group(function () {
-                            Route::get('/', 'Api\Instructor\ChapterController@show');
-                            Route::patch('/', 'Api\Instructor\ChapterController@update');
-                            Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                            Route::prefix('lesson')->group(function () {
-                                Route::post('/', 'Api\Instructor\LessonController@store');
-                                Route::post('sort', 'Api\Instructor\LessonController@sort');
-                                Route::prefix('{lesson_id}')->group(function () {
-                                    Route::patch('/', 'Api\Instructor\LessonController@update');
+        Route::patch('/', 'Api\Instructor\InstructorController@update');
+        Route::prefix('course')->group(function () {
+            Route::get('index', 'Api\Instructor\CourseController@index');
+            Route::post('/', 'Api\Instructor\CourseController@store');
+            Route::prefix('{course_id}')->group(function () {
+                Route::get('/', 'Api\Instructor\CourseController@show');
+                Route::get('edit', 'Api\Instructor\CourseController@edit');
+                Route::post('/', 'Api\Instructor\CourseController@update');
+                Route::delete('/', 'Api\Instructor\CourseController@delete');
+                Route::prefix('chapter')->group(function () {
+                    Route::post('/', 'Api\Instructor\ChapterController@store');
+                    Route::post('sort', 'Api\Instructor\ChapterController@sort');
+                    Route::prefix('{chapter_id}')->group(function () {
+                        Route::get('/', 'Api\Instructor\ChapterController@show');
+                        Route::patch('/', 'Api\Instructor\ChapterController@update');
+                        Route::delete('/', 'Api\Instructor\ChapterController@delete');
+                        Route::prefix('lesson')->group(function () {
+                            Route::post('/', 'Api\Instructor\LessonController@store');
+                            Route::post('sort', 'Api\Instructor\LessonController@sort');
+                            Route::prefix('{lesson_id}')->group(function () {
+                                Route::patch('/', 'Api\Instructor\LessonController@update');
                             });
                         });
                     });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-252

## 実施内容
- api.phpを編集。(instructor_idの入力を追記)
- instructorControllerの作成

## 動作確認
- Postomanにて、PATCH：localhost:8080/api/v1/instructor/1　Send押下。
- 空配列が返ってきます。