### PR TITLE
jka-312 ダッシュボード（講師側）空の配列を返すようにコントローラ＋ルーティング作成（米良）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+class AttendanceController extends Controller
+{
+    public function show() {
+        return response()->json([]);
+    }
+}

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\Controller;
 
 class AttendanceController extends Controller
 {
-    public function show() {
+    public function loginRate() {
         return response()->json([]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,26 +29,29 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
-                Route::prefix('chapter')->group(function () {
-                    Route::post('/', 'Api\Instructor\ChapterController@store');
-                    Route::post('sort', 'Api\Instructor\ChapterController@sort');
-                    Route::prefix('{chapter_id}')->group(function () {
-                        Route::get('/', 'Api\Instructor\ChapterController@show');
-                        Route::patch('/', 'Api\Instructor\ChapterController@update');
-                        Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                        Route::prefix('lesson')->group(function () {
-                            Route::post('/', 'Api\Instructor\LessonController@store');
-                            Route::post('sort', 'Api\Instructor\LessonController@sort');
-                            Route::prefix('{lesson_id}')->group(function () {
-                                Route::delete('/', 'Api\Instructor\LessonController@delete');
-                                Route::patch('/', 'Api\Instructor\LessonController@update');
+                Route::prefix('attendance')->group(function () {
+                    Route::get('login_rate', 'Api\Instructor\AttendanceController@show');
+                });
+                    Route::prefix('chapter')->group(function () {
+                        Route::post('/', 'Api\Instructor\ChapterController@store');
+                        Route::post('sort', 'Api\Instructor\ChapterController@sort');
+                        Route::prefix('{chapter_id}')->group(function () {
+                            Route::get('/', 'Api\Instructor\ChapterController@show');
+                            Route::patch('/', 'Api\Instructor\ChapterController@update');
+                            Route::delete('/', 'Api\Instructor\ChapterController@delete');
+                            Route::prefix('lesson')->group(function () {
+                                Route::post('/', 'Api\Instructor\LessonController@store');
+                                Route::post('sort', 'Api\Instructor\LessonController@sort');
+                                Route::prefix('{lesson_id}')->group(function () {
+                                    Route::delete('/', 'Api\Instructor\LessonController@delete');
+                                    Route::patch('/', 'Api\Instructor\LessonController@update');
+                                });
                             });
                         });
                     });
                 });
             });
         });
-    });
 
     // 受講生側API
     Route::prefix('course')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Request;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
@@ -51,6 +52,7 @@ Route::prefix('v1')->group(function () {
             });
         });
     });
+    
     // 受講生側API
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,29 +30,28 @@ Route::prefix('v1')->group(function () {
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
                 Route::prefix('attendance')->group(function () {
-                    Route::get('login_rate', 'Api\Instructor\AttendanceController@show');
+                    Route::get('login_rate', 'Api\Instructor\AttendanceController@loginRate');
                 });
-                    Route::prefix('chapter')->group(function () {
-                        Route::post('/', 'Api\Instructor\ChapterController@store');
-                        Route::post('sort', 'Api\Instructor\ChapterController@sort');
-                        Route::prefix('{chapter_id}')->group(function () {
-                            Route::get('/', 'Api\Instructor\ChapterController@show');
-                            Route::patch('/', 'Api\Instructor\ChapterController@update');
-                            Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                            Route::prefix('lesson')->group(function () {
-                                Route::post('/', 'Api\Instructor\LessonController@store');
-                                Route::post('sort', 'Api\Instructor\LessonController@sort');
-                                Route::prefix('{lesson_id}')->group(function () {
-                                    Route::delete('/', 'Api\Instructor\LessonController@delete');
-                                    Route::patch('/', 'Api\Instructor\LessonController@update');
-                                });
+                Route::prefix('chapter')->group(function () {
+                    Route::post('/', 'Api\Instructor\ChapterController@store');
+                    Route::post('sort', 'Api\Instructor\ChapterController@sort');
+                    Route::prefix('{chapter_id}')->group(function () {
+                        Route::get('/', 'Api\Instructor\ChapterController@show');
+                        Route::patch('/', 'Api\Instructor\ChapterController@update');
+                        Route::delete('/', 'Api\Instructor\ChapterController@delete');
+                        Route::prefix('lesson')->group(function () {
+                            Route::post('/', 'Api\Instructor\LessonController@store');
+                            Route::post('sort', 'Api\Instructor\LessonController@sort');
+                            Route::prefix('{lesson_id}')->group(function () {
+                                Route::delete('/', 'Api\Instructor\LessonController@delete');
+                                Route::patch('/', 'Api\Instructor\LessonController@update');
                             });
                         });
                     });
                 });
             });
         });
-
+    });
     // 受講生側API
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,7 +16,6 @@ use Illuminate\Http\Request;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
-
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {


### PR DESCRIPTION
##  概要
ダッシュボード(講師側)講座のログイン率のコントローラ・ルーティング作成(空配列)

## 実施内容
ルーティングの追加
- routes/api.php
Route::get('login_rate', 'Api\Instructor\AttendanceController@show');追加

- app/Http/Controllers/Api/instructor/
AttendanceController.php作成

## 動作確認
- ポストマンで空配列返ってくるのを確認
GET: localhost:8080/api/v1/instructor/course/1/attendance/login_rate

## 確認してほしい事
- api.phpのファイルですが、prefixに合わせて少しインデントを変えたのですが大丈夫でしょうか？
 