### PR TITLE
不具合修正：ChapterController@show のresult応答を削除

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -59,12 +59,10 @@ class ChapterController extends Controller
         if ((int) $request->course_id !== $chapter->course->id) {
             return response()->json([
                 'message' => 'invalid course_id.',
-            ], 500);
+            ], 403);
         }
 
-        return response()->json([
-            'data' => new ChapterShowResource($chapter)
-        ]);
+        return new ChapterShowResource($chapter);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -58,13 +58,11 @@ class ChapterController extends Controller
         $chapter = Chapter::with('lessons')->findOrFail($request->chapter_id);
         if ((int) $request->course_id !== $chapter->course->id) {
             return response()->json([
-                'result' => false,
                 'message' => 'invalid course_id.',
             ], 500);
         }
 
         return response()->json([
-            'result' => true,
             'data' => new ChapterShowResource($chapter)
         ]);
     }


### PR DESCRIPTION
### 概要
「レッスン表示のresultを削除する【レッスン編集画面】※講師側」を完了しました。

### 動作確認手順
- postmanで`localhost:8080/api/v1/instructor/course/1/chapter/2`にアクセスして応答を確認

### 考慮して欲しいこと
特にありません

### 確認してほしいこと
特にありません