### PR TITLE
Feature/seiichi/jka 500/instructor image display/db logic2

### DIFF
--- a/app/Http/Resources/Instructor/InstructorEditResource.php
+++ b/app/Http/Resources/Instructor/InstructorEditResource.php
@@ -20,7 +20,6 @@ class InstructorEditResource extends JsonResource
             'last_name' => $this->resource->last_name,
             'first_name' => $this->resource->first_name,
             'email' => $this->resource->email,
-            'profile_image' => $this->resource->profile_image,
         ];
     }
 }

--- a/app/Http/Resources/Instructor/InstructorEditResource.php
+++ b/app/Http/Resources/Instructor/InstructorEditResource.php
@@ -20,6 +20,7 @@ class InstructorEditResource extends JsonResource
             'last_name' => $this->resource->last_name,
             'first_name' => $this->resource->first_name,
             'email' => $this->resource->email,
+            'profile_image' => $this->resource->profile_image,
         ];
     }
 }

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -19,8 +19,8 @@ class CreateInstructorsTable extends Migration
             $table->string('last_name', 50)->comment('苗字');
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
-            $table->string('profile_image', 255)->comment('画像のパス');
             $table->string('password', 255)->comment('パスワード');
+            $table->string('profile_image')->nullable()->comment('プロフィール画像 ファイルパス');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -20,6 +20,7 @@ class CreateInstructorsTable extends Migration
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
             $table->string('password', 255)->comment('パスワード');
+            $table->string('profile_image')->nullable()->comment('プロフィール画像 ファイルパス');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -19,6 +19,7 @@ class CreateInstructorsTable extends Migration
             $table->string('last_name', 50)->comment('苗字');
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
+            $table->string('profile_image', 255)->comment('画像のパス');
             $table->string('password', 255)->comment('パスワード');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -20,7 +20,7 @@ class CreateInstructorsTable extends Migration
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
             $table->string('password', 255)->comment('パスワード');
-            $table->string('profile_image')->nullable()->comment('プロフィール画像ファイルパス');
+            $table->string('profile_image')->nullable()->comment('プロフィール画像 ファイルパス');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -20,7 +20,7 @@ class CreateInstructorsTable extends Migration
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
             $table->string('password', 255)->comment('パスワード');
-            $table->string('profile_image')->nullable()->comment('プロフィール画像 ファイルパス');
+            $table->string('profile_image')->nullable()->comment('プロフィール画像ファイルパス');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();

--- a/database/migrations/2022_10_19_215030_create_instructors_table.php
+++ b/database/migrations/2022_10_19_215030_create_instructors_table.php
@@ -20,7 +20,6 @@ class CreateInstructorsTable extends Migration
             $table->string('first_name', 50)->comment('名前');
             $table->string('email', 255)->comment('メールアドレス');
             $table->string('password', 255)->comment('パスワード');
-            $table->string('profile_image')->nullable()->comment('プロフィール画像 ファイルパス');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();

--- a/database/seeds/InstructorSeeder.php
+++ b/database/seeds/InstructorSeeder.php
@@ -19,7 +19,8 @@ class InstructorSeeder extends Seeder
                 'last_name' => '山田',
                 'first_name' => '太郎',
                 'email' => 'test_instructor@example.com',
-                'password' => Hash::make('password')
+                'password' => Hash::make('password'),
+                'profile_image' => 'instructor/default.png'
             ]
         );
 


### PR DESCRIPTION
# issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-500

# 概要
- プロフィール画像表示機能【講師情報編集画面】※講師側

# 動作確認手順
- php artisan migrate:fresh --seedを実行し、Adminerのinstructorsデータベースにprofile_imageカラムが追加され、値はnullを確認
- ポストマンで　GET=>localhost:8080/api/v1/instructor/edit=>Send　実行、レスポンス確認
- {
    "data": {
        "id": 1,
        "nick_name": "ニックネーム",
        "last_name": "山田",
        "first_name": "太郎",
        "email": "test_instructor@example.com",
        "profile_image": null
    }
}

# 確認したいこと
- 今回の変更に、タスク分割見込みの5、Resourseファイル(レスポンスの整型)　の部分も含まれるのでしょうか？

# 考慮して欲しいこと
- トピックブランチ作成時、なぜか
　$table->string('profile_image')->nullable()->comment('プロフィール画像ファイルパス');　が
既にあったので、削除し一度コミットしました。余計な事をしたかもしれません。すみません。