### PR TITLE
JKA-279 受講生情報編集画面の空の配列を返すようにコントローラ＋ルーティング作成(にしだ)

### DIFF
--- a/app/Http/Controllers/Api/Students/StudentController.php
+++ b/app/Http/Controllers/Api/Students/StudentController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api\Students;
+
+use App\Http\Controllers\Controller;
+use App\Model\Student;
+use App\Model\Attendance;
+//use App\Model\LessonAttendance;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class StudentController extends Controller
+{
+
+  /**
+   * 
+   *
+   * @param Request $request
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function edit($student_id)
+  {
+    $students = Student::findOrFail($student_id);
+
+    $attendances = Attendance::where('student_id', $student_id)->get();
+
+    //$lessonAttendances = LessonAttendance::where('student_id', $student_id)->get();
+
+    return response()->json([]);
+  }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,5 +57,6 @@ Route::prefix('v1')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });
     });
+    Route::get('/students/{student_id}/attendances/{course_id}', 'Api\Students\StudentController@edit');
     Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
 });


### PR DESCRIPTION
##  概要
受講生情報編集画面の空の配列を返すようにコントローラ＋ルーティング作成

## 実施内容
- routes/api.php
Route::get('/students/{student_id}/attendances/{course_id}', 'Api\Students\StudentController@edit');追加
- app/Http/Controllers/Api/Students/
StudentController.php作成

## 動作確認
- php artisan route:list でルート確認
- ポストマンで空配列返ってくるのを確認
GET http://localhost:8080/api/v1/students/1/attendances/1

## その他
- //use App\Model\LessonAttendance;と//$lessonAttendances = LessonAttendance::where('student_id', $student_id)->get();
受講生情報編集画面だといるのかわからなかった為コメントアウトして残してしまっています。
最後まで大変申し訳ございません。