### PR TITLE
jka-320 講座受講生詳細画面（講師側）フォームリクエスト（おおた）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -4,12 +4,19 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Model\Student;
+use App\Http\Requests\Instructor\StudentShowRequest;
 
 class StudentController extends Controller
 {
-    public function show($student_id)
+    /**
+     * 講座受講生詳細情報を取得
+     *
+     * @param StudentShowRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(StudentShowRequest $request)
     {
-        $student = Student::with(['attendances.course.chapters.lessons.lessonAttendance'])->findOrFail($student_id);
+        $student = Student::with(['attendances.course.chapters.lessons.lessonAttendance'])->findOrFail($request->student_id);
 
         return response()->json([
             'data' => [
@@ -23,7 +30,7 @@ class StudentController extends Controller
                     'email' => $student->email,
                     'purpose' => $student->purpose,
                     'birth_date' => $student->birth_date->format('Y/m/d'),
-                    'sex' => $student->formatted_sex,
+                    'sex' => $student->sex,
                     'address' => $student->address,
                     'created_at' => $student->created_at->format('Y/m/d'),
                     'last_login_at' => $student->last_login_at, //カラム追加後、日付はフォーマットして渡す ->format('Y/m/d')

--- a/app/Http/Requests/Instructor/StudentShowRequest.php
+++ b/app/Http/Requests/Instructor/StudentShowRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StudentShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'student_id' => ['required','integer'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'student_id' => $this->route('student_id'),
+        ]);
+    }
+
+}

--- a/app/Http/Requests/Instructor/StudentShowRequest.php
+++ b/app/Http/Requests/Instructor/StudentShowRequest.php
@@ -34,5 +34,4 @@ class StudentShowRequest extends FormRequest
             'student_id' => $this->route('student_id'),
         ]);
     }
-
 }

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -40,13 +40,15 @@ class Student extends Authenticatable
      */
     const SEX_MAN = 1;
     const SEX_WOMAN = 2;
-
-    public function getFormattedSexAttribute()
+    const MAN = 'man';
+    const WOMAN = 'woman';
+    
+    public function getSexAttribute($value)
     {    
-        if ($this->sex === self::SEX_MAN) {
-            return 'man';
-        } elseif ($this->sex === self::SEX_WOMAN) {
-            return 'woman';
+        if ($value === self::SEX_MAN) {
+            return self::MAN;
+        } elseif ($value === self::SEX_WOMAN) {
+            return self::WOMAN;
         }
         return null;
     }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-320

## 概要
- StudentShowRequestファイルにて`'student_id' => ['required','integer'],`のバリデーションを作成
- StudentControllerにて`show($student_id)`を`show(StudentShowRequest $request)`へ変更した上で、`findOrFail(student_id);`を`findOrFail($request->student_id);`に変更
- Student.phpに、 `const MAN = 'man';`    `const WOMAN = 'woman';`を追加し、returnの文字列'man'の代わりに定数を使用しました（作業会でKouさんにご指摘いただいた内容です）

## 動作確認手順
- Postmanでlocalhost:8080/api/v1/instructor/student/1をsendしレスポンスを確認
<img width="1440" alt="スクリーンショット 2023-08-22 23 23 52" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/7bcefb80-bf8f-4d36-8850-7ab19951c34d">

- Postmanでlocalhost:8080/api/v1/instructor/student/aをsendしバリデーションを確認
<img width="1440" alt="スクリーンショット 2023-08-22 23 24 08" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/30750dfa-6e92-4cb0-b56c-c313ae6dc13b">


## 考慮して欲しいこと
- 特にありません

## 確認してほしいこと
- Student.phpの `const MAN = 'man';`    `const WOMAN = 'woman';`の定数追加した箇所について、もっとスマートな書き方があれば教えてほしいです

```
    const SEX_MAN = 1;
    const SEX_WOMAN = 2;
    const MAN = 'man';
    const WOMAN = 'woman';
    
    public function getSexAttribute($value)
    {    
        if ($value === self::SEX_MAN) {
            return self::MAN;
        } elseif ($value === self::SEX_WOMAN) {
            return self::WOMAN;
        }
        return null;
    }
```

