### PR TITLE
jka-394 お知らせ削除機能(講師側)/jka-419 ロジック作成(三田村)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
+use App\Http\Requests\Instructor\NotificationDeleteRequest;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Http\Request;
 
 class NotificationController extends Controller
 {
@@ -27,7 +27,7 @@ class NotificationController extends Controller
         ]);
     }
 
-    public function delete(Request $request)
+    public function delete(NotificationDeleteRequest $request)
     {
      try{
         $notification = Notification::findOrFail($request->notification_id);

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 class NotificationController extends Controller
 {
@@ -24,5 +25,22 @@ class NotificationController extends Controller
         return response()->json([
             'result' => true,
         ]);
+    }
+
+    public function delete(Request $request)
+    {
+     try{
+        $notification = Notification::findOrFail($request->notification_id);
+        $notification->delete();
+
+        return response()->json([
+            'result' => true,
+        ]);
+     } catch (\Exception $e) {
+        return response()->json([
+            'result' => false,
+            'message' => 'Notification not found',
+        ]);
+     }
     }
 }

--- a/app/Http/Requests/Instructor/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Instructor/NotificationDeleteRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+          'notification_id' => ['required', 'integer'],
+        ];
+    }
+    protected function prepareForValidation()
+    {
+      $this->merge([
+        'notification_id' => $this->route('notification_id'),
+      ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,7 @@ Route::prefix('v1')->group(function () {
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
+        Route::delete('notification/{notification_id}','Api\Instructor\NotificationController@delete');
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::post('student', 'Api\Instructor\StudentController@store');
         Route::prefix('course')->group(function () {


### PR DESCRIPTION
## issue
- Close jka-419
## 概要
- お知らせ削除機能(講師側)/ロジック作成
## 動作確認手順
- app/Http/Requests/Instructor直下にNotificationDeleteRequest.phpファイルを作成
- ポストマンで　DELETE=>  localhost:8080/api/v1/instructor/notification/1  =>Send
- trueが返ってくるのを確認
- 削除されたままのid=1でもう一度ポストマンで送信後、falseが返ってくるのを確認
- Adminerで削除したidを復活(Null) させてもう一度ポストマンで送信後、trueが返ってくるのを確認

![お知らせ機能削除ポストマンtrue](https://github.com/yukihiroLaravel/juko_laravel/assets/121646428/7a2dca7d-984b-4243-a878-c29c4b283e86)
![お知らせ機能削除ポストマンfalse](https://github.com/yukihiroLaravel/juko_laravel/assets/121646428/b258f0a2-e640-4309-a4b9-ffedb5be0bea)

- ## 考慮してほしい事
- 以前作成した空配列のtopicブランチ(topic/jka-394/delete_notification)に対してfeatureのプルリクエストを申請しようとしたところfiles changedが29とおかしくなってしまった
- (topicに最新のdevelopをマージしたのが原因？以後気を付けたいと思います)
- そのため新しくtopicブランチを作り直して申請しました(feature/mitamura/jka-419/delete_notification_logic_2)申し訳ありません 
## 確認してほしい事
- 期限過ぎのプルリクエスト申請ですが、特別に許可をくださりましてありがとうございます。
