### PR TITLE
プロフィール画像アップロード機能　認可処理、フォームリクエスト、リソースファイルの修正

### DIFF
--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -9,6 +9,7 @@ use App\Http\Resources\Instructor\InstructorEditResource;
 use App\Http\Resources\Instructor\InstructorPatchResource;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Auth;
 
 
 class InstructorController extends Controller
@@ -24,8 +25,15 @@ class InstructorController extends Controller
         
         $file = $request->file('profile_image');
 
+        $instructor = Instructor::findOrFail($request->instructor_id);
+        if (Auth::guard('instructor')->user()->id !== $instructor->id) {
+            return response()->json([
+                'result' => 'false',
+                "message" => "Not authorized."
+            ], 403);
+        }
+
         try{
-            $instructor = Instructor::findOrFail(1);
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除

--- a/app/Http/Requests/Instructor/InstructorPatchRequest.php
+++ b/app/Http/Requests/Instructor/InstructorPatchRequest.php
@@ -16,6 +16,13 @@ class InstructorPatchRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'instructor_id' => $this->route('instructor_id'),
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -28,6 +35,8 @@ class InstructorPatchRequest extends FormRequest
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
             'email' => ['required', 'email'],
+            'instructor_id' => ['required', 'integer', 'exists:instructors,id'],
+            'profile_image' => ['mimes:jpg,png','dimensions:min_width=100,min_height=100,max_width=3700,max_height=2000','max:10000'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/InstructorPatchRequest.php
+++ b/app/Http/Requests/Instructor/InstructorPatchRequest.php
@@ -36,7 +36,7 @@ class InstructorPatchRequest extends FormRequest
             'first_name' => ['required', 'string'],
             'email' => ['required', 'email'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id'],
-            'profile_image' => ['mimes:jpg,png','dimensions:min_width=100,min_height=100,max_width=3700,max_height=2000','max:10000'],
+            'profile_image' => ['mimes:jpg,png', 'max:2000'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/InstructorPatchRequest.php
+++ b/app/Http/Requests/Instructor/InstructorPatchRequest.php
@@ -36,7 +36,7 @@ class InstructorPatchRequest extends FormRequest
             'first_name' => ['required', 'string'],
             'email' => ['required', 'email'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id'],
-            'profile_image' => ['mimes:jpg,png', 'max:2000'],
+            'profile_image' => ['mimes:jpg,png', 'max:2048'],
         ];
     }
 }

--- a/app/Http/Resources/Instructor/InstructorPatchResource.php
+++ b/app/Http/Resources/Instructor/InstructorPatchResource.php
@@ -19,6 +19,7 @@ class InstructorPatchResource extends JsonResource
             'last_name' => $this->last_name,
             'first_name' => $this->first_name,
             'email' => $this->email,
+            'profile_image' => $this->profile_image,
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述
+        Route::prefix('instructor')->group(function () {
+            Route::prefix('{instructor_id}')->group(function () {
+                Route::post('/', 'Api\Instructor\InstructorController@update');
+            });
+        });
     });
 });
 
@@ -48,7 +53,6 @@ Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
         Route::get('edit', 'Api\Instructor\InstructorController@edit');
-        Route::post('/', 'Api\Instructor\InstructorController@update');
         Route::get('student/{student_id}', 'Api\Instructor\StudentController@show');
         Route::prefix('attendance')->group(function () {
             Route::post('/', 'Api\Instructor\AttendanceController@store');


### PR DESCRIPTION
# issue
- https://gut-familie.atlassian.net/browse/JKA-519

# 動作確認手順
- 講師1でログインを行いlocalhost:8080/api/v1/instructor/1をsendするとtrue、localhost:8080/api/v1/instructor/2をsendするとfalseが帰ってきました。
- 要件を満たさないurlやファイルをアップロードするとエラー表示されました。

# 確認したいこと
- 現状のコードだとアップロードするファイルを未選択の状態だとエラーが出るので

<img width="1470" alt="スクリーンショット 2023-10-18 13 16 27" src="https://github.com/yukihiroLaravel/juko_laravel/assets/139059560/26f90407-cc90-43ee-840d-3b738a5b9deb">

- 保存するパスの有無で条件分岐するのでしょうか？
```
if (isset($imagePath)) {
        $instructor->update([
            'nick_name' => $request->nick_name,
            'last_name' => $request->last_name,
            'first_name' => $request->first_name,
            'email' => $request->email,
            'profile_image' => $imagePath,
        ]);
        return response()->json([
            'result' => true,
            'data' => new InstructorPatchResource($instructor)
        ]);}

        $instructor->update([
            'nick_name' => $request->nick_name,
            'last_name' => $request->last_name,
            'first_name' => $request->first_name,
            'email' => $request->email,
        ]);
        return response()->json([
            'result' => true,
            'data' => new InstructorPatchResource($instructor)
        ]);
```