### PR TITLE
JKA-289 ダッシュボード(講師側)講座の受講状況のDBへのロジック作成(ユウキ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -23,19 +23,18 @@ class AttendanceController extends Controller
 
         foreach ($chapterData as $chapter) {
             $completedCount = 0;
-            $chapterId = $chapter->id;
-            $title = $chapter->title;
-            $chapterInfo = ['chapter_id' => $chapterId, 'title' => $title];
             foreach ($chapter->lessons as $lesson) {
                 foreach ($lesson->lessonAttendances as $lessonAttendance) {
-                    $status = $lessonAttendance->status;
-                    if($status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE){
+                    if($lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE){
                         $completedCount+=1;
                     }
                 }
             }
-            $chapterInfo['completed_count'] = $chapter->lessons->isEmpty() ? 0 : $completedCount;
-            $chapters[] = $chapterInfo;
+            $chapters[] = [
+                'chapter_id' => $chapter->id,
+                'title' => $chapter->title,
+                'completed_count' => $completedCount,
+            ];
         }
         
         return response()->json([

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -3,11 +3,41 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Model\Attendance;
+use App\Model\Chapter;
 
 class AttendanceController extends Controller
 {
     public function show() {
-        return response()->json([]);
+        $courseId = 1;
+        $chapters = [];
+        $chapterData = Chapter::where('course_id', $courseId)
+            ->with(['lessons' => function ($query) {
+                $query->with('lessonAttendance');
+            }])
+            ->get();
+        $studentsCount = Attendance::where('course_id', $courseId)->count();
+
+        foreach ($chapterData as $chapter) {
+            $completedCount = 0;
+            $chapterId = $chapter->id;
+            $title = $chapter->title;
+            $chapterInfo = ['chapter_id' => $chapterId, 'title' => $title];
+            foreach ($chapter->lessons as $lesson) {
+                foreach ($lesson->lessonAttendance as $lessonAttendance) {
+                    $status = $lessonAttendance->status;
+                    if($status === 'completed_attendance'){
+                        $completedCount+=1;
+                    }
+                }
+            }
+            $chapterInfo['completed_count'] = empty($chapter->lessons) ? 0 : $completedCount;
+            $chapters[] = $chapterInfo;
+        }
+        
+        return response()->json([
+            "chapters" => $chapters,
+            "students_count" => $studentsCount,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -4,18 +4,21 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Model\Attendance;
+use App\Model\LessonAttendance;
 use App\Model\Chapter;
 
 class AttendanceController extends Controller
 {
-    public function show() {
-        $courseId = 1;
+    /**
+     * 受講状況取得API
+     *
+     * @param 
+     * @return 
+     */
+    public function show($course_id) {
+        $courseId = $course_id;
         $chapters = [];
-        $chapterData = Chapter::where('course_id', $courseId)
-            ->with(['lessons' => function ($query) {
-                $query->with('lessonAttendance');
-            }])
-            ->get();
+        $chapterData = Chapter::with('lessons.lessonAttendances')->where('course_id', $courseId)->get();
         $studentsCount = Attendance::where('course_id', $courseId)->count();
 
         foreach ($chapterData as $chapter) {
@@ -24,14 +27,14 @@ class AttendanceController extends Controller
             $title = $chapter->title;
             $chapterInfo = ['chapter_id' => $chapterId, 'title' => $title];
             foreach ($chapter->lessons as $lesson) {
-                foreach ($lesson->lessonAttendance as $lessonAttendance) {
+                foreach ($lesson->lessonAttendances as $lessonAttendance) {
                     $status = $lessonAttendance->status;
-                    if($status === 'completed_attendance'){
+                    if($status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE){
                         $completedCount+=1;
                     }
                 }
             }
-            $chapterInfo['completed_count'] = empty($chapter->lessons) ? 0 : $completedCount;
+            $chapterInfo['completed_count'] = $chapter->lessons->isEmpty() ? 0 : $completedCount;
             $chapters[] = $chapterInfo;
         }
         

--- a/app/Model/Lesson.php
+++ b/app/Model/Lesson.php
@@ -42,7 +42,7 @@ class Lesson extends Model
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function lessonAttendance()
+    public function lessonAttendances()
     {
         return $this->hasMany(LessonAttendance::class);
     }


### PR DESCRIPTION
##  概要
ダッシュボード(講師側)講座の受講状況のDBへのロジック作成(空配列)

## 実施内容
指定講座(仮でcourse_id = 1)に対するチャプター情報(id, title, completed_count)の取得および受講人数(students_count)を取得してjsonで返すロジックの作成

対象ファイル
- app/Http/Controllers/Api/Instructor/AttendanceController.php

## 動作確認
- ポストマンで必要な情報が返ってくるかを確認
GET: localhost:8080/api/v1/instructor/course/1/attendance/status

## 確認して欲しいこと
- 各データの取得方法が適切か
- コーディングの仕方が適切か
- より簡潔に書ける方法があったら教えて欲しいです

以上、よろしくお願いします。