### PR TITLE
チャプター詳細情報取得API改修 ※受講生側（nari)

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Api;
+namespace App\Http\Controllers\Api\Student;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ChapterGetRequest;
@@ -9,7 +9,7 @@ use App\Model\Attendance;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use App\Model\Chapter;
 
-class ChapterController extends Controller
+class AttendanceController extends Controller
 {
     /**
      * チャプター詳細情報を取得
@@ -18,7 +18,7 @@ class ChapterController extends Controller
      * @return ChapterShowResource
      * @throws HttpException
      */
-    public function show(ChapterGetRequest $request)
+    public function showChapter(ChapterGetRequest $request)
     {
         $attendance = Attendance::with([
                 'course.chapters.lessons',

--- a/app/Http/Requests/ChapterGetRequest.php
+++ b/app/Http/Requests/ChapterGetRequest.php
@@ -26,6 +26,7 @@ class ChapterGetRequest extends FormRequest
         return [
             'attendance_id' => ['required', 'integer'],
             'chapter_id' => ['required', 'integer'],
+            'course_id' => ['required', 'integer'],
         ];
     }
 }

--- a/app/Http/Resources/ChapterShowResource.php
+++ b/app/Http/Resources/ChapterShowResource.php
@@ -15,7 +15,7 @@ class ChapterShowResource extends JsonResource
     }
 
     public function toArray($request)
-    {
+    {   $course = $this->resource->course;
         $chapterId = $this->chapterId;
         $chapter = $this->resource->course->chapters->filter(function($chapter) use ($chapterId) {
                 return $chapter->id === (int)$chapterId;
@@ -46,10 +46,16 @@ class ChapterShowResource extends JsonResource
         });
 
         return [
-            'chapter_id' => $chapter->id,
-            'title' => $chapter->title,
-            'lessons' => $lessons,
+            'data' => [
+                'course_id' => $course->id,
+                'title' => $course->title,
+                'image' => $course->image, 
+                'chapters' => [
+                    'chapter_id' => $chapter->id,
+                    'title' => $chapter->title,
+                    'lessons' => $lessons,
+                ],
+            ],
         ];
     }
 }
-

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,24 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     // 受講生側API
-    Route::middleware('student')->group(function () {
+        Route::middleware('student')->group(function () {
+        Route::prefix('attendance')->group(function () {
+        Route::prefix('{attendance_id}')->group(function () {    
+        Route::prefix('course')->group(function () {
+            Route::get('index', 'Api\CourseController@index');
+            Route::get('/', 'Api\CourseController@show');
+            Route::prefix('{course_id}')->group(function () {
+                Route::get('progress', 'Api\CourseController@progress');
+                Route::prefix('chapter')->group(function () {
+                Route::prefix('{chapter_id}')->group(function () {   
+                    Route::get('/', 'Api\Student\AttendanceController@showChapter');
+                });
+                });
+            });
+        });
+        });
+        });
+    });
         // 受講生
         Route::prefix('student')->group(function () {
             Route::get('edit', 'Api\Student\StudentController@edit');
@@ -113,7 +130,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::post('/', 'Api\Instructor\InstructorController@update');
         });
     });
-});
+
 
 Route::prefix('v1')->group(function () {
     Route::post('student', 'Api\Student\StudentController@store');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-524

## 概要
- チャプター詳細情報取得API改修 ※受講生側（ファイル名・ディレクトリの位置・メソッド名などを変更）
- 受講側のChapterControllerをAttendanceControllerに変更
- メソッド名はshowChapterに変更
- app/Http/Controllers/Api/Student/AttendanceController.php に変更

## 動作確認
- postmanにてGETメソッドに `http://localhost:8080/api/v1/attendance/1/course/1/chapter/1`
　paramsのkeyにattendance_id,course_id,chapter_idを入力しValueにidを入力

## 確認してほしいこと
-  動作確認までしましたが他に変更点等細かい所を教えて欲しいです。
