### PR TITLE
チャプターすべて公開/すべて非公開にする機能【チャプター作成画面】※講師側　ルーティング作成＋DBのロジック作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
 
 class ChapterController extends Controller
 {
@@ -164,5 +165,17 @@ class ChapterController extends Controller
                 'result' => false,
             ], 500);
         }
+    }
+
+    public function putStatus(Request $request)
+    {
+        Chapter::where('course_id', $request->route('course_id'))
+            ->update([
+                'status' => $request->status
+            ]);
+
+        return response()->json([
+            'result' => 'true'
+        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,7 @@ Route::prefix('v1')->group(function () {
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');
+                    Route::put('status', 'Api\Instructor\ChapterController@putStatus');
                     Route::prefix('{chapter_id}')->group(function () {
                         Route::get('/', 'Api\Instructor\ChapterController@show');
                         Route::patch('/', 'Api\Instructor\ChapterController@update');


### PR DESCRIPTION
# 動作確認手順
- Postmanにて`localhost:8080/api/v1/instructor/course/1/chapter/status`でSendする。
対象のcourse_idを持つchaptersテーブルのレコードのstatusカラムがボディリクエストのstatusの値に更新されていることを確認。

# 確認したいこと
- 現在のコードは$request->route('course_id')で受け取ったcourse_idのステータスを変更する内容かと思います。
- すべてという要件を満たすためにルーティングを追加して、ロジックを色々と検討してみたのですが、できませんでした。
- Chapterテーブルに登録されているすべてのレコードのstatusカラムを変えるようなコードを書くことはできるのでしょうか？
```
Chapter::all('id')
    ->update([
        'status' => $request->status
    ]);
```


# 考慮して欲しいこと
- 以前のブランチの`topic/jka-473/instructor_chapter_bulk_status_button`と`feature/shogo/jka-490/put_status_form_request`は複雑なことになってしまったため、

- 新たなブランチ`topic/jka-473/instructor_chapter_bulk_status_button2`と`feature/shinichiro/jka-487/db_logic_put_status2`を作り、前任者が行ったルーティング作成＋DBのロジック作成を行いました。

- お手数ではありますが、`topic/jka-473/instructor_chapter_bulk_status_button`と`feature/shogo/jka-490/put_status_form_request`を都合の良いタイミングで削除をお願いいたします。

- git hub上で480と486というブランチも誤って作ってしまったため、こちらも削除をお願いいたします。
- お手数おかけして申し訳ありませんが、よろしくお願いいたします。