### PR TITLE
受講生一覧画面（講師側）DBへのロジック作成（受講生情報取得実装）（あめみや）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -17,6 +17,8 @@ class StudentController extends Controller
 
         $course = Course::find($request->course_id);
 
+        $students = [];
+
         foreach ($attendances as $attendance) {
             $students[] = [
                 'id' => $attendance->student->id,

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Model\Attendance;
+use App\Model\Course;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
@@ -14,17 +15,13 @@ class StudentController extends Controller
                                     ->where('course_id', $request->course_id)
                                     ->get();
 
-        $course = $attendances->first()->course;
+        $course = Course::find($request->course_id);
 
-        $students = [];
-        
         foreach ($attendances as $attendance) {
-            $student = $attendance->student;
-            
             $students[] = [
-                'id' => $student->id,
-                'nick_name' => $student->nick_name,
-                'email' => $student->email,
+                'id' => $attendance->student->id,
+                'nick_name' => $attendance->student->nick_name,
+                'email' => $attendance->student->email,
                 'course_title' => $attendance->course->title,
                 'attendanced_at' => $attendance->created_at->format('Y/m/d'),
             ];

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -10,7 +10,11 @@ class StudentController extends Controller
 {
     public function index(Request $request)
     {
-        $attendances = Attendance::where('course_id', $request->course_id)->get();
+        $attendances = Attendance::with(['student', 'course'])
+                                    ->where('course_id', $request->course_id)
+                                    ->get();
+
+        $course = $attendances->first()->course;
 
         $students = [];
         
@@ -29,9 +33,9 @@ class StudentController extends Controller
         return response()->json([
             'data' => [
                 'course' => [
-                    'id' => $attendances->first()->course->id,
-                    'image' => $attendances->first()->course->image,
-                    'title' => $attendances->first()->course->title,
+                    'id' => $course->id,
+                    'image' => $course->image,
+                    'title' => $course->title,
                 ],
                 'students' => $students,
             ],

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
+use App\Model\Attendance;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
@@ -9,6 +10,31 @@ class StudentController extends Controller
 {
     public function index(Request $request)
     {
-        return response()->json([]);
+        $attendances = Attendance::where('course_id', $request->course_id)->get();
+
+        $students = [];
+        
+        foreach ($attendances as $attendance) {
+            $student = $attendance->student;
+            
+            $students[] = [
+                'id' => $student->id,
+                'nick_name' => $student->nick_name,
+                'email' => $student->email,
+                'course_title' => $attendance->course->title,
+                'attendanced_at' => $attendance->created_at->format('Y/m/d'),
+            ];
+        }
+
+        return response()->json([
+            'data' => [
+                'course' => [
+                    'id' => $attendances->first()->course->id,
+                    'image' => $attendances->first()->course->image,
+                    'title' => $attendances->first()->course->title,
+                ],
+                'students' => $students,
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
## 概要
- 受講生一覧画面（講師側）DBへのロジック作成（受講生情報取得実装）
・ページ内「講座タイトル」「サムネイル画像」情報の取得
・受講生一覧に表示する受講生情報の取得

## 動作確認手順
- Postmanにて下記URLにてSend
GET：localhost:8080/api/v1/instructor/course/1/student/index
- 講座情報と受講生情報のレスポンスがあることを確認
下記のようにレスポンスがある。
```
{
    "data": {
        "course": {
            "id": 1,
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "title": "PHP入門講座"
        },
        "students": [
            {
                "id": 1,
                "nick_name": "生徒ニックネーム1",
                "email": "test_student_1@example.com",
                "course_title": "PHP入門講座",
                "attendanced_at": "2023/07/24"
            }
        ]
    }
}
```

## 考慮してほしいこと
- 受講生情報のみの実装です。
本来はページネーションも実装予定ですが、
一旦、受講生情報のみの実装となります。

## 確認してほしいこと
- `true`と`false`の記述は必要でしたでしょうか。
他のコントローラーを確認していると、`true`と`false`の記述があり、
下記のような記述が今回も必要なのかがわかりませんでした。
```
'result' => false,
'message' => ''
```
もし必要な場合、ページネーション実装時に追加いたします。