### PR TITLE
プロフィール画像アップロード機能　データベースのロジック作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -7,6 +7,9 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\InstructorPatchRequest;
 use App\Http\Resources\Instructor\InstructorEditResource;
 use App\Http\Resources\Instructor\InstructorPatchResource;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
 
 class InstructorController extends Controller
 {
@@ -18,22 +21,31 @@ class InstructorController extends Controller
      */
     public function update(InstructorPatchRequest $request)
     {
+        
+        $file = $request->file('profile_image');
+
         try{
             $instructor = Instructor::findOrFail(1);
 
-            // ディレクトリ名
-            $dir = 'images';
-            // アップロードされたファイル名を取得
-            $file_name = $request->file('image')->getClientOriginalName();
-            // 取得したファイル名で保存
-            $request->file('image')->storeAs('public/' . $dir, $file_name);
+            // 2回目以降の更新処理で必要
+            // if (isset($file)) {
+            //     // 更新前の画像ファイルを削除
+            //     if (Storage::exists($instructor->image)) {
+            //         Storage::delete($instructor->image);
+            //     }
 
+            // 画像ファイル保存処理
+            $extension = $file->getClientOriginalExtension();
+            $filename = Str::uuid() . '.' . $extension;
+            $imagePath = Storage::putFileAs('public/instructor', $file, $filename);
+            $imagePath = Instructor::convertImagePath($imagePath);
+            
             $instructor->update([
                 'nick_name' => $request->nick_name,
                 'last_name' => $request->last_name,
                 'first_name' => $request->first_name,
                 'email' => $request->email,
-                'profile_image' => $request->image,
+                'profile_image' => $imagePath,
             ]);
             return response()->json([
                 'result' => true,

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -33,11 +33,11 @@ class InstructorController extends Controller
                     Storage::delete($instructor->profile_image);
                 }
 
-            // 画像ファイル保存処理
-            $extension = $file->getClientOriginalExtension();
-            $filename = Str::uuid() . '.' . $extension;
-            $imagePath = Storage::putFileAs('public/instructor', $file, $filename);
-            $imagePath = Instructor::convertImagePath($imagePath);
+                // 画像ファイル保存処理
+                $extension = $file->getClientOriginalExtension();
+                $filename = Str::uuid() . '.' . $extension;
+                $imagePath = Storage::putFileAs('public/instructor', $file, $filename);
+                $imagePath = Instructor::convertImagePath($imagePath);
             }
             
             $instructor->update([

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -29,8 +29,8 @@ class InstructorController extends Controller
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除
-                if (Storage::exists($instructor->profile_image)) {
-                    Storage::delete($instructor->profile_image);
+                if (Storage::disk('public')->exists($instructor->profile_image)) {
+                    Storage::disk('public')->delete($instructor->profile_image);
                 }
 
                 // 画像ファイル保存処理

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -27,18 +27,18 @@ class InstructorController extends Controller
         try{
             $instructor = Instructor::findOrFail(1);
 
-            // 2回目以降の更新処理で必要？
-            // if (isset($file)) {
-            //     // 更新前の画像ファイルを削除
-            //     if (Storage::exists($instructor->profile_image)) {
-            //         Storage::delete($instructor->profile_image);
-            //     }
+            if (isset($file)) {
+                // 更新前の画像ファイルを削除
+                if (Storage::exists($instructor->profile_image)) {
+                    Storage::delete($instructor->profile_image);
+                }
 
             // 画像ファイル保存処理
             $extension = $file->getClientOriginalExtension();
             $filename = Str::uuid() . '.' . $extension;
             $imagePath = Storage::putFileAs('public/instructor', $file, $filename);
             $imagePath = Instructor::convertImagePath($imagePath);
+            }
             
             $instructor->update([
                 'nick_name' => $request->nick_name,

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -27,11 +27,11 @@ class InstructorController extends Controller
         try{
             $instructor = Instructor::findOrFail(1);
 
-            // 2回目以降の更新処理で必要
+            // 2回目以降の更新処理で必要？
             // if (isset($file)) {
             //     // 更新前の画像ファイルを削除
-            //     if (Storage::exists($instructor->image)) {
-            //         Storage::delete($instructor->image);
+            //     if (Storage::exists($instructor->profile_image)) {
+            //         Storage::delete($instructor->profile_image);
             //     }
 
             // 画像ファイル保存処理

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -20,11 +20,20 @@ class InstructorController extends Controller
     {
         try{
             $instructor = Instructor::findOrFail(1);
+
+            // ディレクトリ名
+            $dir = 'images';
+            // アップロードされたファイル名を取得
+            $file_name = $request->file('image')->getClientOriginalName();
+            // 取得したファイル名で保存
+            $request->file('image')->storeAs('public/' . $dir, $file_name);
+
             $instructor->update([
                 'nick_name' => $request->nick_name,
                 'last_name' => $request->last_name,
                 'first_name' => $request->first_name,
-                'email' => $request->email
+                'email' => $request->email,
+                'profile_image' => $request->image,
             ]);
             return response()->json([
                 'result' => true,

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -21,7 +21,7 @@ class Instructor extends Authenticatable
         'last_name',
         'first_name',
         'email',
-        'image'
+        'profile_image',
     ];
 
     /**
@@ -32,5 +32,17 @@ class Instructor extends Authenticatable
     public function courses()
     {
         return $this->hasMany(Course::class);
+    }
+
+    /**
+     * 画像保存パスに変換
+     *
+     * @param string $filePath
+     * @return string
+     */
+    public static function convertImagePath(string $filePath)
+    {
+        // public/を削除
+        return str_replace('public/', '', $filePath);
     }
 }

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -20,7 +20,8 @@ class Instructor extends Authenticatable
         'nick_name',
         'last_name',
         'first_name',
-        'email'
+        'email',
+        'image'
     ];
 
     /**

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -20,6 +20,7 @@ class CreateInstructorsTable extends Migration
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
             $table->string('password', 255)->comment('パスワード');
+            $table->string('profile_image')->nullable()->comment('プロフィール画像');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -20,7 +20,7 @@ class CreateInstructorsTable extends Migration
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
             $table->string('password', 255)->comment('パスワード');
-            $table->string('profile_image')->nullable()->comment('プロフィール画像');
+            $table->string('profile_image')->nullable()->comment('プロフィール画像ファイルパス');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,7 +52,7 @@ Route::prefix('v1')->group(function () {
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
-        Route::patch('/', 'Api\Instructor\InstructorController@update');
+        Route::post('/', 'Api\Instructor\InstructorController@update');
         Route::patch('notification/{notification_id}', 'Api\Instructor\NotificationController@update');
         Route::post('student', 'Api\Instructor\StudentController@store');
         Route::prefix('notification')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,11 +48,11 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
+        Route::post('/', 'Api\Instructor\InstructorController@update');
         Route::get('student/{student_id}', 'Api\Instructor\StudentController@show');
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');
         });
-        Route::post('/', 'Api\Instructor\InstructorController@update');
         Route::patch('notification/{notification_id}', 'Api\Instructor\NotificationController@update');
         Route::post('student', 'Api\Instructor\StudentController@store');
         Route::prefix('notification')->group(function () {


### PR DESCRIPTION
# issue
- https://gut-familie.atlassian.net/browse/JKA-514

# 動作確認手順
- localhost:8080/api/v1/instructorをpostメソッドでsendしてinstructorsテーブルのprofile_imageカラムにパスが保存されることを確認しました。
- 更新を行うたびに`storage/app/public/instructor`のファイルが削除されることを確認しました。

# 確認したいこと
- 細かい部分で恐縮ですが、コードの量を減らすという観点で考えた場合はデータベースにパスを保存する際はpublic/instructor/...とpublicを含める形で保存をした方が良いと思うのですが、なぜinstructor/...とpublicを削除したパスを保存するのでしょうか？

