### PR TITLE
Laravel開発: フロントエンドリファクタリングによる改修

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -21,7 +21,7 @@ class CourseController extends Controller
     public function index(CourseIndexRequest $request)
     {
         if ($request->text === null) {
-            $attendances = Attendance::with(['course.instructor'])->where('student_id', $request->student_id)->get();
+            $attendances = Attendance::with(['course.instructor'])->where('student_id', $request->user()->id)->get();
             $publicAttendances = $this->extractPublicCourse($attendances);
             return new CourseIndexResource($publicAttendances);
         }
@@ -32,6 +32,7 @@ class CourseController extends Controller
             ->with(['course.instructor'])
             ->where('student_id', '=', $request->student_id)
             ->get();
+
         $publicAttendances = $this->extractPublicCourse($attendances);
         return new CourseIndexResource($publicAttendances);
     }

--- a/app/Http/Requests/CourseIndexRequest.php
+++ b/app/Http/Requests/CourseIndexRequest.php
@@ -24,7 +24,6 @@ class CourseIndexRequest extends FormRequest
     public function rules()
     {
         return [
-            'student_id' => ['required', 'integer'],
             'text' => ['string']
         ];
     }

--- a/database/seeds/LessonAttendanceSeeder.php
+++ b/database/seeds/LessonAttendanceSeeder.php
@@ -49,6 +49,13 @@ class LessonAttendanceSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'lesson_id' => 6,
+                'attendance_id' => 1,
+                'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,17 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
+Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
+    // 受講生側API
+    Route::prefix('course')->group(function () {
+        Route::get('index', 'Api\CourseController@index');
+        Route::get('/', 'Api\CourseController@show');
+        Route::prefix('chapter')->group(function () {
+            Route::get('/', 'Api\ChapterController@show');
+        });
+    });
+});
+
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
@@ -58,14 +69,6 @@ Route::prefix('v1')->group(function () {
         });
     });
 
-    // 受講生側API
-    Route::prefix('course')->group(function () {
-        Route::get('/', 'Api\CourseController@show');
-        Route::get('index', 'Api\CourseController@index');
-        Route::prefix('chapter')->group(function () {
-            Route::get('/', 'Api\ChapterController@show');
-        });
-    });
     Route::prefix('lesson_attendance')->group(function () {
         Route::get('edit', 'Api\LessonAttendanceController@edit');
         Route::patch('/', 'Api\LessonAttendanceController@update');


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-387

## やったこと
- レッスン受講状態のデータ整合性があっていないため、シーダーを改修。
- 受講生側で参照するAPIは、認証ミドルウェアをかますように改修。
- 生徒IDはログインセッションから取得するように修正。

## 確認方法
コンテナ内で`php artisan migrate:fresh --seed`を実行