### PR TITLE
jka-327 講座受講生登録（講師側）で登録したユーザにテストメールを送付/jka-329 DBへのロジック作成(三田村 2023.9.2)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -17,6 +17,5 @@ class StudentController extends Controller
       Mail::send(new TestMail($name,$email));
       return response()->json(['message'=>'テストメールが送信されました',]);
   
-      // return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -4,11 +4,19 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\TestMail;
 
 class StudentController extends Controller
 {
     public function sendMail(Request $request)
     {
-      return response()->json([]);
+      $name = 'ユーザー１';
+      $email = 'user_1@test.com';
+  
+      Mail::send(new TestMail($name,$email));
+      return response()->json(['message'=>'テストメールが送信されました',]);
+  
+      // return response()->json([]);
     }
 }

--- a/app/Mail/TestMail.php
+++ b/app/Mail/TestMail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class TestMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($name,$email)
+    {
+      $this->name = $name;
+      $this->email = $email;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->to($this->email)
+        ->subject('テストメール')
+        ->view('testMail')
+        ->with(['name'=>$this->name,]);
+    }
+}

--- a/resources/views/testMail.blade.php
+++ b/resources/views/testMail.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>テストメール</title>
+</head>
+<body>
+    <p>{{ $name }} さん</p>
+    <p>テストメールです。</p>
+</body>
+</html>


### PR DESCRIPTION
## issue
- Close jka-329
## 概要
- テストメールの作成
## 動作確認手順
- 以前の空配列のタスクで作成したStudentControllerのsendMailメソッド内で実装	
- 空配列return response()->json([]);を削除しました
- mailtrapを利用
- postmanでget⇒ http://localhost:8080/api/send_mail ⇒send
- "テストメールが送信されました"　と返ってくるのを確認
- mailtrapでテストメールが受信されているのを確認
- ## 考慮してほしい事
- 特にありません
## 確認してほしい事
- 修正すべき点があればご指摘願います