### PR TITLE
チャプター&レッスン画面にチャプター進捗などを表示（受講生側）：DBへのロジック作成(二宮)

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\CourseIndexResource;
 use App\Http\Resources\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
+use App\Model\Chapter;
 
 class CourseController extends Controller
 {
@@ -68,6 +69,74 @@ class CourseController extends Controller
      */
     public function progress(Request $request)
     {
-        return response()->json([]);
+        // TODO 認証ユーザーを一時的にid=1とする。
+        $authId = 1;
+        $attendance = Attendance::with([
+            'course.chapters.lessons.lessonAttendance'
+        ])
+        ->where([
+            'course_id' => $request->route('course_id'),
+            'student_id' => $authId
+        ])
+        ->first();
+
+        
+        // 終了済みのレッスン数
+        $completedLessonsCount = 0;
+        foreach ($attendance->course->chapters as $chapter) {
+            foreach ($chapter->lessons as $lesson) {
+                $completedAttendancesCount = $lesson->lessonAttendance->where('status', 'completed_attendance')->count();
+                $completedLessonsCount += $completedAttendancesCount;
+            }
+        }
+
+        // 終了済みのチャプター数
+        $completedChaptersCount = 0;
+        foreach ($attendance->course->chapters as $chapter) {
+            if (count($chapter->lessons) === 0 ) {
+                continue;
+            }
+            if ($this->getChapterProgress($chapter->lessons)) {
+                $completedChaptersCount++;
+            }
+        }
+
+        // チャプター・チャプター毎のレッスン数
+        $chapterLessons = Chapter::where('course_id', $request->route('course_id'))
+            ->withCount('lessons')
+            ->get();
+
+        // 最もIDが若い未完了のチャプター（続きのレッスンID取得）
+        $youngestUnCompletedChapter = null;
+        foreach ($attendance->course->chapters as $chapter) {
+            if (!$this->getChapterProgress($chapter->lessons)) {
+                if ($youngestUnCompletedChapter === null || $chapter->id < $youngestUnCompletedChapter) {
+                    $youngestUnCompletedChapter = $chapter->id;
+                }
+            }
+        }
+
+        return response()->json([
+            'course' =>[
+                'course_id' => $request->course_id,
+                'progress' => $attendance->progress
+            ],
+            "number_of_completed_chapters" => $completedChaptersCount,
+            "number_of_total_chapters" => $chapterLessons->count(),
+            "number_of_completed_lessons" => $completedLessonsCount,
+            "number_of_total_lessons" => $chapterLessons->sum('lessons_count'),
+            "continue_lesson_id" => $youngestUnCompletedChapter
+        ]); 
+    }
+
+    private function getChapterProgress($lessons) {
+        foreach ($lessons as $lesson) {
+            foreach ($lesson->lessonAttendance as $lessonAttendance) {
+                if ($lessonAttendance->status !== 'completed_attendance') {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -67,7 +67,7 @@ class CourseController extends Controller
      * チャプター進捗状況、続きのレッスンID取得API
      *
      * @param Request $request
-     * @return Resource
+     * @return \Illuminate\Http\JsonResponse
      */
     public function progress(Request $request)
     {

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -10,7 +10,6 @@ use App\Http\Resources\CourseIndexResource;
 use App\Http\Resources\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
-use App\Model\Chapter;
 use App\Model\LessonAttendance;
 
 class CourseController extends Controller
@@ -82,62 +81,94 @@ class CourseController extends Controller
         ])
         ->firstOrFail();
 
-        // 終了済みのチャプター数
-        $completedLessonAttendanceIds = $attendance->lessonAttendances->filter(function ($lessonAttendance) {
-            return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-        })
-        ->pluck('id');
-        
-        $groupedLessons = $attendance->course->chapters
-        ->flatMap(function ($chapter) {
-            return $chapter->lessons->groupBy('chapter_id');
-        });
-
-        $completedChaptersCount = $groupedLessons->filter(function ($groupedLesson) use ($completedLessonAttendanceIds) {
-            return $groupedLesson->pluck('id')->intersect($completedLessonAttendanceIds)->count() === $groupedLesson->count();
-        })->count();
-
-        // チャプター合計
-        $totalChaptersCount = $attendance->course->chapters->count();
-
-        // 終了済みのレッスン数
-        $completedLessonsCount = 0;
-        foreach ($attendance->lessonAttendances as $lessonAttendance)
-        if ($lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
-            $completedLessonsCount ++;
-        }
-        
-        // レッスン合計
-        $totalLessonsCount = 0;
-        foreach ($attendance->course->chapters as $chapter) {
-            $lessonCount = $chapter->lessons->count();
-            $totalLessonsCount += $lessonCount; 
-        }
-
-        // 未完了のチャプターでIDが最も若いレッスン（続きのレッスンID取得）
-        $UnCompletedLessonAttendanceIds = $attendance->lessonAttendances->filter(function ($lessonAttendance) {
-            return $lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-        })
-        ->pluck('id');
-        
-        $youngestUnCompletedLesson = $attendance->course->chapters
-        ->flatMap(function ($chapter) use ($UnCompletedLessonAttendanceIds) {
-            return $chapter->lessons->filter(function ($lesson) use ($UnCompletedLessonAttendanceIds) {
-                return $UnCompletedLessonAttendanceIds->contains($lesson->id);
-            });
-        })
-        ->sortBy('chapter_id')->first()['id'];
-
         return response()->json([
             'course' =>[
                 'course_id' => $request->course_id,
                 'progress' => $attendance->progress
             ],
-            "number_of_completed_chapters" => $completedChaptersCount,
-            "number_of_total_chapters" => $totalChaptersCount,
-            "number_of_completed_lessons" => $completedLessonsCount,
-            "number_of_total_lessons" => $totalLessonsCount,
-            "continue_lesson_id" => $youngestUnCompletedLesson
+            "number_of_completed_chapters" => $this->getCompletedChaptersCount($attendance),
+            "number_of_total_chapters" => $this->getTotalChaptersCount($attendance),
+            "number_of_completed_lessons" => $this->getCompletedLessonsCount($attendance),
+            "number_of_total_lessons" => $this->getTotalLessonsCount($attendance),
+            "continue_lesson_id" => $this->getYoungestUnCompletedLesson($attendance)
         ]); 
+    }
+    /**
+     * 完了済みのチャプター数を取得する
+     *
+     * @param Attendance $attendance
+     */
+    private function getCompletedChaptersCount($attendance)
+    {
+        return $attendance->course->chapters->filter(function ($chapter) use ($attendance) {
+            $isCompleted = false;
+            // 全てのレッスンが完了済みかどうかをチェック
+            $chapter->lessons->each(function ($lesson) use ($attendance, &$isCompleted) {
+                $lessonAttendance = $attendance->lessonAttendances->where('lesson_id', $lesson->id)->first();
+                if ($lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
+                    $isCompleted = false;
+                    return false;
+                }
+                $isCompleted = true;
+            });
+            return $isCompleted;
+        })->count();        
+    }
+    /**
+     * チャプター合計を取得する
+     *
+     * @param Attendance $attendance
+     */
+    private function getTotalChaptersCount($attendance)
+    {
+        return $attendance->course->chapters->count();
+    }
+    /**
+     * 完了済みのレッスン数を取得する
+     *
+     * @param Attendance $attendance
+     */
+    private function getCompletedLessonsCount($attendance)
+    {
+        return $attendance->lessonAttendances->filter(function ($lessonAttendance) {
+            return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+        })->count();
+    }
+    /**
+     * レッスン合計を取得する
+     *
+     * @param Attendance $attendance
+     */
+    private function getTotalLessonsCount($attendance)
+    {
+        $totalLessonsCount = 0;
+        foreach ($attendance->course->chapters as $chapter) {
+            $lessonCount = $chapter->lessons->count();
+            $totalLessonsCount += $lessonCount; 
+        }
+        return $totalLessonsCount;
+    }
+    /**
+     * 続きのレッスンIDを取得する（IDが最も若い未完了のチャプターの内、IDが最も若い未完了のレッスン）
+     *
+     * @param Attendance $attendance
+     */
+    private function getYoungestUnCompletedLesson($attendance)
+    {
+        $UnCompletedLessonAttendanceIds = $attendance->lessonAttendances->filter(function ($lessonAttendance) {
+            return $lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+        })
+        ->pluck('id');
+        // 全てのレッスンが完了済みの場合
+        if ($UnCompletedLessonAttendanceIds->isEmpty()) {
+            return null;
+        }
+
+        return $attendance->course->chapters->flatMap(function ($chapter) use ($UnCompletedLessonAttendanceIds) {
+            return $chapter->lessons->filter(function ($lesson) use ($UnCompletedLessonAttendanceIds) {
+                return $UnCompletedLessonAttendanceIds->contains($lesson->id);
+            });
+        })
+        ->sortBy('chapter_id')->first()['id'];
     }
 }


### PR DESCRIPTION
概要
---
- タスク「チャプター&レッスン画面にチャプター進捗などを表示（受講生側）」
DBへのロジック

実施内容
---
下記のレスポンスを作成
- 終了済みチャプター数
チャプターが保有するレッスンが全て終了している状態を終了とカウントする
- 全チャプター数
- 終了済みレッスン数
- 全レッスン数
- 最もIDが若い未完了のチャプター
**→(追記)最もIDが若い未完了のチャプターの内の最もIDが若い未完了のレッスン**
**→(追記)すべてのレッスンが完了済みの場合 null を返す**
動作確認
---
postmanにて、GET：http\://localhost:8080/api/v1/course/1/progress　→sendにて確認
それぞれ5つのレスポンスについて、adminerdで数字を変化させて問題ないことを確認。

確認してほしいこと
---
- よりスマートな書き方や効率の良い書き方があればご教示頂きたいです。


