### PR TITLE
受講生側のチャプター取得APIは、公開状態のチャプターのみを取得：DBロジックへの変更（おおた）

### DIFF
--- a/app/Http/Controllers/Api/ChapterController.php
+++ b/app/Http/Controllers/Api/ChapterController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\ChapterGetRequest;
 use App\Http\Resources\ChapterShowResource;
 use App\Model\Attendance;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use App\Model\Chapter;
 
 class ChapterController extends Controller
 {
@@ -30,6 +31,21 @@ class ChapterController extends Controller
             throw new HttpException(404, "Not found attendance.");
         }
 
+        $publicChapters = $this->extractPublicChapter($attendance->course->chapters);
+        $attendance->course->chapters = $publicChapters;
         return new ChapterShowResource($attendance, $request->chapter_id);
+    }
+
+    /**
+     * 公開中のチャプターを抽出
+     *
+     * @param \Illuminate\Support\Collection $chapters
+     * @return \Illuminate\Support\Collection
+     */
+    private function extractPublicChapter($chapters)
+    {
+        return $chapters->filter(function ($chapter) {
+            return $chapter->status === Chapter::STATUS_PUBLIC;
+        });
     }
 }

--- a/app/Http/Controllers/Api/ChapterController.php
+++ b/app/Http/Controllers/Api/ChapterController.php
@@ -31,21 +31,8 @@ class ChapterController extends Controller
             throw new HttpException(404, "Not found attendance.");
         }
 
-        $publicChapters = $this->extractPublicChapter($attendance->course->chapters);
+        $publicChapters = Chapter::extractPublicChapter($attendance->course->chapters);
         $attendance->course->chapters = $publicChapters;
         return new ChapterShowResource($attendance, $request->chapter_id);
-    }
-
-    /**
-     * 公開中のチャプターを抽出
-     *
-     * @param \Illuminate\Support\Collection $chapters
-     * @return \Illuminate\Support\Collection
-     */
-    private function extractPublicChapter($chapters)
-    {
-        return $chapters->filter(function ($chapter) {
-            return $chapter->status === Chapter::STATUS_PUBLIC;
-        });
     }
 }

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -68,22 +68,8 @@ class CourseController extends Controller
         ])
         ->findOrFail($request->attendance_id);
 
-        $publicChapters = $this->extractPublicChapter($attendance->course->chapters);
+        $publicChapters = Chapter::extractPublicChapter($attendance->course->chapters);
         $attendance->course->chapters = $publicChapters;
         return new CourseShowResource($attendance);
-    }
-
-    /**
-     * 公開中のチャプターを抽出
-     *
-     * @param \Illuminate\Support\Collection $chapters
-     * @return \Illuminate\Support\Collection
-     */
-    private function extractPublicChapter($chapters)
-    {
-        return $chapters->filter(function ($chapter) {
-            return $chapter->status === Chapter::STATUS_PUBLIC;
-        })
-        ->values();
     }
 }

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -59,4 +59,17 @@ class Chapter extends Model
             }
         });
     }
+
+    /**
+     * 公開中のチャプターを抽出
+     *
+     * @param \Illuminate\Support\Collection $chapters
+     * @return \Illuminate\Support\Collection
+     */
+    public static function extractPublicChapter($chapters)
+    {
+        return $chapters->filter(function ($chapter) {
+            return $chapter->status === Chapter::STATUS_PUBLIC;
+        });
+    }
 }


### PR DESCRIPTION
## 概要
- 受講生側のチャプター取得APIは、公開状態のチャプターのみを取得：DBロジックへの変更

## 動作確認手順
- Adminerでchapter_id:1をprivateに変更した状態で
- Postmanでlocalhost:8080/api/v1/course/chapter?chapter_id=1&attendance_id=1をsendし、chapterが非公開になったことを確認
<img width="1440" alt="スクリーンショット 2023-09-17 8 29 07" src="https://github.com/yukihiroLaravel/juko_laravel/assets/126071123/84c7812b-31e2-4a67-aa35-b92dcb0de125">

## 考慮して欲しいこと
- 状況に応じて下記コマンドで動作確認する必要あり。
Php artisan migrate:fresh —seed


## 確認してほしいこと
- レスポンス内容がこれで適切か、記述内容がこれで適切か、自信がないので、ご指摘いただければ幸いです。
- プルリクが9/17締切だったので、一旦ご提出いたします。こちらのタスクを最後まで対応させていただければありがたいですが、次の期の方に引き継ぐか否か、またご連絡いただければ幸いです。
