### PR TITLE
認証者の認可ミドルウェアの実装

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,6 +64,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'student' => \App\Http\Middleware\EnsureIsStudent::class,
         'instructor' => \App\Http\Middleware\EnsureIsInstructor::class,
     ];
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,6 +64,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'instructor' => \App\Http\Middleware\EnsureIsInstructor::class,
     ];
 
     /**

--- a/app/Http/Middleware/EnsureIsInstructor.php
+++ b/app/Http/Middleware/EnsureIsInstructor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class EnsureIsInstructor
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (Auth::guard('instructor')->check() === false) {
+            return new JsonResponse([
+                'message' => 'Unauthorized'
+            ], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureIsStudent.php
+++ b/app/Http/Middleware/EnsureIsStudent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class EnsureIsStudent
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (Auth::check() === false || Auth::guard('instructor')->check()) {
+            return new JsonResponse([
+                'message' => 'Unauthorized'
+            ], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,6 +32,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::patch('/', 'Api\Student\StudentController@update');
     });
     Route::get('notification', 'Api\NotificationController@index');
+
+    Route::middleware('instructor')->group(function () {
+        // TODO 講師側APIはここに記述
+    });
 });
 
 Route::prefix('v1')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,17 +19,20 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     // 受講生側API
-    Route::prefix('course')->group(function () {
-        Route::get('index', 'Api\CourseController@index');
-        Route::get('/', 'Api\CourseController@show');
-        Route::get('{course_id}/progress', 'Api\CourseController@progress');
-        Route::prefix('chapter')->group(function () {
-            Route::get('/', 'Api\ChapterController@show');
+    Route::middleware('student')->group(function () {
+        Route::prefix('course')->group(function () {
+            Route::get('index', 'Api\CourseController@index');
+            Route::get('/', 'Api\CourseController@show');
+            Route::get('{course_id}/progress', 'Api\CourseController@progress');
+            Route::prefix('chapter')->group(function () {
+                Route::get('/', 'Api\ChapterController@show');
+            });
         });
-    });
-    Route::prefix('student')->group(function () {
-        Route::get('edit', 'Api\Student\StudentController@edit');
-        Route::patch('/', 'Api\Student\StudentController@update');
+        Route::prefix('student')->group(function () {
+            Route::get('edit', 'Api\Student\StudentController@edit');
+            Route::patch('/', 'Api\Student\StudentController@update');
+        });
+        Route::get('notification', 'Api\NotificationController@index');
     });
     Route::get('notification', 'Api\NotificationController@index');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,7 +34,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         });
         Route::get('notification', 'Api\NotificationController@index');
     });
-    Route::get('notification', 'Api\NotificationController@index');
 
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-493

## やったこと
- 生徒の認可ミドルウェアを実装
- 講師の認可ミドルウェアを実装

## 確認方法
- 各々のログインAPIで認証状態で、認可で弾かれることを確認。
例 )
講師でログインし、受講講座一覧APIをリクエストし、エラーが返ってくることを確認。