### PR TITLE
CORSのAllow-Originを環境変数を参照するように改修。

### DIFF
--- a/app/Http/Middleware/CorsMiddleware.php
+++ b/app/Http/Middleware/CorsMiddleware.php
@@ -9,7 +9,7 @@ class CorsMiddleware
     public function handle($request, Closure $next)
     {
         return $next($request)
-        ->header('Access-Control-Allow-Origin', 'http://localhost:3000')
+        ->header('Access-Control-Allow-Origin', env('ALLOW_ORIGIN', 'http://localhost:3000'))
         ->header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS')
         ->header('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With, X-XSRF-TOKEN')
         ->header('Access-Control-Allow-Credentials', 'true');


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-283

## やったこと
CORSのAccess-Control-Allow-Originの設定値を環境変数を参照するように修正。

## 確認方法
.envに次の設定値を追加。

````.env
ALLOW_ORIGIN=http://localhost:3000
````