### PR TITLE
チャプターすべて公開/すべて非公開にする機能【チャプター作成画面】※講師側 / 空の配列を返すようにコントローラ＋ルーティング作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
 
 class ChapterController extends Controller
 {
@@ -105,10 +106,10 @@ class ChapterController extends Controller
 
     /**
      * チャプター並び替えAPI
-     * 
+     *
      * @param ChapterSortRequest $request
      * @return \Illuminate\Http\JsonResponse
-     * 
+     *
      */
     public function sort(ChapterSortRequest $request)
     {
@@ -149,5 +150,10 @@ class ChapterController extends Controller
                 'result' => false,
             ], 500);
         }
+    }
+
+    public function putStatus(Request $request)
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -65,7 +65,7 @@ class CourseController extends Controller
         $extension = $file->getClientOriginalExtension();
         $filename = date('YmdHis') . '.' . $extension;
         $filePath = Storage::putFileAs('course', $file, $filename);
-    
+
         $course = Course::create([
             'instructor_id' => $instructorId,
             'title' => $request->title,
@@ -74,7 +74,7 @@ class CourseController extends Controller
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ]);
-    
+
         return response()->json([
             "result" => true,
             "data" => new CourseStoreResource($course),
@@ -167,5 +167,10 @@ class CourseController extends Controller
                 "message" => "Lecturer (cannot be deleted because the creator does not match)"
             ]);
         }
+    }
+
+    public function put(Request $request)
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -168,9 +168,4 @@ class CourseController extends Controller
             ]);
         }
     }
-
-    public function putStatus(Request $request)
-    {
-        return response()->json([]);
-    }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -169,7 +169,7 @@ class CourseController extends Controller
         }
     }
 
-    public function put(Request $request)
+    public function putStatus(Request $request)
     {
         return response()->json([]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,7 +57,7 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
-                Route::put('put', 'Api\Instructor\CourseController@put');
+                Route::put('status', 'Api\Instructor\CourseController@putStatus');
                 Route::prefix('notification')->group(function () {
                     Route::post('/', 'Api\Instructor\NotificationController@store');
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,6 +57,7 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
+                Route::put('put', 'Api\Instructor\CourseController@put');
                 Route::prefix('notification')->group(function () {
                     Route::post('/', 'Api\Instructor\NotificationController@store');
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,7 +57,6 @@ Route::prefix('v1')->group(function () {
                 Route::get('edit', 'Api\Instructor\CourseController@edit');
                 Route::post('/', 'Api\Instructor\CourseController@update');
                 Route::delete('/', 'Api\Instructor\CourseController@delete');
-                Route::put('status', 'Api\Instructor\CourseController@putStatus');
                 Route::prefix('notification')->group(function () {
                     Route::post('/', 'Api\Instructor\NotificationController@store');
                 });
@@ -67,6 +66,7 @@ Route::prefix('v1')->group(function () {
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');
+                    Route::put('status', 'Api\Instructor\ChapterController@putStatus');
                     Route::prefix('{chapter_id}')->group(function () {
                         Route::get('/', 'Api\Instructor\ChapterController@show');
                         Route::patch('/', 'Api\Instructor\ChapterController@update');


### PR DESCRIPTION
## issue
* https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-479
## 概要
* 空の配列を返すようにコントローラ＋ルーティング作成
## 動作確認手順
* Postmanにて、
メソッド：PUT、URL：localhost:8080/api/v1/instructor/course/1/chapter/status でSendし、
空の配列がレスポンスされることを確認しました。
## 考慮して欲しいこと
* 無し
## 確認してほしいこと
* ルーティングの階層とメソッド・ルーティング名が適切かをご確認お願いいたします。