### PR TITLE
チャプターすべて公開/すべて非公開にする機能【チャプター作成画面】※講師側 認可処理の実装

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -168,6 +168,12 @@ class ChapterController extends Controller
         }
     }
 
+    /**
+     * チャプター一括更新API(公開・非公開切り替え)
+     * 
+     * @param ChapterPutStatusRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function putStatus(ChapterPutStatusRequest $request)
     {
         $course = Course::findOrFail($request->route('course_id'));

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
 
 class ChapterController extends Controller
 {
@@ -164,5 +165,17 @@ class ChapterController extends Controller
                 'result' => false,
             ], 500);
         }
+    }
+
+    public function putStatus(Request $request)
+    {
+        Chapter::where('course_id', $request->route('course_id'))
+            ->update([
+                'status' => $request->status
+            ]);
+
+        return response()->json([
+            'result' => 'true'
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -181,10 +181,10 @@ class ChapterController extends Controller
             return response()->json([
                 'result' => 'true'
             ]);
-        } else {
-            return response()->json([
-                'result' => 'false'
-            ]);
-        }
+        } 
+        return response()->json([
+            'result' => 'false',
+            "message" => "Not authorized."
+        ], 403);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
 
 class ChapterController extends Controller
 {
@@ -169,13 +170,21 @@ class ChapterController extends Controller
 
     public function putStatus(ChapterPutStatusRequest $request)
     {
-        Chapter::where('course_id', $request->route('course_id'))
-            ->update([
-                'status' => $request->status
-            ]);
+        $course = Course::findOrFail($request->route('course_id'));
 
-        return response()->json([
-            'result' => 'true'
-        ]);
+        if (Auth::guard('instructor')->user()->id === $course->instructor_id) {
+            Chapter::where('course_id', $request->route('course_id'))
+                ->update([
+                    'status' => $request->status
+                ]);
+
+            return response()->json([
+                'result' => 'true'
+            ]);
+        } else {
+            return response()->json([
+                'result' => 'false'
+            ]);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Instructor\ChapterPatchRequest;
 use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
 use App\Http\Requests\Instructor\ChapterSortRequest;
 use App\Http\Requests\Instructor\ChapterShowRequest;
+use App\Http\Requests\Instructor\ChapterPutStatusRequest;
 use App\Http\Resources\Instructor\ChapterStoreResource;
 use App\Http\Resources\Instructor\ChapterPatchResource;
 use App\Http\Resources\Instructor\ChapterShowResource;
@@ -19,7 +20,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Http\Request;
 
 class ChapterController extends Controller
 {
@@ -167,7 +167,7 @@ class ChapterController extends Controller
         }
     }
 
-    public function putStatus(Request $request)
+    public function putStatus(ChapterPutStatusRequest $request)
     {
         Chapter::where('course_id', $request->route('course_id'))
             ->update([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -172,19 +172,19 @@ class ChapterController extends Controller
     {
         $course = Course::findOrFail($request->route('course_id'));
 
-        if (Auth::guard('instructor')->user()->id === $course->instructor_id) {
-            Chapter::where('course_id', $request->route('course_id'))
-                ->update([
-                    'status' => $request->status
-                ]);
-
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
             return response()->json([
-                'result' => 'true'
+                'result' => 'false',
+                "message" => "Not authorized."
+            ], 403);
+        }
+        Chapter::where('course_id', $request->route('course_id'))
+            ->update([
+                'status' => $request->status
             ]);
-        } 
+
         return response()->json([
-            'result' => 'false',
-            "message" => "Not authorized."
-        ], 403);
+            'result' => 'true'
+        ]);
     }
 }

--- a/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
@@ -32,7 +32,7 @@ class ChapterPutStatusRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:chapters,course_id'],
+            'course_id' => ['required', 'integer', 'exists:courses,id'],
             'status' => ['required', 'string', new ChapterStatusRule()],
         ];
     }

--- a/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\ChapterStatusRule;
+
+class ChapterPutStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'status' => ['required', 'string', new ChapterStatusRule()],
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
@@ -17,6 +17,13 @@ class ChapterPutStatusRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -25,6 +32,7 @@ class ChapterPutStatusRequest extends FormRequest
     public function rules()
     {
         return [
+            'course_id' => ['required', 'integer', 'exists:chapters,id'],
             'status' => ['required', 'string', new ChapterStatusRule()],
         ];
     }

--- a/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPutStatusRequest.php
@@ -32,7 +32,7 @@ class ChapterPutStatusRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:chapters,id'],
+            'course_id' => ['required', 'integer', 'exists:chapters,course_id'],
             'status' => ['required', 'string', new ChapterStatusRule()],
         ];
     }

--- a/database/migrations/2022_10_29_021904_create_chapters_table.php
+++ b/database/migrations/2022_10_29_021904_create_chapters_table.php
@@ -22,6 +22,7 @@ class CreateChaptersTable extends Migration
             $table->datetime('created_at');
             $table->datetime('updated_at');
             $table->softDeletes();
+            $table->foreign('course_id')->references('id')->on('courses');
         });
     }
 

--- a/database/migrations/2022_10_29_060342_create_lessons_table.php
+++ b/database/migrations/2022_10_29_060342_create_lessons_table.php
@@ -24,7 +24,8 @@ class CreateLessonsTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
-            $table->unsignedTinyInteger('order')->coment('順番');
+            $table->unsignedTinyInteger('order')->comment('順番');
+            $table->foreign('chapter_id')->references('id')->on('chapters');
 
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,7 @@ Route::prefix('v1')->group(function () {
                 Route::prefix('chapter')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');
+                    Route::put('status', 'Api\Instructor\ChapterController@putStatus');
                     Route::prefix('{chapter_id}')->group(function () {
                         Route::get('/', 'Api\Instructor\ChapterController@show');
                         Route::patch('/', 'Api\Instructor\ChapterController@update');


### PR DESCRIPTION
# 動作確認手順
- id1の講師でログインしてlocalhost:8080/api/v1/instructor/course/1/chapter/statusをsendするとtrue、localhost:8080/api/v1/instructor/course/2/chapter/statusをsendするとfalseが帰ってきました。

# 確認して欲しいこと
- topicからdevelopへのプルリクとなり、マイグレーションファイルも修正したので確認をお願いいたします。

- ルーティングの移動も今回のタスクでしょうか？試しにやってみたのですが、PUT methodはサポートされていないと出てしまいました。

- Route::patch('status/aaa', 'Api\Instructor\ChapterController@putStatus');など色々試しましたが、うまくできませんでした。

```
Route::prefix('v1')->group(function () {
            Route::prefix('instructor')->group(function () {
                Route::prefix('course')->group(function () {
                    Route::prefix('{course_id}')->group(function () {
                        Route::prefix('chapter')->group(function () {
                            Route::put('status', 'Api\Instructor\ChapterController@putStatus');
                        });
                    });
                });
            });
        });    
```
<img width="1470" alt="スクリーンショット 2023-10-12 11 20 52" src="https://github.com/yukihiroLaravel/juko_laravel/assets/139059560/c4649e62-89b6-47ce-85e7-85f65136be9c">
