### PR TITLE
お知らせ登録機能（講師側）空の配列を返すようにコントローラ＋ルーティング作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function store(Request $request)
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,9 +24,6 @@ Route::prefix('v1')->group(function () {
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
-        Route::prefix('notification')->group(function () {
-            Route::post('/', 'Api\Instructor\NotificationController@store');
-        });
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
@@ -36,6 +33,9 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
+                Route::prefix('notification')->group(function () {
+                    Route::post('/', 'Api\Instructor\NotificationController@store');
+                });
                 Route::prefix('attendance')->group(function () {
                     Route::get('status', 'Api\Instructor\AttendanceController@show');
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,9 @@ Route::prefix('v1')->group(function () {
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
+        Route::prefix('notification')->group(function () {
+            Route::post('/', 'Api\Instructor\NotificationController@store');
+        });
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');


### PR DESCRIPTION
## issue
* https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-376
## 概要
* 空の配列を返すようにコントローラ＋ルーティング作成
## 動作確認手順
* Postmanにてlocalhost:8080/api/v1/instructor/course/1/notificationをSendし、[]がレスポンスされることを確認しました。
## 考慮して欲しいこと
* なし
## 確認してほしいこと
* ルーティングの階層が適切かどうかご確認いただけますと幸いです。