### PR TITLE
jka-408 チャプター作成機能の画面修正（講師側）Resourseファイル変更（おおた）

### DIFF
--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -23,6 +23,7 @@ class CourseShowResource extends JsonResource
                 return [
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
+                    'status' => $chapter->status,
                     'lessons' => $chapter->lessons->map(function ($lesson) {
                         return [
                            'lesson_id'=>$lesson->id,

--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -23,6 +23,7 @@ class CourseShowResource extends JsonResource
                 return [
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
+                    'order' => $chapter->order,
                     'status' => $chapter->status,
                     'lessons' => $chapter->lessons->map(function ($lesson) {
                         return [

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -55,7 +55,7 @@ class Course extends Model
      */
     public function chapters()
     {
-        return $this->hasMany(Chapter::class);
+        return $this->hasMany(Chapter::class)->orderBy('order', 'asc');
     }
 
     protected static function boot() 


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-408

## 概要
- チャプター作成機能の画面修正（講師側） Resourseファイルに"status"を追加しました

## 動作確認手順
- Postmanにてlocalhost:8080/api/v1/instructor/course/1をsendし、レスポンスのチャプター内に"status"が追加されたことを確認
<img width="1440" alt="スクリーンショット 2023-09-10 23 03 11" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/bc27a224-e79d-4ffb-8928-6b6be2085070">


## 考慮して欲しいこと
- 状況に応じて下記コマンドで動作確認する必要あり。
Php artisan migrate:fresh —seed

## 確認してほしいこと
- DBロジックとバリデーションは変更しておりません
- swaggerのExample Valueには"order": 1,のカラムの表示がありますが、Postmanのレスポンスには現状は表示されておりませんでした。問題なかったでしょうか？
<img width="961" alt="スクリーンショット 2023-09-10 23 16 02" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/31c55246-0e4e-4ece-9eaf-2a2d1bbc120a">

