### PR TITLE
チャプター詳細情報取得API改修 ※受講生側（nari)

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Api\Student;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\ChapterGetRequest;
-use App\Http\Resources\ChapterShowResource;
+use App\Http\Requests\Student\AttendanceShowChapterRequest;
+use App\Http\Resources\Student\AttendanceShowChapterResource;
 use App\Model\Attendance;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use App\Model\Chapter;
@@ -14,11 +14,11 @@ class AttendanceController extends Controller
     /**
      * チャプター詳細情報を取得
      *
-     * @param ChapterGetRequest $request
-     * @return ChapterShowResource
+     * @param AttendanceShowChapterRequest $request
+     * @return AttendanceShowChapterResource
      * @throws HttpException
      */
-    public function showChapter(ChapterGetRequest $request)
+    public function showChapter(AttendanceShowChapterRequest $request)
     {
         $attendance = Attendance::with([
                 'course.chapters.lessons',
@@ -33,6 +33,6 @@ class AttendanceController extends Controller
 
         $publicChapters = Chapter::extractPublicChapter($attendance->course->chapters);
         $attendance->course->chapters = $publicChapters;
-        return new ChapterShowResource($attendance, $request->chapter_id);
+        return new AttendanceShowChapterResource($attendance, $request->chapter_id);
     }
 }

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Api;
+namespace App\Http\Controllers\Api\Student;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ChapterGetRequest;
@@ -9,7 +9,7 @@ use App\Model\Attendance;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use App\Model\Chapter;
 
-class ChapterController extends Controller
+class AttendanceController extends Controller
 {
     /**
      * チャプター詳細情報を取得
@@ -18,7 +18,7 @@ class ChapterController extends Controller
      * @return ChapterShowResource
      * @throws HttpException
      */
-    public function show(ChapterGetRequest $request)
+    public function showChapter(ChapterGetRequest $request)
     {
         $attendance = Attendance::with([
                 'course.chapters.lessons',

--- a/app/Http/Requests/ChapterGetRequest.php
+++ b/app/Http/Requests/ChapterGetRequest.php
@@ -26,6 +26,7 @@ class ChapterGetRequest extends FormRequest
         return [
             'attendance_id' => ['required', 'integer'],
             'chapter_id' => ['required', 'integer'],
+            'course_id' => ['required', 'integer'],
         ];
     }
 }

--- a/app/Http/Requests/Student/AttendanceShowChapterRequest.php
+++ b/app/Http/Requests/Student/AttendanceShowChapterRequest.php
@@ -33,9 +33,9 @@ class AttendanceShowChapterRequest extends FormRequest
     public function rules()
     {
         return [
-            'attendance_id' => ['required', 'integer'],
-            'chapter_id' => ['required', 'integer'],
-            'course_id' => ['required', 'integer'],
+            'attendance_id' => ['required', 'integer', 'exists:attendances,id'],
+            'course_id' => ['required', 'integer', 'exists:courses,id'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id'],
         ];
     }
 }

--- a/app/Http/Requests/Student/AttendanceShowChapterRequest.php
+++ b/app/Http/Requests/Student/AttendanceShowChapterRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Student;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class ChapterGetRequest extends FormRequest
+class AttendanceShowChapterRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -14,6 +14,15 @@ class ChapterGetRequest extends FormRequest
     public function authorize()
     {
         return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'attendance_id' => $this->route('attendance_id'),
+            'chapter_id' => $this->route('chapter_id')
+        ]);
     }
 
     /**

--- a/app/Http/Resources/ChapterShowResource.php
+++ b/app/Http/Resources/ChapterShowResource.php
@@ -46,10 +46,18 @@ class ChapterShowResource extends JsonResource
         });
 
         return [
-            'chapter_id' => $chapter->id,
-            'title' => $chapter->title,
-            'lessons' => $lessons,
+            'data' => [
+                'course_id' => $this->resource->course->id,
+                'title' => $this->resource->course->title,
+                'image' => $this->resource->course->image, 
+                'chapters' => [
+                    'chapter_id' => $chapter->id,
+                    'title' => $chapter->title,
+                    'lessons' => $lessons,
+                ],
+            ],
         ];
     }
 }
+
 

--- a/app/Http/Resources/Student/AttendanceShowChapterResource.php
+++ b/app/Http/Resources/Student/AttendanceShowChapterResource.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Http\Resources;
+namespace App\Http\Resources\Student;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class ChapterShowResource extends JsonResource
+class AttendanceShowChapterResource extends JsonResource
 {
     private int $chapterId;
     public function __construct($attendances, $chapterId)

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,10 +31,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('index', 'Api\CourseController@index');
             Route::get('/', 'Api\CourseController@show');
             Route::get('{course_id}/progress', 'Api\CourseController@progress');
-            // 受講生-講座-チャプター
-            Route::prefix('chapter')->group(function () {
-                Route::get('/', 'Api\ChapterController@show');
-            });
+        });    
+        
+        // 受講生-講座-チャプター 
+        Route::prefix('attendance/{attendance_id}/course/{course_id}/chapter/{chapter_id}')->group(function () {
+            Route::get('/', 'Api\Student\AttendanceController@showChapter');
         });
 
         // 受講生-お知らせ


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-524

## 概要
- チャプター詳細情報取得API改修 ※受講生側（ファイル名・ディレクトリの位置・メソッド名などを変更）
- 受講側のChapterControllerをAttendanceControllerに変更
- メソッド名はshowChapterに変更
- app/Http/Controllers/Api/Student/AttendanceController.php に変更

## 動作確認
- postmanにてGETメソッドに `http://localhost:8080/api/v1/attendance/1/course/1/chapter/1`
　paramsのkeyにattendance_id,course_id,chapter_idを入力しValueにidを入力

## 確認してほしいこと
-  動作確認までしましたが他に変更点等細かい所を教えて欲しいです。

- 10/26追記
　①インデント崩れを意識して再度作成しましたので御確認宜しくお願いします。 
　②api.phpの36行目から

```
// 受講生-講座-チャプター 
        Route::prefix('attendance/{attendance_id}/course/{course_id}/chapter/{chapter_id}')->group(function () {
            Route::get('/', 'Api\Student\AttendanceController@showChapter');
        });
```
と記述しましたがこのような形で大丈夫でしょうか？周りのコードにも影響ないでしょうか？
一応動作確認しているのでOKだと思いますが細かい点等宜しくお願いします。

