### PR TITLE
Feature/makino/jka 525/add profile image to api course index

### DIFF
--- a/app/Http/Resources/CourseIndexResource.php
+++ b/app/Http/Resources/CourseIndexResource.php
@@ -25,6 +25,7 @@ class CourseIndexResource extends JsonResource
                     'last_name' => $value->course->instructor->last_name,
                     'first_name' => $value->course->instructor->first_name,
                     'email' => $value->course->instructor->email,
+                    'profile_image' => $value->course->instructor->profile_image,
                 ],
                 'attendance' => [
                     'attendance_id' => $value->id,


### PR DESCRIPTION
プルリクを作成しましたのでよろしくお願いいたします。

■JKA-525：講師プロフィール画像表示【講座一覧】 ※受講生側

### 確認
Student 1 でログインして
http://localhost:8080/api/v1/course/index
で以下の取得を確認。

> {
    "data": [
        {
            "course_id": 1,
            "title": "PHP入門講座",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "instructor": {
                "instructor": 1,
                "nick_name": "ニックネーム",
                "last_name": "山田",
                "first_name": "太郎",
                "email": "test_instructor@example.com",
                "profile_image": null
            },
            "attendance": {
                "attendance_id": 1,
                "progress": 10
            }
        }
    ]
}