### PR TITLE
JKA-314　ユーザ情報編集画面（受講生側）空の配列を返すようにコントローラ＋ルーティング作成 ユーザ情報更新（受講生側）空の配列を返すようにコントローラ＋ルーティング作成（森島）

### DIFF
--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -10,7 +10,7 @@ use App\Http\Controllers\Controller;
 class StudentController extends Controller
 {
     /**
-     * 学生情報更新API
+     * 生徒情報更新API
      *
      * @param StudentPatchRequest $request
      * @return \Illuminate\Http\JsonResponse

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api\Student;
+
+use Illuminate\Http\Request;
+use App\Model\Student;
+use App\Http\Controllers\Controller;
+
+
+class StudentController extends Controller
+{
+    /**
+     * チャプター更新API
+     *
+     * @param InstructorPatchRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(Request $request)
+    {
+        return response()->json([
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -10,9 +10,9 @@ use App\Http\Controllers\Controller;
 class StudentController extends Controller
 {
     /**
-     * チャプター更新API
+     * 学生情報更新API
      *
-     * @param InstructorPatchRequest $request
+     * @param StudentPatchRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function update(Request $request)

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Http\Request;
+use App\Http\Controllers\Api\Student\StudentController;
+
 
 /*
 |--------------------------------------------------------------------------
@@ -58,5 +60,10 @@ Route::prefix('v1')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });
     });
+    Route::prefix('student')->group(function () {
+        // チャプター更新API（updateメソッド）
+        Route::patch('{student_id}/update', [StudentController::class, 'update']);
+    });
+
     Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,7 +59,7 @@ Route::prefix('v1')->group(function () {
         });
     });
     Route::prefix('student')->group(function () {
-        // チャプター更新API（updateメソッド）
+        // 生徒情報更新API（updateメソッド）
         Route::patch('/', 'Api\Student\StudentController@update');
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -62,7 +62,7 @@ Route::prefix('v1')->group(function () {
     });
     Route::prefix('student')->group(function () {
         // チャプター更新API（updateメソッド）
-        Route::patch('{student_id}/update', [StudentController::class, 'update']);
+        Route::patch('/', 'Api\Student\StudentController@update');
     });
 
     Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Http\Request;
-use App\Http\Controllers\Api\Student\StudentController;
-
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## issue
- Closes #160

## 概要
　ユーザ情報編集画面（受講生側）空の配列を返すようにコントローラ＋ルーティング作成 ユーザ情報更新（受講生側）空の配列を返すようにコントローラ＋ルーティング作成（森島）

## 動作確認手順
- 添付画像のようにpostmanでpatchメソッドをurl `http://localhost:8080/api/v1/student`
に行うと空配列が返ってくることを確認

## 考慮してほしいこと
-`Route::middleware('auth:sanctum')`の処理を省いているためstudent_id毎の
表示はできない。

