### PR TITLE
jka-327 講座受講生登録（講師側）で登録したユーザにテストメールを送付/jka-328 空の配列を返すようにコントローラ＋仮のルーティング作成(三田村 2023.8.23)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 
 class StudentController extends Controller
 {
-    public function StudentRegisterTest(Request $request)
+    public function sendMail(Request $request)
     {
       return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StudentController extends Controller
+{
+    public function StudentRegisterTest(Request $request)
+    {
+      return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,7 +17,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 //動作確認テスト
-Route::get('student_register_test','Api\Instructor\StudentController@StudentRegisterTest');
+Route::get('send_mail','Api\Instructor\StudentController@sendMail');
 
 Route::prefix('v1')->group(function () {
     // 講師側API

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,8 @@ use Illuminate\Http\Request;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+//動作確認テスト
+Route::get('student_register_test','Api\Instructor\StudentController@StudentRegisterTest');
 
 Route::prefix('v1')->group(function () {
     // 講師側API


### PR DESCRIPTION
## issue
- Close jka-328
## 概要
- 空の配列を返すようにコントローラ＋仮のルーティング作成(講師側・講座受講生登録)
## 動作確認手順
- developから新規にtopic/jka-327/test_mail_2を作成
- 新規topicブランチからfeature/mitamura/jka-328/test_empty_arrayブランチを作成
- Api/Instructorディレクトリの下にStudentControllerファイルを作成
- api.phpに動作確認用のルーティング(URL:student_register_test/)を追加
- StudentControllerに空配列を返すStudentRegisterTestメソッドを追加
- postmanでget⇒ http://localhost:8080/api/student_register_test ⇒send
- []が返ってくるのを確認
- ## 考慮してほしい事
- 特にありません
## 確認してほしい事
- 動作確認用ルーティングの位置に問題ありませんか？
