### PR TITLE
講座一覧 修正（受講生側）statusがpublicな講座のみを表示する

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -22,8 +22,8 @@ class CourseController extends Controller
     {
         if ($request->text === null) {
             $attendances = Attendance::with(['course.instructor'])->where('student_id', $request->student_id)->get();
-            $publicAttendances = $this->extractPublicCourse($attendances);
-            return new CourseIndexResource($publicAttendances);
+            $attendances = $this->extractPublicCourse($attendances);
+            return new CourseIndexResource($attendances);
         }
 
         $attendances = Attendance::whereHas('course', function ($q) use ($request) {
@@ -32,8 +32,8 @@ class CourseController extends Controller
             ->with(['course.instructor'])
             ->where('student_id', '=', $request->student_id)
             ->get();
-        $publicAttendances = $this->extractPublicCourse($attendances);
-        return new CourseIndexResource($publicAttendances);
+        $attendances = $this->extractPublicCourse($attendances);
+        return new CourseIndexResource($attendances);
     }
 
     private function extractPublicCourse($attendances)

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -43,7 +43,6 @@ class CourseController extends Controller
         });
         return $publicAttendances;
     }
-
     /**
      * 講座詳細取得API
      *

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -18,10 +18,9 @@ class CourseController extends Controller
      * @return CourseIndexResource
      */
     public function index(CourseIndexRequest $request)
-    {
+    {        
         if ($request->text === null) {
             $attendances = Attendance::with(['course.instructor'])->where('student_id', $request->student_id)->get();
-            return new CourseIndexResource($attendances);
         }
 
         $attendances = Attendance::whereHas('course', function ($q) use ($request) {
@@ -30,7 +29,15 @@ class CourseController extends Controller
             ->with(['course.instructor'])
             ->where('student_id', '=', $request->student_id)
             ->get();
-        return new CourseIndexResource($attendances);
+            
+        $publicAttendances = collect();
+        foreach ($attendances as $attendance) {
+            if ($attendance->course->status === 'public') {
+                $publicAttendances->push($attendance);
+            }
+        }
+
+        return new CourseIndexResource($publicAttendances);
     }
 
     /**

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -22,8 +22,8 @@ class CourseController extends Controller
     {
         if ($request->text === null) {
             $attendances = Attendance::with(['course.instructor'])->where('student_id', $request->student_id)->get();
-            $attendances = $this->extractPublicCourse($attendances);
-            return new CourseIndexResource($attendances);
+            $publicAttendances = $this->extractPublicCourse($attendances);
+            return new CourseIndexResource($publicAttendances);
         }
 
         $attendances = Attendance::whereHas('course', function ($q) use ($request) {
@@ -32,16 +32,15 @@ class CourseController extends Controller
             ->with(['course.instructor'])
             ->where('student_id', '=', $request->student_id)
             ->get();
-        $attendances = $this->extractPublicCourse($attendances);
-        return new CourseIndexResource($attendances);
+        $publicAttendances = $this->extractPublicCourse($attendances);
+        return new CourseIndexResource($publicAttendances);
     }
 
     private function extractPublicCourse($attendances)
     {
-        $publicAttendances = $attendances->filter(function ($attendance) {
+        return $attendances->filter(function ($attendance) {
             return $attendance->course->status === Course::STATUS_PUBLIC;
         });
-        return $publicAttendances;
     }
     /**
      * 講座詳細取得API


### PR DESCRIPTION
実施内容
---
- App/Http/Controllers/Api/CourseController@indexメソッドにて、coursesテーブルのstatusがpublic状態の講座のみを
表示するよう実装。
- （クエリではなく）PHPで抽出処理をかける。

動作確認
---
Postmanにてhttp\://localhost:8080/api/v1/course/index（getメソッド）
Body：”student_id：1”
![image](https://github.com/yukihiroLaravel/juko_laravel/assets/128295535/1965964d-3ab9-46eb-ba83-230b8b688721)

上図のように講座情報が返される。
adminerにてcoursesテーブル/id3/React講座でstatusの項目をprivateに変更。
もともと1,2,3,4の講座情報が返されていたものが、3の情報が返されなくなることを確認。
また、postmanのBodyにtext："PHP"を追加し実行。口座名に”PHP”を含むid1/PHP入門講座のみ表示されることを確認。

確認してほしいこと
---
postmanの使い方も含めて誤っている部分があれば、ご教示をお願いしたいです。
