### PR TITLE
jka-327 講座受講生登録（講師側）で登録したユーザにテストメールを送付/jka-329 DBへのロジック作成再提出(三田村 2023.9.5)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -6,6 +6,9 @@ use App\Http\Controllers\Controller;
 use App\Model\Student;
 use App\Http\Requests\Instructor\StudentShowRequest;
 use App\Http\Resources\Instructor\StudentShowResource;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\TestMail;
 
 class StudentController extends Controller
 {
@@ -20,5 +23,15 @@ class StudentController extends Controller
         $student = Student::with(['attendances.course.chapters.lessons.lessonAttendances'])->findOrFail($request->student_id);
 
         return new StudentShowResource($student);
+    }
+
+    public function sendMail(Request $request)
+    {
+      $name = 'ユーザー１';
+      $email = 'user_1@test.com';
+
+      Mail::send(new TestMail($name,$email));
+      return response()->json(['message'=>'テストメールが送信されました',]);
+
     }
 }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -27,11 +27,10 @@ class StudentController extends Controller
 
     public function sendMail(Request $request)
     {
-      $name = 'ユーザー１';
-      $email = 'user_1@test.com';
+        $name = 'ユーザー１';
+        $email = 'user_1@test.com';
 
-      Mail::send(new TestMail($name,$email));
-      return response()->json(['message'=>'テストメールが送信されました',]);
-
+        Mail::send(new TestMail($name,$email));
+        return response()->json(['message'=>'テストメールが送信されました',]);
     }
 }


### PR DESCRIPTION
## issue
- Close jka-329
## 概要
- テストメールの作成
## 動作確認手順
- 以前の空配列のタスクで作成したStudentControllerのsendMailメソッド内で実装	
- 空配列return response()->json([]);を削除しました
- mailtrapを利用
- postmanでget⇒ http://localhost:8080/api/send_mail ⇒send
- "テストメールが送信されました"　と返ってくるのを確認
- mailtrapでテストメールが受信されているのを確認
- ## 考慮してほしい事
- topicからdevelopへのプルリクエスト申請の時競合が発生
- 競合の解消作業の時に誤った操作をしてしまった(pushしてしまった)
- リモートリポジトリにあるtopicのデーター(StudentControllerの実装)が消えてしまった事による再提出となります(featureからtopicに再提出)
## 確認してほしい事
- postmanとmailtrapでテストメールの再確認済みです
- 修正すべき点があればご指摘願います