### PR TITLE
Feature/seiichi/jka 419/delete notification 2

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -5,6 +5,8 @@ use App\Http\Requests\Instructor\NotificationStoreRequest;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Instructor\NotificationDeleteRequest;
+use Exception;
+
 
 class NotificationController extends Controller
 {
@@ -24,6 +26,11 @@ class NotificationController extends Controller
         ]);
     }
 
+    /**
+     * お知らせ通知の削除
+     *
+     * @return bool
+     */
     public function delete(NotificationDeleteRequest $request)
     {
      try{
@@ -33,7 +40,7 @@ class NotificationController extends Controller
         return response()->json([
             'result' => true,
         ]);
-     } catch (\Exception $e) {
+     } catch (Exception $e) {
         return response()->json([
             'result' => false,
             'message' => 'Notification not found',

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -101,8 +101,8 @@ class NotificationController extends Controller
     public function delete(NotificationDeleteRequest $request)
     {
         try {
-            $notification = Notification::findOrFail($request->notification_id);
-            $notification->delete();
+            Notification::findOrFail($request->notification_id)
+            ->delete();
 
             return response()->json([
                 'result' => true,
@@ -111,7 +111,7 @@ class NotificationController extends Controller
             return response()->json([
                 'result' => false,
                 'message' => 'Notification not found',
-            ], 404); // 404 エラーコードを返す
+            ], 500); // 500 エラーコードを返す
         }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -1,13 +1,57 @@
 <?php
+
 namespace App\Http\Controllers\Api\Instructor;
+
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\NotificationIndexRequest;
+use App\Http\Resources\Instructor\NotificationIndexResource;
+use App\Http\Requests\Instructor\NotificationShowRequest;
+use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
-use App\Model\Notification;
-use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\Instructor\NotificationUpdateRequest;
+use App\Http\Resources\Instructor\NotificationUpdateResource;
 use App\Http\Requests\Instructor\NotificationDeleteRequest;
+use App\Model\Notification;
 
 class NotificationController extends Controller
 {
+   /**
+    * 講師側お知らせ一覧取得API
+    *
+    * @param NotificationIndexRequest $request
+    * @return NotificationIndexResource
+    */
+   public function index(NotificationIndexRequest $request)
+   {
+       $perPage = $request->input('per_page', 20);
+       $page = $request->input('page', 1);
+
+       $notifications = Notification::with(['course'])
+                                       ->where('instructor_id', 1) //講師IDは仮で1を指定
+                                       ->paginate($perPage, ['*'], 'page', $page);
+
+       return new NotificationIndexResource($notifications);
+   }
+
+   /**
+    * お知らせ詳細
+    *
+    * @param NotificationShowRequest $request
+    * @return NotificationShowResource
+    */
+   public function show(NotificationShowRequest $request)
+   {
+       $notification = Notification::findOrFail($request->notification_id);
+
+       return new NotificationShowResource($notification);
+   }
+
+   /**
+    * お知らせ登録
+    *
+    * @param NotificationStoreRequest $request
+    * @return \Illuminate\Http\JsonResponse
+    */
     public function store(NotificationStoreRequest $request)
     {
         Notification::create([
@@ -19,25 +63,49 @@ class NotificationController extends Controller
             'end_date'      => $request->end_date,
             'content'       => $request->content,
         ]);
+
         return response()->json([
             'result' => true,
         ]);
     }
 
-    public function delete(NotificationDeleteRequest $request)
-    {
-     try{
+    /**
+     * お知らせ更新API
+     *
+     * @param   NotificationUpdateRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(NotificationUpdateRequest $request) {
         $notification = Notification::findOrFail($request->notification_id);
-        $notification->delete();
+        $notification->fill([
+            'type'  => $request->type,
+            'start_date' => $request->start_date,
+            'end_date' => $request->end_date,
+            'title' => $request->title,
+            'content' => $request->content,
+        ])
+        ->save();
 
         return response()->json([
             'result' => true,
+            'data' => new NotificationUpdateResource($notification),
         ]);
-     } catch (\Exception $e) {
-        return response()->json([
-            'result' => false,
-            'message' => 'Notification not found',
-        ]);
-     }
+    }
+
+    public function delete(NotificationDeleteRequest $request)
+    {
+        try{
+            $notification = Notification::findOrFail($request->notification_id);
+            $notification->delete();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Notification not found',
+            ]);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace App\Http\Controllers\Api\Instructor;
+
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
 use Illuminate\Support\Facades\Auth;
@@ -11,86 +13,84 @@ use Exception;
 
 class NotificationController extends Controller
 {
-   /**
-    * 講師側お知らせ一覧取得API
-    *
-    * @param NotificationIndexRequest $request
-    * @return NotificationIndexResource
-    */
-   public function index(NotificationIndexRequest $request)
-   {
-       $perPage = $request->input('per_page', 20);
-       $page = $request->input('page', 1);
+    /**
+     * 講師側お知らせ一覧取得API
+     *
+     * @param NotificationIndexRequest $request
+     * @return NotificationIndexResource
+     */
+    public function index(NotificationIndexRequest $request)
+    {
+        $perPage = $request->input('per_page', 20);
+        $page = $request->input('page', 1);
 
-       $notifications = Notification::with(['course'])
-                                       ->where('instructor_id', 1) //講師IDは仮で1を指定
-                                       ->paginate($perPage, ['*'], 'page', $page);
+        $notifications = Notification::with(['course'])
+            ->where('instructor_id', 1) // 講師IDは仮で1を指定
+            ->paginate($perPage, ['*'], 'page', $page);
 
-       return new NotificationIndexResource($notifications);
-   }
+        return new NotificationIndexResource($notifications);
+    }
 
-   /**
-    * お知らせ詳細
-    *
-    * @param NotificationShowRequest $request
-    * @return NotificationShowResource
-    */
-   public function show(NotificationShowRequest $request)
-   {
-       $notification = Notification::findOrFail($request->notification_id);
+    /**
+     * お知らせ詳細
+     *
+     * @param NotificationShowRequest $request
+     * @return NotificationShowResource
+     */
+    public function show(NotificationShowRequest $request)
+    {
+        try {
+            $notification = Notification::findOrFail($request->notification_id);
 
-       return new NotificationShowResource($notification);
-   }
+            return new NotificationShowResource($notification);
+        } catch (Exception $e) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Notification not found',
+            ], 404); // 404 エラーコードを返す
+        }
+    }
 
-   /**
-    * お知らせ登録
-    *
-    * @param NotificationStoreRequest $request
-    * @return \Illuminate\Http\JsonResponse
-    */
+    /**
+     * お知らせ登録
+     *
+     * @param NotificationStoreRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function store(NotificationStoreRequest $request)
     {
         Notification::create([
-            'course_id'     => $request->course_id,
+            'course_id' => $request->course_id,
             'instructor_id' => 1,
-            'title'         => $request->title,
-            'type'          => $request->type,
-            'start_date'    => $request->start_date,
-            'end_date'      => $request->end_date,
-            'content'       => $request->content,
+            'title' => $request->title,
+            'type' => $request->type,
+            'start_date' => $request->start_date,
+            'end_date' => $request->end_date,
+            'content' => $request->content,
         ]);
+        
         return response()->json([
             'result' => true,
         ]);
     }
 
-     /**
+    /**
      * お知らせ更新API
      *
      * @param   NotificationUpdateRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function update(NotificationUpdateRequest $request) {
-        $notification->fill([
-            'type'  => $request->type,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-            'title' => $request->title,
-            'content' => $request->content,
-        ])
-        ->save();
-
-    /**
-     * お知らせ通知削除API
-     * 
-     * @param NotificationDeleteRequest $request
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function delete(NotificationDeleteRequest $request)
+    public function update(NotificationUpdateRequest $request)
     {
-        try{
+        try {
             $notification = Notification::findOrFail($request->notification_id);
-            $notification->delete();
+            $notification->fill([
+                'type' => $request->type,
+                'start_date' => $request->start_date,
+                'end_date' => $request->end_date,
+                'title' => $request->title,
+                'content' => $request->content,
+            ])->save();
 
             return response()->json([
                 'result' => true,
@@ -100,8 +100,30 @@ class NotificationController extends Controller
             return response()->json([
                 'result' => false,
                 'message' => 'Notification not found',
-            ]);
+            ], 404); // 404 エラーコードを返す
         }
     }
+
+    /**
+     * お知らせ通知削除API
+     * 
+     * @param NotificationDeleteRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function delete(NotificationDeleteRequest $request)
+    {
+        try {
+            $notification = Notification::findOrFail($request->notification_id);
+            $notification->delete();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Notification not found',
+            ], 404); // 404 エラーコードを返す
+        }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -1,57 +1,13 @@
 <?php
-
 namespace App\Http\Controllers\Api\Instructor;
-
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\NotificationIndexRequest;
-use App\Http\Resources\Instructor\NotificationIndexResource;
-use App\Http\Requests\Instructor\NotificationShowRequest;
-use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
-use App\Http\Requests\Instructor\NotificationUpdateRequest;
-use App\Http\Resources\Instructor\NotificationUpdateResource;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\Instructor\NotificationDeleteRequest;
 
 class NotificationController extends Controller
 {
-    /**
-     * 講師側お知らせ一覧取得API
-     *
-     * @param NotificationIndexRequest $request
-     * @return NotificationIndexResource
-     */
-    public function index(NotificationIndexRequest $request)
-    {
-        $perPage = $request->input('per_page', 20);
-        $page = $request->input('page', 1);
-
-        $notifications = Notification::with(['course'])
-                                        ->where('instructor_id', 1) //講師IDは仮で1を指定
-                                        ->paginate($perPage, ['*'], 'page', $page);
-
-        return new NotificationIndexResource($notifications);
-    }
-
-    /**
-     * お知らせ詳細
-     *
-     * @param NotificationShowRequest $request
-     * @return NotificationShowResource
-     */
-    public function show(NotificationShowRequest $request)
-    {
-        $notification = Notification::findOrFail($request->notification_id);
-
-        return new NotificationShowResource($notification);
-    }
-
-    /**
-     * お知らせ登録
-     *
-     * @param NotificationStoreRequest $request
-     * @return \Illuminate\Http\JsonResponse
-     */
     public function store(NotificationStoreRequest $request)
     {
         Notification::create([
@@ -63,32 +19,25 @@ class NotificationController extends Controller
             'end_date'      => $request->end_date,
             'content'       => $request->content,
         ]);
-
         return response()->json([
             'result' => true,
         ]);
     }
 
-    /**
-     * お知らせ更新API
-     *
-     * @param   NotificationUpdateRequest $request
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function update(NotificationUpdateRequest $request) {
+    public function delete(NotificationDeleteRequest $request)
+    {
+     try{
         $notification = Notification::findOrFail($request->notification_id);
-        $notification->fill([
-            'type'  => $request->type,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-            'title' => $request->title,
-            'content' => $request->content,
-        ])
-        ->save();
+        $notification->delete();
 
         return response()->json([
             'result' => true,
-            'data' => new NotificationUpdateResource($notification),
         ]);
+     } catch (\Exception $e) {
+        return response()->json([
+            'result' => false,
+            'message' => 'Notification not found',
+        ]);
+     }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -3,13 +3,15 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\NotificationDeleteRequest;
+use App\Http\Requests\Instructor\NotificationIndexRequest;
+use App\Http\Resources\Instructor\NotificationIndexResource;
+use App\Http\Requests\Instructor\NotificationShowRequest;
+use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
-use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationUpdateResource;
-use App\Http\Requests\Instructor\NotificationDeleteRequest;
 use App\Model\Notification;
-use Exception;
 
 class NotificationController extends Controller
 {
@@ -25,8 +27,8 @@ class NotificationController extends Controller
         $page = $request->input('page', 1);
 
         $notifications = Notification::with(['course'])
-            ->where('instructor_id', 1) // 講師IDは仮で1を指定
-            ->paginate($perPage, ['*'], 'page', $page);
+                                        ->where('instructor_id', 1) //講師IDは仮で1を指定
+                                        ->paginate($perPage, ['*'], 'page', $page);
 
         return new NotificationIndexResource($notifications);
     }
@@ -39,16 +41,9 @@ class NotificationController extends Controller
      */
     public function show(NotificationShowRequest $request)
     {
-        try {
-            $notification = Notification::findOrFail($request->notification_id);
+        $notification = Notification::findOrFail($request->notification_id);
 
-            return new NotificationShowResource($notification);
-        } catch (Exception $e) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Notification not found',
-            ], 404); // 404 エラーコードを返す
-        }
+        return new NotificationShowResource($notification);
     }
 
     /**
@@ -60,15 +55,15 @@ class NotificationController extends Controller
     public function store(NotificationStoreRequest $request)
     {
         Notification::create([
-            'course_id' => $request->course_id,
+            'course_id'     => $request->course_id,
             'instructor_id' => 1,
-            'title' => $request->title,
-            'type' => $request->type,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-            'content' => $request->content,
+            'title'         => $request->title,
+            'type'          => $request->type,
+            'start_date'    => $request->start_date,
+            'end_date'      => $request->end_date,
+            'content'       => $request->content,
         ]);
-        
+
         return response()->json([
             'result' => true,
         ]);
@@ -80,33 +75,26 @@ class NotificationController extends Controller
      * @param   NotificationUpdateRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function update(NotificationUpdateRequest $request)
-    {
-        try {
-            $notification = Notification::findOrFail($request->notification_id);
-            $notification->fill([
-                'type' => $request->type,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'title' => $request->title,
-                'content' => $request->content,
-            ])->save();
+    public function update(NotificationUpdateRequest $request) {
+        $notification = Notification::findOrFail($request->notification_id);
+        $notification->fill([
+            'type'  => $request->type,
+            'start_date' => $request->start_date,
+            'end_date' => $request->end_date,
+            'title' => $request->title,
+            'content' => $request->content,
+        ])
+        ->save();
 
-            return response()->json([
-                'result' => true,
-                'data' => new NotificationUpdateResource($notification),
-            ]);
-        } catch (Exception $e) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Notification not found',
-            ], 404); // 404 エラーコードを返す
-        }
+        return response()->json([
+            'result' => true,
+            'data' => new NotificationUpdateResource($notification),
+        ]);
     }
 
     /**
      * お知らせ通知削除API
-     * 
+     *
      * @param NotificationDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse
      */

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -64,26 +64,44 @@ class NotificationController extends Controller
         ]);
     }
 
