### PR TITLE
空の配列を返すようにコントローラ＋ルーティング作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendancesController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendancesController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class AttendancesController extends Controller
+{
+    public function store(Request $request)
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,9 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
+        Route::prefix('attendances')->group(function () {
+            Route::post('/', 'Api\Instructor\AttendancesController@store');
+        });
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');


### PR DESCRIPTION
- issue

https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-343

- 概要

講座受講生登録画面（講師側）：空の配列を返すようにコントローラ＋ルーティング作成

- 動作確認手順

Postmanで「localhost:8080/api/v1/instructor/attendances」をsendし、[]が返ってくることを確認しました。

- 考慮して欲しいこと

特にありません

- 確認してほしいこと

コントローラの名称（AttendancesController）
ルーティングのURL（instructor/attendances）
ルーティングの階層が適切かご教授いただければ幸いです。