### PR TITLE
studentsテーブルにユーザー名(仮)カラム追加(マイグレーションとシーダー)(二宮)

### DIFF
--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -15,6 +15,7 @@ class CreateStudentsTable extends Migration
     {
         Schema::create('students', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->string('given_name_by_instructor', 50)->comment('ユーザー名(仮)');
             $table->string('nick_name', 50)->comment('ニックネーム');
             $table->string('last_name', 50)->comment('苗字');
             $table->string('first_name', 50)->comment('名前');

--- a/database/seeds/StudentSeeder.php
+++ b/database/seeds/StudentSeeder.php
@@ -16,6 +16,7 @@ class StudentSeeder extends Seeder
     {
         Student::insert([
             [
+                'given_name_by_instructor' => 'ユーザー名(仮)1',
                 'nick_name' => '生徒ニックネーム1',
                 'last_name' => '生徒',
                 'first_name' => 'テスト1',
@@ -30,6 +31,7 @@ class StudentSeeder extends Seeder
                 'updated_at' => Carbon::now(),
             ],
             [
+                'given_name_by_instructor' => 'ユーザー名(仮)2',
                 'nick_name' => '生徒ニックネーム2',
                 'last_name' => '生徒',
                 'first_name' => 'テスト2',


### PR DESCRIPTION
実施内容
---
- sutudentsテーブルに「ユーザー名(仮)」カラムを追加する(マイグレーションとシーダーの変更)。
カラム名は「given_name_by_instructor」とし、テーブルのコメントに「ユーザー名(仮)」を記述する。

動作確認
---
- `php artisan migrate:fresh --seed` コマンドを実行し、adminerにてstudentsテーブルに
「given_name_by_instructor」カラムが追加されていること、コメントが付与されていることを確認する。
