### PR TITLE
受講生一覧画面（講師側）空の配列を返すようにコントローラ＋ルーティング作成（あめみや）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 
 class StudentController extends Controller
 {
-    public function show(Request $request)
+    public function index(Request $request)
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\Instructor;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class StudentController extends Controller

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class StudentController extends Controller
+{
+    public function show(Request $request)
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ Route::prefix('v1')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');
             Route::prefix('{course_id}')->group(function () {
+                Route::get('student', 'Api\Instructor\StudentController@show');
                 Route::get('/', 'Api\Instructor\CourseController@show');
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,7 +25,7 @@ Route::prefix('v1')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');
             Route::prefix('{course_id}')->group(function () {
-                Route::get('index', 'Api\Instructor\StudentController@index');
+                Route::get('student/index', 'Api\Instructor\StudentController@index');
                 Route::get('/', 'Api\Instructor\CourseController@show');
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,7 +25,7 @@ Route::prefix('v1')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');
             Route::prefix('{course_id}')->group(function () {
-                Route::get('student', 'Api\Instructor\StudentController@index');
+                Route::get('index', 'Api\Instructor\StudentController@index');
                 Route::get('/', 'Api\Instructor\CourseController@show');
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,7 +25,7 @@ Route::prefix('v1')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');
             Route::prefix('{course_id}')->group(function () {
-                Route::get('student', 'Api\Instructor\StudentController@show');
+                Route::get('student', 'Api\Instructor\StudentController@index');
                 Route::get('/', 'Api\Instructor\CourseController@show');
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');


### PR DESCRIPTION
## 概要
- 受講生一覧画面（講師側）
空の配列を返すようにコントローラ＋ルーティング作成
- 新たに下記コントローラーを作成
backend\laravelapp\app\Http\Controllers\Api\Instructor\StudentController.php
- `backend\laravelapp\routes\api.php`内に新たにルーティングを追加
## 動作確認手順
- 特になし

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- namespaceやuseは今回は変更しない。という解釈でよろしかったでしょうか。
- コントローラー、ルーティングの位置に不安があります。
コントローラーは`Instructor`直下で良い気はしたのですが、
ルーティングの位置は`course/{course_id}/`直下で良かったでしょうか。
一応、コース別の受講生一覧を表示するページとなるため、コース直下かも？というご指摘はいただきました。