### PR TITLE
講座受講生登録（講師側）で登録した際にstudentsテーブルに受講生データを追加：DBへのロジック作成(二宮)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -21,7 +21,7 @@ class StudentController extends Controller
         if ( Student::where('email', $request->email)->first() !== null ) {
             return response()->json([
                 'result' => false,
-                "message" => "The email has already been taken."
+                'message' => 'The email has already been taken.'
             ]);
         }
 

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -21,8 +21,7 @@ class StudentController extends Controller
         if ( Student::where('email', $request->email)->first() !== null ) {
             return response()->json([
                 'result' => false,
-                "error_message" => "Invalid email.",
-                "error_code" => "400"
+                "message" => "The email has already been taken.",
             ]);
         }
 

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -18,23 +18,22 @@ class StudentController extends Controller
 
     public function store(Request $request)
     {
-        $student = null;
-        if ( Student::where('email', $request->email)->first() === null ) {
-            $student = Student::create([
-                // 'given_name_by_instructor' => $request->name, まだ実装されてないのでnick_nameで代用
-                'nick_name' => $request->nick_name,
-                'email' => $request->email,
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now()
-            ]);
-        } else {
+        if ( Student::where('email', $request->email)->first() !== null ) {
             return response()->json([
                 'result' => false,
                 "error_message" => "Invalid email.",
                 "error_code" => "400"
             ]);
         }
-        
+
+        $student = Student::create([
+            // 'given_name_by_instructor' => $request->name, まだ実装されてないのでnick_nameで代用
+            'nick_name' => $request->nick_name,
+            'email' => $request->email,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now()
+        ]);
+
         return response()->json([
             'result' => true,
             'data' => [

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -21,7 +21,7 @@ class StudentController extends Controller
         if ( Student::where('email', $request->email)->first() !== null ) {
             return response()->json([
                 'result' => false,
-                "message" => "The email has already been taken.",
+                "message" => "The email has already been taken."
             ]);
         }
 

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Model\Student;
+use Carbon\Carbon;
 
 class StudentController extends Controller
 {
@@ -16,6 +18,31 @@ class StudentController extends Controller
 
     public function store(Request $request)
     {
-        return response()->json([]);
+        $student = null;
+        if ( Student::where('email', $request->email)->first() === null ) {
+            $student = Student::create([
+                // 'given_name_by_instructor' => $request->name, まだ実装されてないのでnick_nameで代用
+                'nick_name' => $request->nick_name,
+                'email' => $request->email,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ]);
+        } else {
+            return response()->json([
+                'result' => false,
+                "error_message" => "Invalid email.",
+                "error_code" => "400"
+            ]);
+        }
+        
+        return response()->json([
+            'result' => true,
+            'data' => [
+                'id' => $student->id,
+                // $student->given_name_by_instructor, まだ実装されてないのでnick_nameで代用
+                'nick_name' => $student->nick_name,
+                'email' => $student->email
+            ]
+        ]);
     }
 }

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -13,6 +13,14 @@ class Student extends Authenticatable
      */
     protected $table = 'students';
 
+    protected $fillable = [
+        // 'given_name_by_instructor'がまだの為 nick_nameで確認
+        'nick_name',
+        'email',
+        'created_at',
+        'updated_at',
+    ];
+
     /**
      * 講座を取得
      *

--- a/database/migrations/2022_10_21_204552_create_students_table.php
+++ b/database/migrations/2022_10_21_204552_create_students_table.php
@@ -16,15 +16,15 @@ class CreateStudentsTable extends Migration
         Schema::create('students', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('nick_name', 50)->comment('ニックネーム');
-            $table->string('last_name', 50)->comment('苗字');
-            $table->string('first_name', 50)->comment('名前');
-            $table->string('occupation', 50)->comment('職業');
-            $table->string('email', 255)->unique()->comment('メールアドレス');
-            $table->string('password', 255)->comment('パスワード');
-            $table->string('purpose', 50)->comment('目的');
-            $table->dateTime('birthdate')->comment('誕生日');
-            $table->tinyInteger('sex')->comment('性別');
-            $table->string('address', 255)->comment('都道府県');
+            $table->string('last_name', 50)->nullable()->comment('苗字');
+            $table->string('first_name', 50)->nullable()->comment('名前');
+            $table->string('occupation', 50)->nullable()->comment('職業');
+            $table->string('email', 255)->nullable()->unique()->comment('メールアドレス');
+            $table->string('password', 255)->nullable()->comment('パスワード');
+            $table->string('purpose', 50)->nullable()->comment('目的');
+            $table->dateTime('birthdate')->nullable()->comment('誕生日');
+            $table->tinyInteger('sex')->nullable()->comment('性別');
+            $table->string('address', 255)->nullable()->comment('都道府県');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();


### PR DESCRIPTION
実施内容
---
- 講座受講生登録（講師側）で登録した際にstudentsテーブルに受講生データを追加
登録しようとしている受講生のメールアドレスがstudentsテーブルに未登録である場合のみ登録する機能について
DBへのロジックを作成する。

動作確認
---
postmanにて、POST：http://localhost:8080/api/v1/instructor/student
Body："nick_name" : "山田太郎"、"email" : "zzzz@zzzz.com"　　→sendを実行
- 登録しようとしている受講生のメールアドレスが未登録の場合
下記レスポンスが返される。
```
{
    "result": true,
    "data": {
        "id": 3,
        "nick_name": "山田太郎",
        "email": "zzzz@zzzz.com"
    }
}
```
また、studentsテーブルへ新規ユーザー(nick_name,email,created_at,updated_at)が追加されていることをadminerで確認。

- 登録しようとしている受講生のメールアドレスが登録済みの場合
下記レスポンスが返される。
```
 {
    "result": false,
    "error_message": "Invalid email.",
    "error_code": "400"
}

```

考慮してほしいこと
---
- 状況に応じて、下記コマンドで動作確認する必要あり。
php artisan migrate:fresh --seed
- studentsテーブルに`given_name_by_instructor`カラムがまだ実装されていない為、`nick_name`カラムで代用しています。