### PR TITLE
jka-421 受講生側の講座取得API:公開状態のチャプターのみ取得に変更　DBへのロジック変更（おおた）

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -42,7 +42,7 @@ class CourseController extends Controller
     /**
      * 公開中の講座を抽出
      *
-     * @param \Illuminate\Support\Collection $chapters
+     * @param \Illuminate\Support\Collection $attendances
      * @return \Illuminate\Support\Collection
      */
     private function extractPublicCourse($attendances)

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -39,12 +39,20 @@ class CourseController extends Controller
         return new CourseIndexResource($publicAttendances);
     }
 
+    /**
+     * 公開中の講座を抽出
+     *
+     * @param \Illuminate\Support\Collection $chapters
+     * @return \Illuminate\Support\Collection
+     */
     private function extractPublicCourse($attendances)
     {
         return $attendances->filter(function ($attendance) {
             return $attendance->course->status === Course::STATUS_PUBLIC;
-        });
+        })
+        ->values();
     }
+
     /**
      * 講座詳細取得API
      *
@@ -65,10 +73,17 @@ class CourseController extends Controller
         return new CourseShowResource($attendance);
     }
 
+    /**
+     * 公開中のチャプターを抽出
+     *
+     * @param \Illuminate\Support\Collection $chapters
+     * @return \Illuminate\Support\Collection
+     */
     private function extractPublicChapter($chapters)
     {
         return $chapters->filter(function ($chapter) {
             return $chapter->status === Chapter::STATUS_PUBLIC;
-        });
+        })
+        ->values();
     }
 }

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -9,6 +9,7 @@ use App\Http\Resources\CourseIndexResource;
 use App\Http\Resources\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
+use App\Model\Chapter;
 
 class CourseController extends Controller
 {
@@ -59,6 +60,15 @@ class CourseController extends Controller
         ])
         ->findOrFail($request->attendance_id);
 
+        $publicChapters = $this->extractPublicChapter($attendance->course->chapters);
+        $attendance->course->chapters = $publicChapters;
         return new CourseShowResource($attendance);
+    }
+
+    private function extractPublicChapter($chapters)
+    {
+        return $chapters->filter(function ($chapter) {
+            return $chapter->status === Chapter::STATUS_PUBLIC;
+        });
     }
 }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-421

## 概要
- 受講生側の講座取得API:公開状態のチャプターのみ取得に変更するDBへのロジック変更
- 受講生側のCourseControllerにてshowメソッドを修正し、extractPublicChapterメソッドを追加しました

## 動作確認手順
- Postmanでログイン認証
- Adminerでchaptersテーブルのid:1のstatusをprivateに変更
- Postmanでlocalhost:8080/api/v1/course/?attendance_id=1をsend
- chapter_id:1が非表示になったことを確認
<img width="1440" alt="スクリーンショット 2023-09-13 11 23 26" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/4ccae62f-b0de-41b8-9622-a8b5ba321999">

## 考慮して欲しいこと
状況に応じて下記コマンドで動作確認する必要あり。
Php artisan migrate:fresh —seed

## 確認してほしいこと
本タスク（27.受講生側の講座取得APIは、公開状態のチャプターのみを取得するように変更）については以下のステップになっておりますが、

a.DBへのロジック作成
b.フォームリクエスト(Requestバリデーション)必要あれば
c.Resourseファイル(レスポンスの整型)作成
d.その他修正して完成

今回の「DBへのロジック作成」で公開状態のチャプターのみ取得できるようになっております。
フォームリクエストとリソースファイルは変更なしでも良いのかと思ったのですがいかがでしょうか？