### PR TITLE
JKA-511:講師の受講生一覧取得にプロフィール画像応答を追加

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -21,7 +21,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Facades\Auth;
 
 class ChapterController extends Controller
 {

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -39,6 +39,7 @@ class StudentIndexResource extends JsonResource
                 'id' => $attendance->student->id,
                 'nick_name' => $attendance->student->nick_name,
                 'email' => $attendance->student->email,
+                'profile_image' => $attendance->student->profile_image,
                 'course_title' => $attendance->course->title,
                 'last_login_at' => $attendance->student->last_login_at->format('Y/m/d  H:i:s'),
                 'attendanced_at' => $attendance->created_at->format('Y/m/d'),


### PR DESCRIPTION
プルリクを作成しました。
よろしくお願いいたします。

■JKA-511：受講生のプロフィール画像表示【受講生一覧】※講師側

### 変更内容
既存の`/api/v1/instructor/course/{course_id}/student/index`にprofile_imageを応答するように変更。

### 確認
postmanで、Instructor 1 でログインして、
http://localhost:8080/api/v1/instructor/course/1/student/index
で以下のレスポンスを確認。

> {
>     "data": {
>         "course": {
>             "id": 1,
>             "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
>             "title": "PHP入門講座"
>         },
>         "pagination": {
>             "page": 1,
>             "total": 1
>         },
>         "students": [
>             {
>                 "id": 1,
>                 "nick_name": "生徒ニックネーム1",
>                 "email": "test_student_1@example.com",
>                 "profile_image": "/student/image1.jpg",
>                 "course_title": "PHP入門講座",
>                 "last_login_at": "2023/10/20  22:21:14",
>                 "attendanced_at": "2023/10/20"
>             }
>         ]
>     }
> }