### PR TITLE
Feature/kimura/jka 475/update

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -176,11 +176,11 @@ class ChapterController extends Controller
                 ],
             ]);
         } catch (Exception $e) {
-            Log::error($e); //エラーをログに出力
+            Log::error($e);
             // エラー時のレスポンス
             return response()->json([
                 'result' => false,
-            ], 500); // HTTPステータスコード 500: Internal Server Error
+            ], 500);
         }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -5,12 +5,14 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Model\Instructor;
 use App\Model\Course;
 use App\Model\Chapter;
+use App\Model\Lesson;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
 use App\Http\Requests\Instructor\ChapterStoreRequest;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
 use App\Http\Requests\Instructor\ChapterSortRequest;
 use App\Http\Requests\Instructor\ChapterShowRequest;
+use App\Http\Requests\Instructor\LessonTitlePatchRequest;
 use App\Http\Resources\Instructor\ChapterStoreResource;
 use App\Http\Resources\Instructor\ChapterPatchResource;
 use App\Http\Resources\Instructor\ChapterShowResource;
@@ -105,10 +107,10 @@ class ChapterController extends Controller
 
     /**
      * チャプター並び替えAPI
-     * 
+     *
      * @param ChapterSortRequest $request
      * @return \Illuminate\Http\JsonResponse
-     * 
+     *
      */
     public function sort(ChapterSortRequest $request)
     {
@@ -148,6 +150,40 @@ class ChapterController extends Controller
             return response()->json([
                 'result' => false,
             ], 500);
+        }
+    }
+
+    /**
+     * レッスン名更新API
+     *
+     * @param LessonTitlePatchRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function updateLessonTitle(LessonTitlePatchRequest $request)
+    {
+        try {
+            // リクエストから lesson_id と title を取得
+            $lessonId = $request->input('lesson_id');
+            $newTitle = $request->input('title');
+            // lesson_id に対応するLessonモデルを取得
+            $lesson = Lesson::findOrFail($lessonId);
+            // Lessonのタイトルを更新
+            $lesson->update([
+                'title' => $newTitle
+            ]);
+            // 成功時のレスポンス
+            return response()->json([
+                'result' => true,
+                'data' => [
+                    'lesson_id' => $lesson->id,
+                    'title' => $lesson->title,
+                ],
+            ]);
+        } catch (Exception $e) {
+            // エラー時のレスポンス
+            return response()->json([
+                'result' => false,
+            ], 500); // HTTPステータスコード 500: Internal Server Error
         }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -154,7 +154,7 @@ class ChapterController extends Controller
     }
 
     /**
-     * レッスン名更新API
+     * レッスンタイトル更新API
      *
      * @param LessonTitlePatchRequest $request
      * @return \Illuminate\Http\JsonResponse
@@ -162,14 +162,10 @@ class ChapterController extends Controller
     public function updateLessonTitle(LessonTitlePatchRequest $request)
     {
         try {
-            // リクエストから lesson_id と title を取得
-            $lessonId = $request->input('lesson_id');
-            $newTitle = $request->input('title');
-            // lesson_id に対応するLessonモデルを取得
-            $lesson = Lesson::findOrFail($lessonId);
             // Lessonのタイトルを更新
+            $lesson = Lesson::findOrFail($request->input('lesson_id'));
             $lesson->update([
-                'title' => $newTitle
+                'title' => $request->input('title')
             ]);
             // 成功時のレスポンス
             return response()->json([
@@ -180,6 +176,7 @@ class ChapterController extends Controller
                 ],
             ]);
         } catch (Exception $e) {
+            Log::error($e); //エラーをログに出力
             // エラー時のレスポンス
             return response()->json([
                 'result' => false,

--- a/app/Http/Requests/Instructor/LessonTitlePatchRequest.php
+++ b/app/Http/Requests/Instructor/LessonTitlePatchRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonTitlePatchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+            'lesson_id' => $this->route('lesson_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer'],
+            'chapter_id' => ['required', 'integer'],
+            'lesson_id' => ['required', 'integer'],
+            'title' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/LessonTitlePatchRequest.php
+++ b/app/Http/Requests/Instructor/LessonTitlePatchRequest.php
@@ -33,10 +33,10 @@ class LessonTitlePatchRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer'],
-            'chapter_id' => ['required', 'integer'],
-            'lesson_id' => ['required', 'integer'],
-            'title' => ['required', 'string'],
+            'course_id' => ['required', 'integer', 'exists:courses,id'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id'],
+            'lesson_id' => ['required', 'integer', 'exists:lessons,id'],
+            'title' => ['required', 'string', 'max:50'],
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,6 +68,7 @@ Route::prefix('v1')->group(function () {
                             Route::prefix('{lesson_id}')->group(function () {
                                 Route::delete('/', 'Api\Instructor\LessonController@delete');
                                 Route::patch('/', 'Api\Instructor\LessonController@update');
+                                Route::patch('title', 'Api\Instructor\ChapterController@updateLessonTitle');
                             });
                         });
                     });


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-475

##動作確認
Postmanにて下記を実施
メソッド：PATCH
URL：localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1/title?lesson_id=1&title=echo1
Params：
☑ lesson_id -> 1
☑ title -> echo1

response
```
{
    "result": true,
    "data": {
        "lesson_id": 1,
        "title": "echo1"
    }
}
```
Adminerの方でも指定したtitleが変更されるのを確認しております。

##確認してほしいこと
① Postmanでの動作確認の際、URLに直接{lesson_id}や{chapter_id}、{course_id}を数値で記載しているがそのやり方で問題ないか
 /course/1/chapter/1/lesson/1/
 