### PR TITLE
JKA-377 お知らせ更新機能 送信部分のみ（講師側）:空配列を返すコントローラ＋ルーティング作成（ユウキ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Request;
 class NotificationController extends Controller
 {
     /**
-     * お知らせ表示更新API
+     * お知らせ更新API
      * @param
      * @return
      */

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    /**
+     * お知らせ表示更新API
+     * @param
+     * @return
+     */
+    public function update() {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,7 @@ Route::prefix('v1')->group(function () {
                 Route::prefix('attendance')->group(function () {
                     Route::get('status', 'Api\Instructor\AttendanceController@show');
                 });
+                Route::patch('notification', 'Api\Instructor\NotificationController@update');
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');


### PR DESCRIPTION
##  概要
JKA-377 お知らせ更新機能 送信部分のみ（講師側）:空配列を返すコントローラ＋ルーティング作成

## 実施内容
空配列を返すコントローラ＋ルーティング作成

対象ファイル
- app/Http/Controllers/Api/Instructor/NotificationController.php
- routes/api.php

## 動作確認
- ポストマンで必要な情報が整形されて返ってくるかを確認
PATCH: localhost:8080/api/v1/instructor/course/1/notification

## 確認して欲しいこと
- ルーティングが正しいか

以上、よろしくお願いします。