### PR TITLE
JKA-418 お知らせ編集機能 表示GET部分のみ（講師側）フォームリクエスト(Requestバリデーション)作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -10,10 +10,8 @@ class NotificationController extends Controller
 {
     public function show(NotificationShowRequest $request)
     {
-        $validatedData = $request->validated();
-
-        // バリデーションに合格した場合、データベースから通知情報を取得
-        $notification = Notification::findOrFail($validatedData['notification_id']);
+        // データベースから通知情報を取得
+        $notification = Notification::findOrFail($request->notification_id);
 
         return response()->json($notification);
     }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -3,23 +3,18 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use App\Model\Notification; // Notificationモデルをインポート
-use Illuminate\Http\Request;
+use App\Http\Requests\Instructor\NotificationShowRequest;
+use App\Model\Notification;
 
 class NotificationController extends Controller
 {
-    public function show(Request $request, $notification_id)
+    public function show(NotificationShowRequest $request)
     {
-        // 通知情報をデータベースから取得
-        $notification = Notification::find($notification_id);
+        // リクエストクラスを使用してバリデーション済みのデータにアクセス
+        $validatedData = $request->validated();
 
-        if (!$notification) {
-            return response()->json([
-                "result" => "false",
-                "error_code" => 400,
-                "error_message" => "Bad request."
-            ], 400);
-        }
+        // バリデーションに合格した場合、データベースから通知情報を取得
+        $notification = Notification::findOrFail($validatedData['notification_id']);
 
         return response()->json($notification);
     }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -10,7 +10,6 @@ class NotificationController extends Controller
 {
     public function show(NotificationShowRequest $request)
     {
-        // リクエストクラスを使用してバリデーション済みのデータにアクセス
         $validatedData = $request->validated();
 
         // バリデーションに合格した場合、データベースから通知情報を取得

--- a/app/Http/Requests/Instructor/NotificationShowRequest.php
+++ b/app/Http/Requests/Instructor/NotificationShowRequest.php
@@ -4,6 +4,8 @@ namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 class NotificationShowRequest extends FormRequest
 {
@@ -34,5 +36,15 @@ class NotificationShowRequest extends FormRequest
                 }),
             ],
         ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'result' => 'false',
+                'error_message' => 'Bad request.'
+            ], 400)
+        );
     }
 }

--- a/app/Http/Requests/Instructor/NotificationShowRequest.php
+++ b/app/Http/Requests/Instructor/NotificationShowRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class NotificationShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true; // 通常はtrueに設定しますが、必要に応じて認可ロジックを追加できます。
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'notification_id' => [
+                'required',
+                'integer',
+                'exists:notifications,id',
+                Rule::exists('notifications', 'id')->where(function ($query) {
+                    return $query->where('id', $this->route('notification_id'));
+                }),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/NotificationShowRequest.php
+++ b/app/Http/Requests/Instructor/NotificationShowRequest.php
@@ -3,9 +3,6 @@
 namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
-use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Http\Exceptions\HttpResponseException;
 
 class NotificationShowRequest extends FormRequest
 {
@@ -17,6 +14,13 @@ class NotificationShowRequest extends FormRequest
     public function authorize()
     {
         return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_id' => $this->route('notification_id'),
+        ]);
     }
 
     /**
@@ -31,20 +35,7 @@ class NotificationShowRequest extends FormRequest
                 'required',
                 'integer',
                 'exists:notifications,id',
-                Rule::exists('notifications', 'id')->where(function ($query) {
-                    return $query->where('id', $this->route('notification_id'));
-                }),
             ],
         ];
-    }
-
-    protected function failedValidation(Validator $validator)
-    {
-        throw new HttpResponseException(
-            response()->json([
-                'result' => 'false',
-                'error_message' => 'Bad request.'
-            ], 400)
-        );
     }
 }

--- a/app/Http/Requests/Instructor/NotificationShowRequest.php
+++ b/app/Http/Requests/Instructor/NotificationShowRequest.php
@@ -14,7 +14,7 @@ class NotificationShowRequest extends FormRequest
      */
     public function authorize()
     {
-        return true; // 通常はtrueに設定しますが、必要に応じて認可ロジックを追加できます。
+        return true;
     }
 
     /**


### PR DESCRIPTION
## issue
- Closes #235 

## 概要
お知らせ編集機能 表示GET部分のみ（講師側）フォームリクエスト(Requestバリデーション)作成

## 手順
-添付画像のように
![2023-09-14 (1)](https://github.com/yukihiroLaravel/juko_laravel/assets/128276058/f816e4d7-2ffb-4f0d-8c0e-e2bbfb38bdbe)
![2023-09-14](https://github.com/yukihiroLaravel/juko_laravel/assets/128276058/d91caf37-7720-40ed-a4b6-3a138158d692)
idがあっている場合はデータベースの情報を表示、そうでない場合はエラーメッセージを返せるようにした。

## 確認してほしいこと
- `public function show`の部分を変えてしまったが問題ないか。

