### PR TITLE
お知らせ一覧（講師側）/DBへのロジック作成（お知らせ情報取得）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -13,7 +13,7 @@ class NotificationController extends Controller
 {
     public function index(Request $request)
     {
-        $notifications = Notification::with(['course'])->get();
+        $notifications = Notification::with(['course'])->where('instructor_id', 1)->get(); //講師IDは仮で1を指定
 
         $modifiedNotifications = $notifications->map(function ($notification) {
             return [

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
-use App\Model\Course;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -13,17 +13,21 @@ class NotificationController extends Controller
 {
     public function index(Request $request)
     {
-        $notifications = Notification::with(['course:id,title'])
-                                        ->select('id', 'course_id', 'title', 'type', 'start_date')
-                                        ->get();
+        $notifications = Notification::with(['course'])->get();
 
-        $notifications->each(function ($notification) {
-            $notification->course_title = $notification->course ? $notification->course->title : null;
-            unset($notification->course);
+        $modifiedNotifications = $notifications->map(function ($notification) {
+            return [
+                "id" => $notification->id,
+                "course_id" => $notification->course_id,
+                "course_title" => $notification->course->title,
+                "title" => $notification->title,
+                "type" => $notification->type,
+                "start_date" => $notification->start_date,
+            ];
         });
 
         return response()->json([
-            'notifications' => $notifications,
+            'notifications' => $modifiedNotifications,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
+use App\Model\Course;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
@@ -12,7 +13,18 @@ class NotificationController extends Controller
 {
     public function index(Request $request)
     {
-        return response()->json([]);
+        $notifications = Notification::with(['course:id,title'])
+                                        ->select('id', 'course_id', 'title', 'type', 'start_date')
+                                        ->get();
+
+        $notifications->each(function ($notification) {
+            $notification->course_title = $notification->course ? $notification->course->title : null;
+            unset($notification->course);
+        });
+
+        return response()->json([
+            'notifications' => $notifications,
+        ]);
     }
 
     public function store(NotificationStoreRequest $request)

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -47,4 +47,14 @@ class Notification extends Model
             $this->attributes['type'] = self::TYPE_ONCE_INT;
         }
     }
+
+    public function getTypeAttribute($value)
+    {
+        if ($value === self::TYPE_ALWAYS_INT) {
+            return self::TYPE_ALWAYS;
+        } elseif ($value === self::TYPE_ONCE_INT) {
+            return self::TYPE_ONCE;
+        }
+        return null;
+    }
 }

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -32,6 +32,11 @@ class Notification extends Model
     const TYPE_ALWAYS = 'always';
     const TYPE_ONCE = 'once';
 
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+
     public function setTypeAttribute($value)
     {
         $this->attributes['type'] = null;


### PR DESCRIPTION
## issue
* https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-435
## 概要
* お知らせ一覧（講師側）/DBへのロジック作成（お知らせ情報取得）
## 動作確認手順
* PostmanにてGETメソッドでlocalhost:8080/api/v1/instructor/notification/indexというURLをSendし、お知らせ情報がレスポンスされることを確認しました。
<img width="1085" alt="スクリーンショット 2023-09-15 0 47 04" src="https://github.com/yukihiroLaravel/juko_laravel/assets/99865549/5cd260f4-57c7-488d-9397-8300eb5fa628">

## 考慮して欲しいこと
* ページネーション機能は次タスクで行う予定です。
## 確認してほしいこと
* Eloquentでのデータ取得が適切か確認して頂けますと幸いです。