### PR TITLE
講座ステータス　一括更新機能の実装　(ロジック、フォームリクエストの作成）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -187,22 +187,15 @@ class CourseController extends Controller
     }
 
     /**
-     * コースステータス一括更新API(公開・非公開切り替え)
+     * 講座ステータス一括更新API(公開・非公開切り替え)
      * 
      * @param CoursePutStatusRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function putStatus(coursePutStatusRequest $request)
     {
-        $course = Course::findOrFail($request->instructor_id);
-
-        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
-            return response()->json([
-                'result' => 'false',
-                "message" => "Not authorized."
-            ], 403);
-        }
-        Course::where('instructor_id', $request->instructor_id)
+        $instructorId = Auth::guard('instructor')->user()->id;
+        Course::where('instructor_id', $instructorId)
             ->update([
                 'status' => $request->status
             ]);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -8,6 +8,7 @@ use App\Model\Instructor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\CourseDeleteRequest;
 use App\Http\Requests\Instructor\CourseUpdateRequest;
+use App\Http\Requests\Instructor\CoursePutStatusRequest;
 use App\Http\Requests\Instructor\CourseShowRequest;
 use App\Http\Requests\Instructor\CourseStoreRequest;
 use App\Http\Requests\Instructor\CourseEditRequest;
@@ -22,6 +23,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Auth;
 
 class CourseController extends Controller
 {
@@ -182,5 +184,31 @@ class CourseController extends Controller
             ], 500);
 
         }
+    }
+
+    /**
+     * コースステータス一括更新API(公開・非公開切り替え)
+     * 
+     * @param CoursePutStatusRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function putStatus(coursePutStatusRequest $request)
+    {
+        $course = Course::findOrFail($request->instructor_id);
+
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+            return response()->json([
+                'result' => 'false',
+                "message" => "Not authorized."
+            ], 403);
+        }
+        Course::where('instructor_id', $request->instructor_id)
+            ->update([
+                'status' => $request->status
+            ]);
+
+        return response()->json([
+            'result' => 'true'
+        ]);
     }
 }

--- a/app/Http/Requests/Instructor/CoursePutStatusRequest.php
+++ b/app/Http/Requests/Instructor/CoursePutStatusRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
-use App\Rules\ChapterStatusRule;
+use App\Rules\CourseStatusRule;
 
 class CoursePutStatusRequest extends FormRequest
 {
@@ -33,7 +33,7 @@ class CoursePutStatusRequest extends FormRequest
     {
         return [
             'instructor_id' => ['required', 'integer', 'exists:instructors,id'],
-            'status' => ['required', 'string', new ChapterStatusRule()],
+            'status' => ['required', 'string', new CourseStatusRule()],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/CoursePutStatusRequest.php
+++ b/app/Http/Requests/Instructor/CoursePutStatusRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\ChapterStatusRule;
+
+class CoursePutStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'instructor_id' => $this->route('instructor_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'instructor_id' => ['required', 'integer', 'exists:instructors,id'],
+            'status' => ['required', 'string', new ChapterStatusRule()],
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/CoursePutStatusRequest.php
+++ b/app/Http/Requests/Instructor/CoursePutStatusRequest.php
@@ -17,13 +17,6 @@ class CoursePutStatusRequest extends FormRequest
         return true;
     }
 
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'instructor_id' => $this->route('instructor_id'),
-        ]);
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *
@@ -32,7 +25,6 @@ class CoursePutStatusRequest extends FormRequest
     public function rules()
     {
         return [
-            'instructor_id' => ['required', 'integer', 'exists:instructors,id'],
             'status' => ['required', 'string', new CourseStatusRule()],
         ];
     }

--- a/app/Http/Requests/Instructor/CourseUpdateRequest.php
+++ b/app/Http/Requests/Instructor/CourseUpdateRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
-use App\Rules\CourseUpdateStatusRule;
+use App\Rules\CourseStatusRule;
 
 class CourseUpdateRequest extends FormRequest
 {
@@ -35,7 +35,7 @@ class CourseUpdateRequest extends FormRequest
             'course_id' => ['required','integer'],
             'title' => ['required','string'],
             'image' => ['mimes:jpg,png'],
-            'status' => ['required', 'string', new CourseUpdateStatusRule()],
+            'status' => ['required', 'string', new CourseStatusRule()],
         ];
     }
 }

--- a/app/Rules/CourseStatusRule.php
+++ b/app/Rules/CourseStatusRule.php
@@ -5,7 +5,7 @@ namespace App\Rules;
 use Illuminate\Contracts\Validation\Rule;
 use App\Model\Course;
 
-class CourseUpdateStatusRule implements Rule
+class CourseStatusRule implements Rule
 {
     /**
      * Determine if the validation rule passes.

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('course')->group(function () {
                 Route::get('index', 'Api\Instructor\CourseController@index');
                 Route::post('/', 'Api\Instructor\CourseController@store');
+                Route::put('{instructor_id}/status', 'Api\Instructor\CourseController@putStatus');
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', 'Api\Instructor\CourseController@show');
                     Route::get('edit', 'Api\Instructor\CourseController@edit');

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,7 +56,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('course')->group(function () {
                 Route::get('index', 'Api\Instructor\CourseController@index');
                 Route::post('/', 'Api\Instructor\CourseController@store');
-                Route::put('{instructor_id}/status', 'Api\Instructor\CourseController@putStatus');
+                Route::put('status', 'Api\Instructor\CourseController@putStatus');
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', 'Api\Instructor\CourseController@show');
                     Route::get('edit', 'Api\Instructor\CourseController@edit');


### PR DESCRIPTION
# issue
- https://gut-familie.atlassian.net/browse/JKA-528

# 動作確認手順
- ID1または2の講師でログインをしている状態でlocalhost:8080/api/v1/instructor/course/statusをsendするとデータベースの内容が更新されました。

- ルールの名称変更に伴い、影響範囲のあったupdateメソッドの動作確認を行いました。
localhost:8080/api/v1/instructor/course/1をsendしてtrueが帰ってきました。
<img width="1470" alt="スクリーンショット 2023-10-25 10 02 09" src="https://github.com/yukihiroLaravel/juko_laravel/assets/139059560/83daedc1-e24e-422b-9185-40025048a221">


# 確認して欲しいこと
- featureからdevelopのプルリクです。