+     /**
+     * お知らせ更新API
+     *
+     * @param   NotificationUpdateRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(NotificationUpdateRequest $request) {
+        $notification->fill([
+            'type'  => $request->type,
+            'start_date' => $request->start_date,
+            'end_date' => $request->end_date,
+            'title' => $request->title,
+            'content' => $request->content,
+        ])
+        ->save();
+
     /**
-     * お知らせ通知の削除
+     * お知らせ通知削除API
      * 
      * @param NotificationDeleteRequest $request
-     * @return bool
+     * @return \Illuminate\Http\JsonResponse
      */
     public function delete(NotificationDeleteRequest $request)
     {
-     try{
-        $notification = Notification::findOrFail($request->notification_id);
-        $notification->delete();
+        try{
+            $notification = Notification::findOrFail($request->notification_id);
+            $notification->delete();
 
-        return response()->json([
-            'result' => true,
-        ]);
-    } catch (Exception $e) {
-        return response()->json([
-            'result' => false,
-            'message' => 'Notification not found',
-        ]);
-     }
+            return response()->json([
+                'result' => true,
+                'data' => new NotificationUpdateResource($notification),
+            ]);
+        } catch (Exception $e) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Notification not found',
+            ]);
+        }
+    }
     }
 }

--- a/app/Http/Requests/Instructor/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Instructor/NotificationDeleteRequest.php
@@ -22,14 +22,14 @@ class NotificationDeleteRequest extends FormRequest
     public function rules()
     {
         return [
-          'notification_id' => ['required', 'integer'],
+            'notification_id' => ['required', 'integer'],
         ];
     }
 
     protected function prepareForValidation()
     {
         $this->merge([
-          'notification_id' => $this->route('notification_id'),
+            'notification_id' => $this->route('notification_id'),
         ]);
     }
 }

