### PR TITLE
最終ログイン日時を表示して、登録日をyyyy/mm/ddの記法に変更　topicからdevelop

### DIFF
--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -40,6 +40,7 @@ class StudentIndexResource extends JsonResource
                 'nick_name' => $attendance->student->nick_name,
                 'email' => $attendance->student->email,
                 'course_title' => $attendance->course->title,
+                'last_login_at' => $attendance->student->last_login_at->format('Y/m/d  H:i:s'),
                 'attendanced_at' => $attendance->created_at->format('Y/m/d'),
             ];
         });

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -35,7 +35,7 @@ class Student extends Authenticatable
      */
     protected $casts = [
         'birth_date' => 'date',
-        'last_login_at' => 'date',
+        'last_login_at' => 'datetime',
     ];
 
     // 性別定数


### PR DESCRIPTION
# issue
- https://gut-familie.atlassian.net/browse/JKA-485

# 動作確認
- 生徒人数を増やして、localhost:8080/api/v1/instructor/course/1/student/indexをsendして最終ログイン日時が帰ってくることを確認しました。

# 確認して欲しいこと
- こちらのタスクが完了しましたらtopicからdevelopへプルリクを作成してよろしいでしょうか。

# 疑問点
- 添付させていただいたスクショの緑のラインを引いた箇所が具体的にどこの何を表すのか分からないので教えていただきたいです。$Perpageは１ページあたりのデータ表示数を20にして、$pageは現在の表示するページを１ページ目にしていると考えています。
<img width="1470" alt="スクリーンショット 2023-10-05 13 18 50" src="https://github.com/yukihiroLaravel/juko_laravel/assets/139059560/eea0cfb5-61a2-4872-be56-b45a2ad79d6c">
