### PR TITLE
チャプター&レッスン画面にチャプター進捗などを表示（受講生側）：フォームリクエスト作成(二宮)

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;    //postman確認のため仮作成
+use App\Http\Requests\CourseProgressRequest;
 use App\Http\Requests\CourseShowRequest;
 use App\Http\Requests\CourseIndexRequest;
 use App\Http\Resources\CourseIndexResource;
@@ -66,10 +66,10 @@ class CourseController extends Controller
     /**
      * チャプター進捗状況、続きのレッスンID取得API
      *
-     * @param Request $request
+     * @param CourseProgressRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function progress(Request $request)
+    public function progress(CourseProgressRequest $request)
     {
         // TODO 認証ユーザーを一時的にid=1とする。
         $authId = 1;

--- a/app/Http/Requests/CourseProgressRequest.php
+++ b/app/Http/Requests/CourseProgressRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CourseProgressRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id')
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer']
+        ];
+    }
+}


### PR DESCRIPTION
実施内容
---
タスク「チャプター&レッスン画面にチャプター進捗などを表示（受講生側）」
- フォームリクエストの作成

動作確認
---
postmanにてURIの{course_id}の部分を変更してレスポンスを確認。

1. GET：http:\//localhost:8080/api/v1/course/1/progress　→sendにて確認
問題なくレスポンスが返される
2. GET：http:\//localhost:8080/api/v1/course/あ/progress　→sendにて確認
The course id must be an integer が返される
3. GET：http:\//localhost:8080/api/v1/course/2/progress　→sendにて確認
"message": "No query results for model [App\\Model\\Attendance].",
"exception": "Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException",が返される
(firstOrFail()が機能する)

考慮してほしいこと
---
- 状況に応じて、下記コマンドで動作確認する必要あり。  
php artisan migrate:fresh --seed

確認してほしいこと
---
動作確認の(3)のケースはfindOrFailが機能しており、問題ないという認識でよろしいのでしょうか？
