### PR TITLE
JKA-377 お知らせ更新機能 送信部分のみ（講師側): リソースファイル作成（ユウキ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationUpdateRequest;
+use App\Http\Resources\Instructor\NotificationUpdateResource;
 use App\Model\Notification;
 
 class NotificationController extends Controller
@@ -14,17 +15,19 @@ class NotificationController extends Controller
      * @return \Illuminate\Http\JsonResponse
      */
     public function update(NotificationUpdateRequest $request) {
-        Notification::findOrFail($request->notification_id)
-            ->fill([
-                'type'  => $request->type,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'title' => $request->title,
-                'content' => $request->content,
-            ])
-            ->save();
+        $notification = Notification::findOrFail($request->notification_id);
+        $notification->fill([
+            'type'  => $request->type,
+            'start_date' => $request->start_date,
+            'end_date' => $request->end_date,
+            'title' => $request->title,
+            'content' => $request->content,
+        ])
+        ->save();
+
         return response()->json([
             'result' => true,
+            'data' => new NotificationUpdateResource($notification),
         ]);
     }
 }

--- a/app/Http/Resources/Instructor/NotificationUpdateResource.php
+++ b/app/Http/Resources/Instructor/NotificationUpdateResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Instructor;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class NotificationUpdateResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'type'       => $this->resource->type,
+            'start_date' => $this->resource->start_date,
+            'end_date'   => $this->resource->end_date,
+            'title'      => $this->resource->title,
+            'content'    => $this->resource->content,
+        ];
+    }
+}

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -32,6 +32,21 @@ class Notification extends Model
     const TYPE_ALWAYS = 'always';
     const TYPE_ONCE = 'once';
 
+    /**
+     * 表示区分
+     *
+     * @return string
+     */
+    public function getTypeAttribute($value)
+    {
+        if ($value === self::TYPE_ALWAYS_INT) {
+            return self::TYPE_ALWAYS;
+        } elseif ($value === self::TYPE_ONCE_INT) {
+            return self::TYPE_ONCE;
+        }
+        return null;
+    }
+
     public function setTypeAttribute($value)
     {
         $this->attributes['type'] = null;


### PR DESCRIPTION
##  概要
JKA-377 お知らせ更新機能 送信部分のみ（講師側）:フォームリクエスト作成

## 実施内容
リソースファイルを作成し、JsonResponseのdataとして更新したパラメータを表示

対象ファイル
- app/Http/Controllers/Api/Instructor/NotificationController.php
- app/Http/Resources/Instructor/NotificationUpdateResource.php

## 動作確認
- ポストマンで確認
<img width="1075" alt="スクリーンショット 2023-09-15 23 50 03" src="https://github.com/yukihiroLaravel/juko_laravel/assets/128158806/06d7b23f-faf3-4ff3-9361-9d323cb394f6">

## 確認して欲しいこと
- 修正前の記載（$notification = Notification::findOrFail($request->notification_id)->fill〜）だとエラーになっていたので今回のように修正をしましたが、修正方法はあっていますでしょうか？


以上、よろしくお願いします。