### PR TITLE
jka-394 お知らせ削除機能(講師側)/jka-414 空の配列を返すようにコントローラ＋ルーティング作成(三田村)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+  public function delete(Request $request)
+  {
+    return response()->json([]);
+  }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -49,6 +49,7 @@ Route::prefix('v1')->group(function () {
                 Route::prefix('attendance')->group(function () {
                     Route::get('status', 'Api\Instructor\AttendanceController@show');
                 });
+                Route::delete('notification','Api\Instructor\NotificationController@delete');
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,7 @@ Route::prefix('v1')->group(function () {
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
+        Route::delete('notification/{notification_id}','Api\Instructor\NotificationController@delete');
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::prefix('course')->group(function () {
             Route::get('index', 'Api\Instructor\CourseController@index');
@@ -49,7 +50,6 @@ Route::prefix('v1')->group(function () {
                 Route::prefix('attendance')->group(function () {
                     Route::get('status', 'Api\Instructor\AttendanceController@show');
                 });
-                Route::delete('notification','Api\Instructor\NotificationController@delete');
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');


### PR DESCRIPTION
## issue
- Close jka-414
## 概要
- お知らせ削除機能(講師側)/空の配列を返すようにコントローラ＋ルーティング作成
## 動作確認手順
- app/Http/Controllers/Api/Instructor直下にNotificationControllerを作成
- routes/api.phpファイル内に削除ルートを作成	
- ポストマンで　DELETE=>  localhost:8080/api/v1/instructor/notification/1  =>Send
- 空配列[]が返ってくるのを確認
- ## 考慮してほしい事
- 特にありません
## 確認してほしい事
- 修正すべき点があればご指摘願います