### PR TITLE
JKA-377 お知らせ更新機能 送信部分のみ（講師側): フォームリクエスト作成（ユウキ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -11,7 +11,7 @@ class NotificationController extends Controller
     /**
      * お知らせ更新API
      * @param   NotificationUpdateRequest $request
-     * @return
+     * @return \Illuminate\Http\JsonResponse
      */
     public function update(NotificationUpdateRequest $request) {
         Notification::findOrFail($request->notification_id)

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -10,7 +10,7 @@ class NotificationController extends Controller
 {
     /**
      * お知らせ更新API
-     * @param
+     * @param   NotificationUpdateRequest $request
      * @return
      */
     public function update(NotificationUpdateRequest $request) {

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -13,8 +13,8 @@ class NotificationController extends Controller
      * @param
      * @return
      */
-    public function update(NotificationUpdateRequest $request, int $notification_id) {
-        Notification::findOrFail($notification_id)
+    public function update(NotificationUpdateRequest $request) {
+        Notification::findOrFail($request->notification_id)
             ->fill([
                 'type'  => $request->type,
                 'start_date' => $request->start_date,

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Model\Notification;
 
 class NotificationController extends Controller
@@ -13,7 +13,7 @@ class NotificationController extends Controller
      * @param
      * @return
      */
-    public function update(Request $request, int $notification_id) {
+    public function update(NotificationUpdateRequest $request, int $notification_id) {
         Notification::findOrFail($notification_id)
             ->fill([
                 'type'  => $request->type,

--- a/app/Http/Requests/Instructor/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Instructor/NotificationUpdateRequest.php
@@ -17,6 +17,12 @@ class NotificationUpdateRequest extends FormRequest
         return true;
     }
     
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_id' => $this->route('notification_id'),
+        ]);
+    }
     /**
      * Get the validation rules that apply to the request.
      *
@@ -25,11 +31,12 @@ class NotificationUpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'type'          => ['required', new NotificationStoreStatusRule()],
-            'start_date'    => ['required', 'date_format:Y-m-d H:i:s'],
-            'end_date'      => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
-            'title'         => ['required', 'string', 'max:50'],
-            'content'       => ['required', 'string', 'max:500'],
+            'notification_id' => ['required', 'integer'],
+            'type'            => ['required', new NotificationStoreStatusRule()],
+            'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
+            'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
+            'title'           => ['required', 'string', 'max:50'],
+            'content'         => ['required', 'string', 'max:500'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Instructor/NotificationUpdateRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests\Instructor;
 
-use App\Rules\NotificationStoreStatusRule;
+use App\Rules\NotificationUpdateStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class NotificationUpdateRequest extends FormRequest
@@ -32,7 +32,7 @@ class NotificationUpdateRequest extends FormRequest
     {
         return [
             'notification_id' => ['required', 'integer'],
-            'type'            => ['required', new NotificationStoreStatusRule()],
+            'type'            => ['required', new NotificationUpdateStatusRule()],
             'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
             'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
             'title'           => ['required', 'string', 'max:50'],

--- a/app/Http/Requests/Instructor/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Instructor/NotificationUpdateRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use App\Rules\NotificationStoreStatusRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+    
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'type'          => ['required', new NotificationStoreStatusRule()],
+            'start_date'    => ['required', 'date_format:Y-m-d H:i:s'],
+            'end_date'      => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
+            'title'         => ['required', 'string', 'max:50'],
+            'content'       => ['required', 'string', 'max:500'],
+        ];
+    }
+}

--- a/app/Rules/NotificationStoreStatusRule.php
+++ b/app/Rules/NotificationStoreStatusRule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Rules;
+
+use App\Model\Notification;
+use Illuminate\Contracts\Validation\Rule;
+
+class NotificationStoreStatusRule implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (
+            in_array(
+                $value,
+                [
+                Notification::TYPE_ALWAYS,
+                Notification::TYPE_ONCE
+                ],
+                true
+            )
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'Invalid Type.';
+    }
+}

--- a/app/Rules/NotificationUpdateStatusRule.php
+++ b/app/Rules/NotificationUpdateStatusRule.php
@@ -5,7 +5,7 @@ namespace App\Rules;
 use App\Model\Notification;
 use Illuminate\Contracts\Validation\Rule;
 
-class NotificationStoreStatusRule implements Rule
+class NotificationUpdateStatusRule implements Rule
 {
     /**
      * Determine if the validation rule passes.


### PR DESCRIPTION
##  概要
JKA-377 お知らせ更新機能 送信部分のみ（講師側）:フォームリクエスト作成

## 実施内容
リクエストファイルを作成し、ルールを設定しバリデーションを作成。
※app/Rules/NotificationStoreStatusRule.phpは他の方のプルリクエストからコピーして使用しました

対象ファイル
- app/Http/Controllers/Api/Instructor/NotificationController.php
- app/Http/Requests/Instructor/NotificationUpdateRequest.php

## 動作確認
- ポストマンで確認

## 確認して欲しいこと
- ルールに沿ったリクエストを投げているつもりですが、日付のフォーマットが異なると言われています。どこが不適切でしょうか？
![image](https://github.com/yukihiroLaravel/juko_laravel/assets/128158806/92293020-576a-4d53-89b6-5a2ca1214e57)


以上、よろしくお願いします。