### PR TITLE
生徒側の進捗率取得をログインしている生徒のidで取得できるように改修(DAIKI)

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -13,6 +13,7 @@ use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\LessonAttendance;
 use App\Model\Chapter;
+use Illuminate\Support\Facades\Auth;
 
 class CourseController extends Controller
 {
@@ -85,7 +86,7 @@ class CourseController extends Controller
     public function progress(CourseProgressRequest $request)
     {
         // TODO 認証ユーザーを一時的にid=1とする。
-        $authId = 1;
+        $authId = Auth::id();
         $attendance = Attendance::with([
             'course.chapters.lessons',
             'lessonAttendances'

--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -85,14 +85,13 @@ class CourseController extends Controller
      */
     public function progress(CourseProgressRequest $request)
     {
-        // TODO 認証ユーザーを一時的にid=1とする。
         $authId = Auth::id();
         $attendance = Attendance::with([
             'course.chapters.lessons',
             'lessonAttendances'
         ])
         ->where([
-            'course_id' => $request->route('course_id'),
+            'course_id' => $request->course_id,
             'student_id' => $authId
         ])
         ->firstOrFail();

--- a/app/Http/Requests/CourseProgressRequest.php
+++ b/app/Http/Requests/CourseProgressRequest.php
@@ -31,7 +31,7 @@ class CourseProgressRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer']
+            'course_id' => ['required', 'integer', 'exists:courses,id']
         ];
     }
 }

--- a/app/Http/Resources/CourseProgressResource.php
+++ b/app/Http/Resources/CourseProgressResource.php
@@ -18,9 +18,14 @@ class CourseProgressResource extends JsonResource
         $progressData = $this->resource['progressData'];
 
         return [
-            'course' =>[
-                'course_id' => $attendance->course_id,
+            'attendance' => [
+                'attendance_id' => $attendance->id,
                 'progress' => $attendance->progress,
+                'course' => [
+                    'course_id' => $attendance->course->id,
+                    'title' => $attendance->course->title,
+                    'image' => $attendance->course->image,
+                ]
             ],
             "number_of_completed_chapters" => $progressData['completedChaptersCount'],
             "number_of_total_chapters" => $progressData['totalChaptersCount'],


### PR DESCRIPTION
やったこと
・CourseController内でAuthクラスをuse
・Auth::id();でログインしている生徒のidを取得して変数$authIdに格納。

動作確認
Postmanで生徒1の情報でログイン後に以下URLをSend
http://localhost:8080/api/v1/course/1/progress

実行結果
{
"data": {
"course": {
"course_id": 1,
"progress": 10
},
"number_of_completed_chapters": 1,
"number_of_total_chapters": 3,
"number_of_completed_lessons": 2,
"number_of_total_lessons": 6,
"continue_lesson_id": 3
}
}

しかし、講座idを100にして試すとエラーとなるため、おそらくバリデーションが不足していると思われる。