### PR TITLE
jka-298最終ログイン日時カラムを受講生テーブル(students)に追加/マイグレーション・シーダー変更(jka-300)

### DIFF
--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -28,6 +28,7 @@ class CreateStudentsTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
+            $table->dateTime('last_login_at');
         });
     }
 

--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -28,7 +28,7 @@ class CreateStudentsTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
-            $table->dateTime('last_login_at');//カラム追加(最終ログイン日時)
+            $table->dateTime('last_login_at')->comment('最終ログイン日時');
         });
     }
 

--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -28,7 +28,7 @@ class CreateStudentsTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
-            $table->dateTime('last_login_at');
+            $table->dateTime('last_login_at');//カラム追加(最終ログイン日時)
         });
     }
 

--- a/database/seeds/StudentSeeder.php
+++ b/database/seeds/StudentSeeder.php
@@ -28,6 +28,7 @@ class StudentSeeder extends Seeder
                 'address' => '東京都',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
+                'last_login_at' => Carbon::now(),
             ],
             [
                 'nick_name' => '生徒ニックネーム2',
@@ -42,6 +43,7 @@ class StudentSeeder extends Seeder
                 'address' => '大阪府',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
+                'last_login_at' => Carbon::now(),
             ]
         ]);
     }


### PR DESCRIPTION
jka-298 最終ログイン日時カラムを受講生テーブル(students)に追加/マイグレーション・シーダー変更(jka-300)

## issue
- Close jka-300
## 概要
- studentsテーブルに最終ログイン日時のカラムを追加する
## 動作確認手順
- studentsテーブルに'last_login_date'カラムを追加、StudentSeeder.phpファイルに'last_login_at' => Carbon::now(),を追加。マイグレーションとシーダーを実行後、Adminerで追加されているか確認
- ## 考慮してほしい事
- 特にありません
## 確認してほしい事
- マイグレーション・シーダーファイルが適切に作成されているかどうか
- 状況に応じて、下記コマンドで動作確認をする必要あり。  
   php artisan migrate:fresh --seed