### PR TITLE
チャプターすべて公開/すべて非公開にする機能【チャプター作成画面】※講師側 / DBへのロジック作成（チャプターテーブルのステータスの一括更新）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -154,6 +154,13 @@ class ChapterController extends Controller
 
     public function putStatus(Request $request)
     {
-        return response()->json([]);
+        Chapter::where('course_id', $request->route('course_id'))
+            ->update([
+                'status' => $request->status
+            ]);
+
+        return response()->json([
+            'result' => 'true'
+        ]);
     }
 }


### PR DESCRIPTION
## issue
* https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-487
## 概要
* DBへのロジック作成（チャプターテーブルのステータスの一括更新）
## 動作確認手順
* Postmanにて`localhost:8080/api/v1/instructor/course/1/chapter/status`でSendする。
対象のcourse_idを持つchaptersテーブルのレコードのstatusカラムがボディリクエストのstatusの値に更新されていることを確認。
## 考慮して欲しいこと
* 別タスクによりchaptersテーブルにstatusカラムが追加されているので必要に応じて`php artisan migrate:refresh --seed`を実行してください。
## 確認してほしいこと
* Eloquentの実装が適切かご確認いただけますと幸いです。