### PR TITLE
チャプター&レッスン画面にチャプター進捗などを表示（受講生側）：空の配列を返すようにコントローラ＋ルーティング作成(二宮)

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;    //postman確認のため仮作成
 use App\Http\Requests\CourseShowRequest;
 use App\Http\Requests\CourseIndexRequest;
 use App\Http\Resources\CourseIndexResource;
@@ -58,5 +59,15 @@ class CourseController extends Controller
         ->findOrFail($request->attendance_id);
 
         return new CourseShowResource($attendance);
+    }
+    /**
+     * チャプター進捗状況、続きのレッスンID取得API
+     *
+     * @param Request $request
+     * @return Resource
+     */
+    public function progress(Request $request)
+    {
+        return response()->json([]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,7 +55,7 @@ Route::prefix('v1')->group(function () {
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');
         Route::get('index', 'Api\CourseController@index');
-        Route::get('progress', 'Api\CourseController@progress');
+        Route::get('{course_id}/progress', 'Api\CourseController@progress');
         Route::prefix('chapter')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,6 +55,7 @@ Route::prefix('v1')->group(function () {
     Route::prefix('course')->group(function () {
         Route::get('/', 'Api\CourseController@show');
         Route::get('index', 'Api\CourseController@index');
+        Route::get('progress', 'Api\CourseController@progress');
         Route::prefix('chapter')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });


### PR DESCRIPTION
概要
---
- タスク「チャプター&レッスン画面にチャプター進捗などを表示（受講生側）」
空の配列を返すようにコントローラ＋ルーティング作成

実施内容
---
- ルーティング
URI：http\://localhost:8080/api/v1/course/progressとして作成。
- コントローラー
Api/CourseContoroller.php内に、空の配列を返すprogressメソッドを作成。

動作確認
---
postmanにて、GET：http\://localhost:8080/api/v1/course/progress　→sendを実行
空配列　[ ]　が返ってくる。

考慮してほしいこと
---
controllerの@parmと@returnは、いったんRequest、Resourceとしております。
また、postmanでの動作確認のため、6行目に`use Illuminate\Http\Request; `を追加しています。
今後のタスクで必要に応じて変更します。