### PR TITLE
フォームリクエスト(Requestバリデーション)を実装(DAIKI)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -8,6 +8,7 @@ use App\Model\Lesson;
 use Illuminate\Support\Carbon;
 use App\Model\LessonAttendance;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\LoginRateRequest;
 use App\Http\Requests\Instructor\AttendanceStoreRequest;
 use App\Http\Requests\Instructor\AttendanceShowRequest;
 use App\Http\Resources\Instructor\AttendanceShowResource;
@@ -95,18 +96,18 @@ class AttendanceController extends Controller
      * @param string $period
      * @return \Illuminate\Http\JsonResponse
      */ 
-    public function loginRate($courseId, $period) {
+    public function loginRate(LoginRateRequest $request) {
         $endDate = new Carbon();
 
-        if ($period === "week") {
+        if ($request->period === "week") {
             $periodAgo = $endDate->subWeek(1);
-        } elseif ($period === "month") {
+        } elseif ($request->period === "month") {
             $periodAgo = $endDate->subMonth(1);
-        } elseif ($period === "year") {
+        } elseif ($request->period === "year") {
             $periodAgo = $endDate->subYear(1);
         } 
 
-        $attendances = Attendance::with('student')->where('course_id', $courseId)->get();
+        $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
         $studentsCount = $attendances->count();
 
         // 期間内にログインした受講生数

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -99,11 +99,11 @@ class AttendanceController extends Controller
     public function loginRate(LoginRateRequest $request) {
         $endDate = new Carbon();
 
-        if ($request->period === "week") {
+        if ($request->period === Attendance::PERIOD_WEEK) {
             $periodAgo = $endDate->subWeek(1);
-        } elseif ($request->period === "month") {
+        } elseif ($request->period === Attendance::PERIOD_MONTH) {
             $periodAgo = $endDate->subMonth(1);
-        } elseif ($request->period === "year") {
+        } elseif ($request->period === Attendance::PERIOD_YEAR) {
             $periodAgo = $endDate->subYear(1);
         } 
 

--- a/app/Http/Requests/Instructor/LoginRateRequest.php
+++ b/app/Http/Requests/Instructor/LoginRateRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use App\Rules\AttendancePeriodRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $validate = [];
+
+        $validate += [
+            'course_id' => [
+                'exists:attendances,course_id','required','integer'
+            ],
+            'period' => ['required', 'string', new AttendancePeriodRule],
+        ];
+
+        return $validate;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'period' => $this->route('period'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/LoginRateRequest.php
+++ b/app/Http/Requests/Instructor/LoginRateRequest.php
@@ -24,16 +24,10 @@ class LoginRateRequest extends FormRequest
      */
     public function rules()
     {
-        $validate = [];
-
-        $validate += [
-            'course_id' => [
-                'exists:attendances,course_id','required','integer'
-            ],
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id'],
             'period' => ['required', 'string', new AttendancePeriodRule],
         ];
-
-        return $validate;
     }
 
     protected function prepareForValidation()

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -54,4 +54,9 @@ class Attendance extends Model
     {
         return $this->hasMany(LessonAttendance::class);
     }
+
+    //$periodのバリデーションに利用する定数
+    const PERIOD_WEEK = 'week';
+    const PERIOD_MONTH = 'month';
+    const PERIOD_YEAR = 'year';
 }

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Model\Attendance;
+
+class AttendancePeriodRule implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (
+            in_array(
+                $value,
+                [
+                Attendance::PERIOD_WEEK,
+                Attendance::PERIOD_MONTH,
+                Attendance::PERIOD_YEAR,
+                ],
+                true
+            )
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'Invalid Period.';
+    }
+}


### PR DESCRIPTION
・バリデーションのためにLoginRateRequestクラスを作成し、そこでルートパラメータから値を取得できるように実装。
・LoginRateRequestで受け取ったcourse_idがattendancesテーブル内にあるidしか受け付けないように実装。
・バリデーションルールを詳細に記述するためにAttendancePeriodRuleクラスを作成。
・AttendancePeriodRuleクラス内でパラメータで受け取ったperiodの値を特定の三つの文字以外受け付けないように実装。
・AttendancePeriodRuleクラス内で利用するためにAttendanceモデル内に期間を示す文字列を定数として記述。
・LoginRateメソッド内でバリデーション後の値を受け取れるように実装。
・LoginRateRequestクラスで内でperiodに対するバリデーションにAttendancePeriodRuleクラスに記述したルールが適用となるようにインスタンス化して実装。

















































