### PR TITLE
Lesson作成時に並べ替え用の数字がlessonsテーブルのorderカラムに入るように実装(DAIKI)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -29,12 +29,13 @@ class LessonController extends Controller
      */
     public function store(LessonStoreRequest $request)
     {
+        $maxOrder = Lesson::where('chapter_id', $request->input('chapter_id'))->max('order');
         try {
             $lesson = Lesson::create([
                 'chapter_id' => $request->input('chapter_id'),
                 'title' => $request->input('title'),
                 'status' => Lesson::STATUS_PRIVATE,
-                'order' => Lesson::where('chapter_id', $request->input('chapter_id'))->get()->count() + 1
+                'order' => (int)$maxOrder + 1,
             ]);
 
             return response()->json([
@@ -48,7 +49,7 @@ class LessonController extends Controller
             ], 500);
         }
     }
-
+    
     public function update(LessonUpdateRequest $request)
     {
         $user = Instructor::find(1);

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -34,6 +34,7 @@ class LessonController extends Controller
                 'chapter_id' => $request->input('chapter_id'),
                 'title' => $request->input('title'),
                 'status' => Lesson::STATUS_PRIVATE,
+                'order' => Lesson::where('chapter_id', $request->input('chapter_id'))->get()->count() + 1
             ]);
 
             return response()->json([

--- a/app/Http/Resources/Instructor/LessonStoreResource.php
+++ b/app/Http/Resources/Instructor/LessonStoreResource.php
@@ -15,12 +15,9 @@ class LessonStoreResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'chapter_id' => $this->resource->chapter_id,
-            'lesson' => [
-                'lesson_id' => $this->resource->id,
-                'title' => $this->resource->title,
-                'order' => $this->order,
-            ],
+            'lesson_id' => $this->resource->id,
+            'title' => $this->resource->title,
+            'order' => $this->order,
         ];
     }
 }

--- a/app/Http/Resources/Instructor/LessonStoreResource.php
+++ b/app/Http/Resources/Instructor/LessonStoreResource.php
@@ -19,6 +19,7 @@ class LessonStoreResource extends JsonResource
             'lesson' => [
                 'lesson_id' => $this->resource->id,
                 'title' => $this->resource->title,
+                'order' => $this->order,
             ],
         ];
     }


### PR DESCRIPTION
やったこと
・Lesson作成時にlessonsテーブル内のorderカラムに数字が並べ替え用の数字がチャプター内の他のLessonと重複せずに入るように実装。
・戻り値でorderカラムに入れた数字もJSONで返せるようにResourceファイルも修正。

確認方法
Postmanでhttp://localhost:8080/api/v1/instructor/course/1/chapter/1/lessonのURLをPostでSendする。
このとき、Bodyには、以下をJSON形式で入力。
{
    "chapter_id": 1,
    "title": "print"
}

質問したいこと
・LessonController内のstoreメソッドでchapter_idを取得する際に、$request->chapter_idで実現可能だが、わざわざ、
$request->input(chapter_id)と記述するメリット。
・レスポンスを返す際に、Resourceファイルを使うメリット
普通に
return response()->json([
                "result" => true,
                "data" => $lesson,
            ]);
と返す場合と何が違うのか。

・ResourceファイルのtoArrayメソッドで戻り値を返すとき、
$this->カラム名だけで十分なのに、$this->resourceを挟むメリット。
また、$thisでモデルの情報を取得するのが一般的だが、$request->のように書いても問題ないのか？
また、本件、chapter_idだけ、連想配列に含めずに値を返した理由。
