### PR TITLE
jka-318 講座受講生詳細画面（講師側）空の配列を返すようにコントローラ＋ルーティング作成（おおた）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\Controller;
 
 class StudentController extends Controller
 {
-    public function show()
+    public function show($student_id)
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+class StudentController extends Controller
+{
+    public function show()
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
+        Route::get('student/show', 'Api\Instructor\StudentController@show');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,7 +21,7 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
-        Route::get('student/show', 'Api\Instructor\StudentController@show');
+        Route::get('student/{student_id}', 'Api\Instructor\StudentController@show');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-318

## 概要
- 講座受講生詳細画面（講師側）空の配列を返すようにコントローラ＋ルーティング作成

## 動作確認手順
- Postmanで「localhost:8080/api/v1/instructor/student/show」をsendし、[]が返ってくることを確認しました。

## 考慮して欲しいこと
- 特にありません
- 
## 確認してほしいこと
- コントローラの名称（StudentController）
- ルーティングのURL（student/show）
- ルーティングの階層
が適切かご教授いただければ幸いです。
