### PR TITLE
チャプター公開・非公開切り替え：空の配列を返すようにコントローラ＋ルーティング作成（講師側）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+
 
 class ChapterController extends Controller
 {
@@ -94,8 +96,9 @@ class ChapterController extends Controller
      *
      *
      */
-    {
-        public function updateStatus(Request $request)
+    
+     public function updateStatus(Request  $request)
+    { 
         {
             return response()->json([]);
         }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -88,7 +88,6 @@ class ChapterController extends Controller
         ]);
     }
 
-
     /**
      * チャプター更新API(公開・非公開切り替え)
      *
@@ -101,11 +100,6 @@ class ChapterController extends Controller
             return response()->json([]);
         }
     }
-
-
-
-
-
 
     /**
      * チャプター削除API

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -88,6 +88,25 @@ class ChapterController extends Controller
         ]);
     }
 
+
+    /**
+     * チャプター更新API(公開・非公開切り替え)
+     *
+     *
+     *
+     */
+    {
+        public function updateStatus(Request $request)
+        {
+            return response()->json([]);
+        }
+    }
+
+
+
+
+
+
     /**
      * チャプター削除API
      *

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -20,7 +20,6 @@ use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 
-
 class ChapterController extends Controller
 {
     /**
@@ -96,7 +95,6 @@ class ChapterController extends Controller
      *
      *
      */
-    
      public function updateStatus(Request  $request)
     { 
         {

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -91,11 +91,8 @@ class ChapterController extends Controller
 
     /**
      * チャプター更新API(公開・非公開切り替え)
-     *
-     *
-     *
      */
-     public function updateStatus(Request  $request)
+    public function updateStatus(Request  $request)
     { 
         {
             return response()->json([]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,6 +60,7 @@ Route::prefix('v1')->group(function () {
                     Route::prefix('{chapter_id}')->group(function () {
                         Route::get('/', 'Api\Instructor\ChapterController@show');
                         Route::patch('/', 'Api\Instructor\ChapterController@update');
+                        Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                         Route::delete('/', 'Api\Instructor\ChapterController@delete');
                         Route::prefix('lesson')->group(function () {
                             Route::post('/', 'Api\Instructor\LessonController@store');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-442

## 概要　
- 空の配列を返すようにコントローラ＋ルーティング作成（講師側）

## 動作確認手順
- PostmanにてPATCHメソッドでlocalhost:8080/api/v1/instructor/course/1/chapter/1/statusをSendし、[]がレスポンスされることを確認済みです。（初回動作確認していなく申し訳ありません。）

## 確認してほしいこと
- 初めての実務ということで講師に御教示頂きながら諸先輩のコードを見つつ作成しました。
　アドバイス等ありましたら宜しくお願いします。