### PR TITLE
fillable に 'given_name_by_instructor' を追加

### DIFF
--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -25,6 +25,7 @@ class Student extends Authenticatable
      * @var array
      */
     protected $fillable = [
+        'given_name_by_instructor',
         'nick_name',
         'last_name',
         'first_name',
@@ -36,7 +37,7 @@ class Student extends Authenticatable
         'sex',
         'address',
     ];
-    
+
     /**
      * 講座を取得
      *
@@ -46,7 +47,7 @@ class Student extends Authenticatable
     {
         return $this->hasMany(Course::class);
     }
-    
+
     /**
      * お知らせを取得
      *
@@ -64,7 +65,7 @@ class Student extends Authenticatable
      */
         public function attendance()
     {
-        return $this->hasMany(Attendance::class); 
+        return $this->hasMany(Attendance::class);
     }
 
     /**
@@ -76,7 +77,7 @@ class Student extends Authenticatable
     {
         return $this->hasMany(Attendance::class);
     }
-    
+
     /**
      * 文字列の性別を数値に変換
      *
@@ -104,7 +105,7 @@ class Student extends Authenticatable
 
         return null;
     }
-    
+
     /**
      * キャスト
      */


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-496

## 動作確認
### Postmanにて下記を実施

- ###  Request

メソッド：POST
URL：localhost:8080/api/v1/instructor/student?given_name_by_instructor=ユーザー名(仮)3&email=test_student_3@example.com
Params：
☑ given_name_by_instructor -> ユーザー名(仮)3
☑ email -> test_student_3@example.com
- ### Response
```
{
    "result": true,
    "data": {
        "id": 3,
        "given_name_by_instructor": "ユーザー名(仮)3",
        "email": "test_student_3@example.com"
    }
}
```
※Adminerの方でも指定した生徒情報が追加されていることを確認しております。