### PR TITLE
お知らせ一覧（講師側）/空の配列を返すようにコントローラ＋ルーティング作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -6,9 +6,15 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 class NotificationController extends Controller
 {
+    public function index(Request $request)
+    {
+        return response()->json([]);
+    }
+
     public function store(NotificationStoreRequest $request)
     {
         Notification::create([

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,7 +47,6 @@ Route::prefix('v1')->group(function () {
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
                 Route::prefix('notification')->group(function () {
-                    Route::get('index', 'Api\Instructor\NotificationController@index');
                     Route::post('/', 'Api\Instructor\NotificationController@store');
                 });
                 Route::prefix('attendance')->group(function () {
@@ -71,6 +70,9 @@ Route::prefix('v1')->group(function () {
                     });
                 });
             });
+        });
+        Route::prefix('notification')->group(function () {
+            Route::get('index', 'Api\Instructor\NotificationController@index');
         });
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,7 @@ Route::prefix('v1')->group(function () {
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
                 Route::prefix('notification')->group(function () {
+                    Route::get('index', 'Api\Instructor\NotificationController@index');
                     Route::post('/', 'Api\Instructor\NotificationController@store');
                 });
                 Route::prefix('attendance')->group(function () {


### PR DESCRIPTION
## issue
* https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-424
## 概要
* お知らせ一覧（講師側）/空の配列を返すようにコントローラ＋ルーティング作成
## 動作確認手順
* PostmanにてGETメソッドでlocalhost:8080/api/v1/instructor/course/1/notification/indexというURLをSendし、[]がレスポンスされることを確認しました。
## 考慮して欲しいこと
* 無し
## 確認してほしいこと
* ルーティングの階層と命名が適切かご確認いただけますと幸いです。