--- a/app/Http/Requests/Instructor/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Instructor/NotificationDeleteRequest.php
@@ -25,10 +25,11 @@ class NotificationDeleteRequest extends FormRequest
           'notification_id' => ['required', 'integer'],
         ];
     }
+
     protected function prepareForValidation()
     {
-      $this->merge([
-        'notification_id' => $this->route('notification_id'),
-      ]);
+        $this->merge([
+          'notification_id' => $this->route('notification_id'),
+        ]);
     }
 }

--- a/app/Http/Requests/Instructor/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Instructor/NotificationDeleteRequest.php
@@ -1,0 +1,34 @@
+<?php
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+          'notification_id' => ['required', 'integer'],
+        ];
+    }
+    protected function prepareForValidation()
+    {
+      $this->merge([
+        'notification_id' => $this->route('notification_id'),
+      ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,7 +38,6 @@ Route::prefix('v1')->group(function () {
         Route::get('student/{student_id}', 'Api\Instructor\StudentController@show');
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
-            Route::delete('notification/{notification_id}','Api\Instructor\NotificationController@delete');
         });
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::patch('notification/{notification_id}', 'Api\Instructor\NotificationController@update');
@@ -47,6 +46,7 @@ Route::prefix('v1')->group(function () {
             Route::get('index', 'Api\Instructor\NotificationController@index');
             Route::prefix('{notification_id}')->group(function () {
                 Route::get('/', 'Api\Instructor\NotificationController@show');
+                Route::delete('/','Api\Instructor\NotificationController@delete');
             });
         });
         Route::prefix('course')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,7 @@ Route::prefix('v1')->group(function () {
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
+        Route::delete('notification/{notification_id}','Api\Instructor\NotificationController@delete');
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::patch('notification/{notification_id}', 'Api\Instructor\NotificationController@update');
         Route::post('student', 'Api\Instructor\StudentController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ Route::prefix('v1')->group(function () {
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
+        Route::delete('notification/{notification_id}','Api\Instructor\NotificationController@delete');
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::patch('notification/{notification_id}', 'Api\Instructor\NotificationController@update');
         Route::post('student', 'Api\Instructor\StudentController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,8 +38,8 @@ Route::prefix('v1')->group(function () {
         Route::get('student/{student_id}', 'Api\Instructor\StudentController@show');
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
+            Route::delete('notification/{notification_id}','Api\Instructor\NotificationController@delete');
         });
-        Route::delete('notification/{notification_id}','Api\Instructor\NotificationController@delete');
         Route::patch('/', 'Api\Instructor\InstructorController@update');
         Route::patch('notification/{notification_id}', 'Api\Instructor\NotificationController@update');
         Route::post('student', 'Api\Instructor\StudentController@store');


### PR DESCRIPTION
## issue
- Closes JKA-419

## 概要
- お知らせ削除機能(講師側)/ ロジック修正

## 動作確認手順
- ポストマンで　DELETE=> localhost:8080/api/v1/instructor/notification/1 =>Send
- true が返ってくるのを確認

## 考慮して欲しい事
- base指定ブランチ「topic/jka-394/delete_notification_2」にしています。
- 以下、三田村氏最後のプルリクより転載（引継ぎタスクの為）
- 以前作成した空配列のtopicブランチ(topic/jka-394/delete_notification)に対してfeatureのプルリクエストを申請しようとしたところfiles changedが29とおかしくなってしまった
(topicに最新のdevelopをマージしたのが原因？以後気を付けたいと思います)
- そのため新しくtopicブランチを作り直して申請しました(feature/mitamura/jka-419/delete_notification_logic_2)
