### PR TITLE
jka-327 講座受講生登録（講師側）で登録したユーザにテストメールを送付/jka-328 空の配列を返すようにコントローラ＋仮のルーティング作成(三田村)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -7,7 +7,8 @@ use Illuminate\Http\Request;
 
 class StudentController extends Controller
 {
-  public function student_test(Request $request){
+  public function student_test(Request $request)
+  {
     return response()->json([]);
   }
 }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StudentController extends Controller
+{
+  public function student_test(Request $request){
+    return response()->json([]);
+  }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,8 @@ use Illuminate\Http\Request;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+//動作確認テスト
+Route::get('student_test','Api\Instructor\StudentController@student_test');
 
 Route::prefix('v1')->group(function () {
     // 講師側API


### PR DESCRIPTION
## issue
- Close jka-328
## 概要
- 空の配列を返すようにコントローラ＋仮のルーティング作成(講師側・講座受講生登録)
## 動作確認手順
- 間違ったブランチの切り方をしていたので再度topic/jka-298/add_last_login_dateから新しくfeatureブランチを切りなおして申請
- Api/Instructorディレクトリの下にStudentControllerファイルを作成
- api.phpに動作確認用のルーティング(URL:student_test/)を追加
- StudentControllerに空配列を返すstudent_testメソッドを追加
- postmanでget⇒ http://localhost:8080/api/student_test ⇒send
- []が返ってくるのを確認
- ## 考慮してほしい事
- 特にありません
## 確認してほしい事
- 動作確認用ルーティングの位置に問題ありませんか？
