### PR TITLE
Add error response for getting info of another instructer's course

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -17,6 +17,7 @@ use App\Http\Resources\Instructor\ChapterPatchResource;
 use App\Http\Resources\Instructor\ChapterShowResource;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -56,10 +57,15 @@ class ChapterController extends Controller
      */
     public function show(ChapterShowRequest $request)
     {
-        $chapter = Chapter::with('lessons')->findOrFail($request->chapter_id);
+        $chapter = Chapter::with(['lessons','course'])->findOrFail($request->chapter_id);
         if ((int) $request->course_id !== $chapter->course->id) {
             return response()->json([
                 'message' => 'invalid course_id.',
+            ], 403);
+        }
+        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
+            return response()->json([
+                'message' => 'invalid instructor_id.',
             ], 403);
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,20 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     Route::get('notification', 'Api\NotificationController@index');
 });
 
+Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
+    Route::prefix('instructor')->group(function () {
+        Route::prefix('course')->group(function () {
+            Route::prefix('{course_id}')->group(function () {
+                Route::prefix('chapter')->group(function () {
+                    Route::prefix('{chapter_id}')->group(function () {
+                        Route::get('/', 'Api\Instructor\ChapterController@show');
+                    });
+                });
+            });
+        });
+    });
+});
+
 Route::prefix('v1')->group(function () {
     // 講師側API
     Route::prefix('instructor')->group(function () {
@@ -67,7 +81,6 @@ Route::prefix('v1')->group(function () {
                     Route::post('/', 'Api\Instructor\ChapterController@store');
                     Route::post('sort', 'Api\Instructor\ChapterController@sort');
                     Route::prefix('{chapter_id}')->group(function () {
-                        Route::get('/', 'Api\Instructor\ChapterController@show');
                         Route::patch('/', 'Api\Instructor\ChapterController@update');
                         Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                         Route::delete('/', 'Api\Instructor\ChapterController@delete');


### PR DESCRIPTION
ようやくpostmanでの確認ができましたので、jka-488 のプルリクを出させていただきます。

## 概要
jka-488 ChapterController で他のインストラクターのコースは参照できないよう
403 invalid instructor_id を応答するように変更

## 動作確認手順
### (1) instructor_id =1 で講師ログイン
http://localhost:8080/login/instructor
{
    "email": "test_instructor2@example.com",
    "password": "password"
}
### (2) チャプター情報を取得に成功
http://localhost:8080/api/v1/instructor/course/1/chapter/1
{
    "data": {
        "chapter_id": 1,
        "title": "PHPとは？",
        "lessons": [
            {
                "lesson_id": 1,
                "title": "echo",
                "url": "sVbEyFZKgqk",
                "remarks": "HTMLでは決められたテキストしか表示することができませんでした。\nPHPを使うと、見る人や状況に応じて、表示するテキストを変えることができます。",
                "order": 1
            }
        ]
    }
}
### (3) instructor_id = 2 で講師ログイン
http://localhost:8080/login/instructor
{
    "email": "test_instructor@example.com",
    "password": "password"
}
### (4) チャプター情報取得に失敗
http://localhost:8080/api/v1/instructor/course/1/chapter/1
{
    "message": "invalid instructor_id."
}

## 考慮して欲しいこと
特にありません
## 確認してほしいこと
特にありません