### PR TITLE
Lesson作成時のバリデーションを修正(DAIKI)

### DIFF
--- a/app/Http/Requests/Instructor/LessonStoreRequest.php
+++ b/app/Http/Requests/Instructor/LessonStoreRequest.php
@@ -20,6 +20,7 @@ class LessonStoreRequest extends FormRequest
     {
         $this->merge([
             'chapter_id' => $this->route('chapter_id'),
+            'course_id' => $this->route('course_id'),
         ]);
     }
 
@@ -31,8 +32,9 @@ class LessonStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'chapter_id' => ['required','integer'],
-            'title' => ['required','string'],
+            'chapter_id' => ['required','integer', 'exists:chapters,id'],
+            'course_id' => ['required','integer', 'exists:courses,id'],
+            'title' => ['required','string', 'max:50'],
         ];
     }
 }

--- a/app/Http/Resources/Instructor/LessonStoreResource.php
+++ b/app/Http/Resources/Instructor/LessonStoreResource.php
@@ -17,7 +17,7 @@ class LessonStoreResource extends JsonResource
         return [
             'lesson_id' => $this->resource->id,
             'title' => $this->resource->title,
-            'order' => $this->order,
+            'order' => $this->resource->order,
         ];
     }
 }


### PR DESCRIPTION
やったこと。
ルートパラメータからの講座idをフォームリクエストクラスで受け取れるように実装。
講座idの存在チェックと必須入力と数値型になるようにバリデーションを作成。
チャプターidの存在チェックをバリデーションの条件に追加。
Lessonのタイトルは50文字以下になるようにバリデーションの条件を追加。
前回のタスクで修正してなかったResourceクラス内の戻り値の記述方法を変更。

確認方法
Postmanで以下URLをSend。
http://localhost:8080/api/v1/instructor/course/100/chapter/100/lesson
この際に、Bodyには、タイトルを50文字を超える長さで入力。

その結果が以下。
{
    "message": "The given data was invalid.",
    "errors": {
        "chapter_id": [
            "The selected chapter id is invalid."
        ],
        "course_id": [
            "The selected course id is invalid."
        ],
        "title": [
            "The title may not be greater than 50 characters."
        ]
    }
}
