### PR TITLE
jka-362 講座受講生詳細画面（講師側）Resourseファイル作成（おおた）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -19,8 +19,6 @@ class StudentController extends Controller
     {
         $student = Student::with(['attendances.course.chapters.lessons.lessonAttendance'])->findOrFail($request->student_id);
 
-        return response()->json([
-            'data' => new StudentShowResource($student)
-        ]);
+        return new StudentShowResource($student);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Http\Controllers\Controller;
 use App\Model\Student;
 use App\Http\Requests\Instructor\StudentShowRequest;
+use App\Http\Resources\Instructor\StudentShowResource;
 
 class StudentController extends Controller
 {
@@ -12,55 +13,14 @@ class StudentController extends Controller
      * 講座受講生詳細情報を取得
      *
      * @param StudentShowRequest $request
-     * @return \Illuminate\Http\JsonResponse
+     * @return StudentShowResource
      */
     public function show(StudentShowRequest $request)
     {
         $student = Student::with(['attendances.course.chapters.lessons.lessonAttendance'])->findOrFail($request->student_id);
 
         return response()->json([
-            'data' => [
-                'student' => [
-                    'given_name_by_instructor' => $student->given_name_by_instructor,
-                    'student_id' => $student->id,
-                    'nick_name' => $student->nick_name,
-                    'last_name' => $student->last_name,
-                    'first_name' => $student->first_name,
-                    'occupation' => $student->occupation,
-                    'email' => $student->email,
-                    'purpose' => $student->purpose,
-                    'birth_date' => $student->birth_date->format('Y/m/d'),
-                    'sex' => $student->sex,
-                    'address' => $student->address,
-                    'created_at' => $student->created_at->format('Y/m/d'),
-                    'last_login_at' => $student->last_login_at, //カラム追加後、日付はフォーマットして渡す ->format('Y/m/d')
-                    'courses' => $student->attendances->map(function ($attendance) {
-                        return [
-                            'course_id' => $attendance->course->id,
-                            'image' => $attendance->course->image,
-                            'title' => $attendance->course->title,
-                            'progress' => $attendance->progress,
-                            'chapters' => $attendance->course->chapters->map(function ($chapter) {
-                                return [
-                                    'chapter_id' => $chapter->id,
-                                    'title' => $chapter->title,
-                                    'lessons' => $chapter->lessons->map(function ($lesson) {
-                                        return [
-                                            'lesson_id' => $lesson->id,
-                                            'lesson_attendance' => $lesson->lessonAttendance->map(function ($attendance) {
-                                                return [
-                                                    'lesson_attendance_id' => $attendance->id,
-                                                    'status' => $attendance->status,
-                                                ];
-                                            }),
-                                        ];
-                                    }),
-                                ];
-                            }),
-                        ];
-                    }),
-                ],
-            ],
+            'data' => new StudentShowResource($student)
         ]);
     }
 }

--- a/app/Http/Resources/Instructor/StudentShowResource.php
+++ b/app/Http/Resources/Instructor/StudentShowResource.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Resources\Instructor;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StudentShowResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        $student = $this->resource; 
+        
+        return [
+            'student' => [
+                'given_name_by_instructor' => $student->given_name_by_instructor,
+                'student_id' => $student->id,
+                'nick_name' => $student->nick_name,
+                'last_name' => $student->last_name,
+                'first_name' => $student->first_name,
+                'occupation' => $student->occupation,
+                'email' => $student->email,
+                'purpose' => $student->purpose,
+                'birth_date' => $student->birth_date->format('Y/m/d'),
+                'sex' => $student->sex,
+                'address' => $student->address,
+                'created_at' => $student->created_at->format('Y/m/d'),
+                'last_login_at' => $student->last_login_at, //カラム追加後、日付はフォーマットして渡す ->format('Y/m/d')
+                'courses' => $student->attendances->map(function ($attendance) {
+                    return [
+                        'course_id' => $attendance->course->id,
+                        'image' => $attendance->course->image,
+                        'title' => $attendance->course->title,
+                        'progress' => $attendance->progress,
+                        'chapters' => $attendance->course->chapters->map(function ($chapter) {
+                            return [
+                                'chapter_id' => $chapter->id,
+                                'title' => $chapter->title,
+                                'lessons' => $chapter->lessons->map(function ($lesson) {
+                                    return [
+                                        'lesson_id' => $lesson->id,
+                                        'lesson_attendance' => $lesson->lessonAttendance->map(function ($attendance) {
+                                            return [
+                                                'lesson_attendance_id' => $attendance->id,
+                                                'status' => $attendance->status,
+                                            ];
+                                        }),
+                                    ];
+                                }),
+                            ];
+                        }),
+                    ];
+                }),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-362

## 概要
- `StudentController.php`に記述していた'student'レスポンスの記述を`StudentShowResource.php`に移動しました。

## 動作確認手順
- Postmanでlocalhost:8080/api/v1/instructor/student/1をsendしレスポンスを確認
<img width="1440" alt="スクリーンショット 2023-08-28 15 32 07" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/614cce4c-106b-41f9-8c5b-b3e1569b8466">

- Postmanでlocalhost:8080/api/v1/instructor/student/aをsendしバリデーションを確認
<img width="1440" alt="スクリーンショット 2023-08-28 15 32 19" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/edbe00eb-0687-4b48-9e96-936c1502ddb7">

## 考慮して欲しいこと
- `StudentShowResource.php`33行目の'last_login_at' => $student->last_login_at, について
 日付をフォーマットして渡すために `->format('Y/m/d')`　を記述するべきですが、nullではエラーになるため現状はコメントアウトしております。

最新のdvelopにはすでに実装されているようですので、最新developをマージした上で再度プルリクを出した方が良いかご指導いただければ幸いです。

## 確認してほしいこと
- 特にありません