### PR TITLE
JKA-289 ダッシュボード(講師側)講座の受講状況のコントローラ・ルーティング作成(ユウキ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
-class LessonAttendanceController extends Controller
+class AttendanceController extends Controller
 {
     public function show() {
         return response()->json([]);

--- a/app/Http/Controllers/Api/Instructor/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonAttendanceController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class LessonAttendanceController extends Controller
+{
+    public function show() {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::prefix('v1')->group(function () {
     // 講師側API
-    Route::prefix('instructor')->group(function () {
+    Route::prefix('{instructor_id}')->group(function () {
+        Route::get('{course_id}', 'Api\Instructor\LessonAttendanceController@show');
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,10 +19,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::prefix('v1')->group(function () {
     // 講師側API
-    Route::prefix('{instructor_id}')->group(function () {
-        Route::prefix('attendance/{course_id}')->group(function () {
-            Route::get('status', 'Api\Instructor\AttendanceController@show');
-        });
+    Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
@@ -32,6 +29,9 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
+                Route::prefix('attendance')->group(function () {
+                    Route::get('status', 'Api\Instructor\AttendanceController@show');
+                });
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,7 +20,9 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('{instructor_id}')->group(function () {
-        Route::get('{course_id}', 'Api\Instructor\LessonAttendanceController@show');
+        Route::prefix('attendance')->group(function () {
+            Route::get('{course_id}', 'Api\Instructor\AttendanceController@show');
+        });
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,7 +21,9 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('{instructor_id}')->group(function () {
         Route::prefix('attendance')->group(function () {
-            Route::get('{course_id}', 'Api\Instructor\AttendanceController@show');
+            Route::prefix('{course_id}')->group(function () {
+                Route::get('status', 'Api\Instructor\AttendanceController@show');
+            });
         });
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
         Route::prefix('course')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,10 +20,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('{instructor_id}')->group(function () {
-        Route::prefix('attendance')->group(function () {
-            Route::prefix('{course_id}')->group(function () {
-                Route::get('status', 'Api\Instructor\AttendanceController@show');
-            });
+        Route::prefix('attendance/{course_id}')->group(function () {
+            Route::get('status', 'Api\Instructor\AttendanceController@show');
         });
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
         Route::prefix('course')->group(function () {


### PR DESCRIPTION
##  概要
ダッシュボード(講師側)講座の受講状況のコントローラ・ルーティング作成(空配列)

## 実施内容
ルーティングの追加および、instructor_idを使用するように変更
- routes/api.php
Route::get('{course_id}', 'Api\Instructor\LessonAttendanceController@show');追加

- app/Http/Controllers/Api/instructor/
LessonAttendanceController.php作成

## 動作確認
- php artisan route:list でルート確認
- ポストマンで空配列返ってくるのを確認
GET: localhost:8080/api/v1/1/1

## 確認して欲しいこと
- ルーティングについて、instructor_idを使用するように変更しましたが、そのやり方で問題ないか
- コントローラーを新たに作成しましたが、既存のものに追加すべきだったのか
（受講生側のAPIにLessonAttendanceControllerがあったため、新規に作成するのが良いのかと思いました。）

以上、よろしくお願いします。