### PR TITLE
JKA-409 お知らせ編集機能 表示GET部分のみ（講師側）空の配列を返すようにコントローラ＋ルーティング作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function show(Request $request)
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,6 +45,9 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
+                Route::prefix('notification')->group(function () {
+                    Route::get('/', 'Api\Instructor\NotificationController@show');
+                });
                 Route::prefix('attendance')->group(function () {
                     Route::get('status', 'Api\Instructor\AttendanceController@show');
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,11 @@ Route::prefix('v1')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
         Route::patch('/', 'Api\Instructor\InstructorController@update');
+        Route::prefix('notification')->group(function () {
+            Route::prefix('{notification_id}')->group(function () {
+                Route::get('/', 'Api\Instructor\NotificationController@show');
+            });
+        });
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
             Route::post('/', 'Api\Instructor\CourseController@store');
@@ -45,9 +50,6 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
-                Route::prefix('notification')->group(function () {
-                    Route::get('/', 'Api\Instructor\NotificationController@show');
-                });
                 Route::prefix('attendance')->group(function () {
                     Route::get('status', 'Api\Instructor\AttendanceController@show');
                 });


### PR DESCRIPTION
## issue
- Closes #219

## 概要
お知らせ編集機能 表示GET部分のみ（講師側）空の配列を返すようにコントローラ＋ルーティング作成
## 動作確認手順
- postman上で(localhost:8080/api/v1/instructor/course/1/notification)を送ると空配列が返ってくることを確認。

