### PR TITLE
jka-327 講座受講生登録（講師側）で登録したユーザにテストメールを送付/空の配列を返すようにコントローラ＋仮のルーティング作成(jka-328)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -18,4 +18,9 @@ class StudentController extends Controller
     {
         return response()->json([]);
     }
+    // 動作確認テスト
+    public function student_test(Request $request)
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StudentController extends Controller
+{
+    /**
+     * 受講生登録API
+     *
+     * @param Request $request
+     * @return Resource
+     */
+
+    public function store(Request $request)
+    {
+        return response()->json([]);
+    }
+}

--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -28,6 +28,7 @@ class CreateStudentsTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
+            $table->dateTime('last_login_at');
         });
     }
 

--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -28,7 +28,7 @@ class CreateStudentsTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
-            $table->dateTime('last_login_at');//カラム追加(最終ログイン日時)
+            $table->dateTime('last_login_at')->comment('最終ログイン日時');
         });
     }
 

--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -28,7 +28,7 @@ class CreateStudentsTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
-            $table->dateTime('last_login_at');
+            $table->dateTime('last_login_at');//カラム追加(最終ログイン日時)
         });
     }
 

--- a/database/seeds/StudentSeeder.php
+++ b/database/seeds/StudentSeeder.php
@@ -28,6 +28,7 @@ class StudentSeeder extends Seeder
                 'address' => '東京都',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
+                'last_login_at' => Carbon::now(),
             ],
             [
                 'nick_name' => '生徒ニックネーム2',
@@ -42,6 +43,7 @@ class StudentSeeder extends Seeder
                 'address' => '大阪府',
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
+                'last_login_at' => Carbon::now(),
             ]
         ]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,7 +16,8 @@ use Illuminate\Http\Request;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
-
+//受講生登録(講師側)動作確認テスト
+Route::post('student_mail_test','Api\Instructor\StudentController@student_mail_test');
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
+        Route::post('student', 'Api\Instructor\StudentController@store');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,7 +17,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 //受講生登録(講師側)動作確認テスト
-Route::post('student_mail_test','Api\Instructor\StudentController@student_mail_test');
+Route::get('student_test','Api\Instructor\StudentController@student_test');
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {


### PR DESCRIPTION
## issue
- Close jka-328
## 概要
- 空の配列を返すようにコントローラ＋仮のルーティング作成(講師側・講座受講生登録)
## 動作確認手順
- api.phpに動作確認用のルーティング(URL:student_test/)を追加
- StudentControllerに空配列を返すstudent_testメソッドを追加
- postmanで
- get → http://localhost:8080/api/student_test  →send
- []が返ってくるのを確認
- ## 考慮してほしい事
- 特にありません
## 確認してほしい事
- 動作確認用ルーティングの位置に問題ありませんか？