### PR TITLE
講座受講生登録（講師側）にて受講生データ追加：空の配列を返すようにコントローラ+ルーティング作成(二宮)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StudentController extends Controller
+{
+    /**
+     * 受講生登録API
+     *
+     * @param Request $request
+     * @return Resource
+     */
+
+    public function store(Request $request)
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
+        Route::post('student', 'Api\Instructor\StudentController@store');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');


### PR DESCRIPTION
概要
---
- タスク「講座受講生登録（講師側）で登録した際にstudentsテーブルに受講生データを追加」
空の配列を返すようにコントローラ＋ルーティング作成

実施内容
---
- ルーティング作成
URI：v1/instructor/studentとして作成。
- コントローラー作成
新規でApi/Instructorディレクトリの下に、StudentControllerファイルを作成。
そのファイルの中に、空の配列を返すstoreメソッドを作成。

動作確認
---
postmanにて、POST：http\://localhost:8080/api/v1/instructor/student　→sendを実行
空配列　[ ]　が返ってくる。

考慮してほしいこと
---
controllerの@parmと@returnは、いったんRequest、Resourceとしております。
今後のタスクで必要に応じて変更します。