### PR TITLE
jka-330受講生一覧画面（講師側）フォームリクエスト（あめみや）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -6,7 +6,6 @@ use App\Model\Attendance;
 use App\Model\Course;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\StudentIndexRequest;
-use Illuminate\Http\Request;
 
 class StudentController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -5,11 +5,12 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Model\Attendance;
 use App\Model\Course;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\StudentIndexRequest;
 use Illuminate\Http\Request;
 
 class StudentController extends Controller
 {
-    public function index(Request $request)
+    public function index(StudentIndexRequest $request)
     {
         $perPage = $request->input('per_page', 20);
         $page = $request->input('page', 1);

--- a/app/Http/Requests/Instructor/StudentIndexRequest.php
+++ b/app/Http/Requests/Instructor/StudentIndexRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StudentIndexRequest extends FormRequest
+{
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer'],
+            'per_page' => ['integer', 'min:1'],
+            'page' => ['integer', 'min:1'],
+        ];
+    }
+}


### PR DESCRIPTION
## 概要
- 受講生一覧画面（講師側）フォームリクエスト(Requestバリデーション)
・下記リクエストファイルを作成
backend\laravelapp\app\Http\Requests\Instructor\StudentIndexRequest.php
・下記バリデーションルールを適用
course_id
per_page
page

## 動作確認手順
- Postmanにて下記URLにてSend
GET：localhost:8080/api/v1/instructor/course/1/student/index
エラーなくレスポンスがあることを確認。

念のため、下記などでも確認したが問題なし。
localhost:8080/api/v1/instructor/course/3/student/index
localhost:8080/api/v1/instructor/course/1/student/index?page=2


## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- course_idのバリデーションルールについて
コントローラーの`$request->course_id`の部分で`course_id`がリクエストに入っているのですが、
それでも、別途リクエストファイルにて、バリデーションルール`'course_id' => ['required', 'integer'],`を設けるのは、
今後、何か機能の拡張や変更があった際のためでしょうか？
または、別途リクエストファイルに記載する事で、わかりやすくするため？などでしょうか？
意図や意味がいまいち理解できておりません。