### PR TITLE
JKA-303 ユーザー情報編集にて空の配列を返すようにコントローラ＋ルーティング作成

### DIFF
--- a/app/Http/Controllers/Api/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/LessonAttendanceController.php
@@ -47,4 +47,9 @@ class LessonAttendanceController extends Controller
             ]);
         }
     }
+
+    public function edit()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,5 +65,6 @@ Route::prefix('v1')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });
     });
+    Route::get('lesson_attendance/edit', 'Api\LessonAttendanceController@edit');
     Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,6 +65,8 @@ Route::prefix('v1')->group(function () {
             Route::get('/', 'Api\ChapterController@show');
         });
     });
-    Route::get('lesson_attendance/edit', 'Api\LessonAttendanceController@edit');
-    Route::patch('lesson_attendance', 'Api\LessonAttendanceController@update');
+    Route::prefix('lesson_attendance')->group(function () {
+        Route::get('edit', 'Api\LessonAttendanceController@edit');
+        Route::patch('/', 'Api\LessonAttendanceController@update');
+    });
 });


### PR DESCRIPTION
# issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-303

# 動作確認手順
- Postmanで「localhost:8080/api/v1/lesson_attendance/edit」を行い、空の配列が返ってくることを確認しました。

# 確認してほしいこと
- メソッドやルーティングを記載した位置は正しいでしょうか。