### PR TITLE
Feature/makino/jka 526/set token to student authorization

### DIFF
--- a/app/Exceptions/DuplicateAuthorizationTokenException.php
+++ b/app/Exceptions/DuplicateAuthorizationTokenException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Model\Student;
+use Exception;
+
+class DuplicateAuthorizationTokenException extends Exception
+{
+    protected $message;
+
+    public function __construct(
+        $message,
+        Student $student
+    )
+    {
+        // メッセージにユーザー情報のemailを追加
+        $message = [
+            $message,
+            'email: ' . $student->email,
+        ];
+
+        $this->message = implode("\n", $message);
+    }
+}

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -102,6 +102,13 @@ class StudentController extends Controller
             return response()->json([
               "result" => false,
             ], 500);
+
+        } catch (DuplicateAuthorizationTokenException $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+            "result" => false,
+            ], 500);
         }
     }
 

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Exception;
 use App\Exceptions\DuplicateAuthorizationCodeException;
+use App\Exceptions\DuplicateAuthorizationTokenException;
 use App\Http\Requests\Student\StudentPostRequest;
 use App\Http\Resources\Student\StudentPostResource;
 use Illuminate\Support\Facades\Mail;
@@ -96,18 +97,18 @@ class StudentController extends Controller
               "result" => false,
             ], 500);
 
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            return response()->json([
-              "result" => false,
-            ], 500);
-
         } catch (DuplicateAuthorizationTokenException $e) {
             DB::rollBack();
             Log::error($e);
             return response()->json([
             "result" => false,
+            ], 500);
+
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+              "result" => false,
             ], 500);
         }
     }

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -68,7 +68,7 @@ class StudentController extends Controller
                 }
                 $token = Str::random(10);
                 if ($i === 5) {
-                    throw new DuplicateAuthorizationCodeException('Failed to generate unique authorization token.', $student);
+                    throw new DuplicateAuthorizationTokenException('Failed to generate unique authorization token.', $student);
                 }
             }
 

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -13,6 +13,7 @@ use App\Rules\UniqueEmailRule;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Exception;
 use App\Exceptions\DuplicateAuthorizationCodeException;
 use App\Http\Requests\Student\StudentPostRequest;
@@ -58,17 +59,30 @@ class StudentController extends Controller
                     throw new DuplicateAuthorizationCodeException('Failed to generate unique authorization code.', $student);
                 }
             }
-            
+
+            //トークンの生成
+            $token = Str::random(10);
+            for ($i = 1; $i <= 5; $i++) {
+                if (!StudentAuthorization::where('token', $token)->exists()) {
+                    break;
+                }
+                $token = Str::random(10);
+                if ($i === 5) {
+                    throw new DuplicateAuthorizationCodeException('Failed to generate unique authorization token.', $student);
+                }
+            }
+
             StudentAuthorization::create([
                 'student_id'  => $student->id,
                 'trial_count' => 0,
                 'code'        => $code,
+                'token'       => $token,
                 'expire_at'   => Carbon::now()->addMinutes(60),
             ]);
 
             DB::commit();
 
-            Mail::send(new AuthenticationConfirmationMail($student, $code));
+            Mail::send(new AuthenticationConfirmationMail($student, $code, $token));
 
             return response()->json([
                 'result'  => true,
@@ -101,7 +115,7 @@ class StudentController extends Controller
         $student = Student::findOrFail($request->user()->id);
         return new StudentEditResource($student);
     }
-    
+
     /**
      * 生徒情報更新API
      *
@@ -111,7 +125,7 @@ class StudentController extends Controller
     public function update(StudentPatchRequest $request)
     {
         try {
-            
+
             $student = Student::findOrFail($request->user()->id); 
 
             $request->validate([
@@ -127,8 +141,8 @@ class StudentController extends Controller
                 'email' => $request->email,
                 'purpose' => $request->purpose,
                 'birth_date' => $request->birth_date,
-                'sex' => $request->sex, 
-                'address' => $request->address,     
+                'sex' => $request->sex,
+                'address' => $request->address,
             ])
             ->save();
 
@@ -136,8 +150,8 @@ class StudentController extends Controller
                 'result' => true,
                 'data' => new StudentPatchResource($student)
             ]);
-        } catch (Exception $e) {            
-            Log::error($e);                    
+        } catch (Exception $e) {
+            Log::error($e);
             return response()->json([
                 'result' => false,
             ], 500);

--- a/app/Mail/AuthenticationConfirmationMail.php
+++ b/app/Mail/AuthenticationConfirmationMail.php
@@ -5,7 +5,6 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
 use App\Model\Student;
 
 class AuthenticationConfirmationMail extends Mailable

--- a/app/Mail/AuthenticationConfirmationMail.php
+++ b/app/Mail/AuthenticationConfirmationMail.php
@@ -5,6 +5,7 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 use App\Model\Student;
 
 class AuthenticationConfirmationMail extends Mailable
@@ -20,11 +21,15 @@ class AuthenticationConfirmationMail extends Mailable
      *
      * @return void
      */
-    public function __construct(Student $student, string $code)
+    public function __construct(
+        Student $student,
+        string $code,
+        string $token)
     {
         $this->email     = $student->email;
         $this->fullName  = $student->fullName;
         $this->code      = $code;
+        $this->token     = $token;
     }
 
     /**
@@ -37,6 +42,10 @@ class AuthenticationConfirmationMail extends Mailable
         return $this->to($this->email)
         ->subject('認証コードのお知らせです')
         ->view('AuthenticationConfirmationMail')
-        ->with(['fullName' => $this->fullName, 'code' => $this->code,]);
+        ->with([
+            'fullName' => $this->fullName,
+            'code' => $this->code,
+            'token' => $this->token,
+        ]);
     }
 }

--- a/app/Model/StudentAuthorization.php
+++ b/app/Model/StudentAuthorization.php
@@ -21,6 +21,7 @@ class StudentAuthorization extends Model
         'student_id',
         'trial_count',
         'code',
+        'token',
         'expire_at',
     ];
 

--- a/config/app.php
+++ b/config/app.php
@@ -177,6 +177,10 @@ return [
 
     ],
 
+
+    // Cache configuration
+    'allow_origin' => env('ALLOW_ORIGIN'),
+
     /*
     |--------------------------------------------------------------------------
     | Class Aliases

--- a/config/cache.php
+++ b/config/cache.php
@@ -87,9 +87,6 @@ return [
 
     ],
 
-    // Cache configuration
-    'allow_origin' => env('ALLOW_ORIGIN'),
-
     /*
     |--------------------------------------------------------------------------
     | Cache Key Prefix

--- a/config/cache.php
+++ b/config/cache.php
@@ -87,6 +87,9 @@ return [
 
     ],
 
+    // Cache configuration
+    'allow_origin' => env('ALLOW_ORIGIN'),
+
     /*
     |--------------------------------------------------------------------------
     | Cache Key Prefix

--- a/database/migrations/2023_09_23_105509_create_student_authorization.php
+++ b/database/migrations/2023_09_23_105509_create_student_authorization.php
@@ -17,8 +17,8 @@ class CreateStudentAuthorization extends Migration
             $table->bigIncrements('id');
             $table->bigInteger('student_id')->unsigned()->unique()->comment('仮登録生徒識別ID');
             $table->tinyInteger('trial_count')->unsigned()->comment('試行回数');
-            $table->string('code')->unique()->comment('認証コード');
-            $table->string('token')->unique()->comment('トークン');
+            $table->string('code', 4)->unique()->comment('認証コード');
+            $table->string('token', 10)->unique()->comment('トークン');
             $table->dateTime('expire_at')->comment('認証コード有効期間');
             $table->foreign('student_id')->references('id')->on('students');
         });

--- a/database/migrations/2023_09_23_105509_create_student_authorization.php
+++ b/database/migrations/2023_09_23_105509_create_student_authorization.php
@@ -18,6 +18,7 @@ class CreateStudentAuthorization extends Migration
             $table->bigInteger('student_id')->unsigned()->unique()->comment('仮登録生徒識別ID');
             $table->tinyInteger('trial_count')->unsigned()->comment('試行回数');
             $table->string('code')->unique()->comment('認証コード');
+            $table->string('token')->unique()->comment('トークン');
             $table->dateTime('expire_at')->comment('認証コード有効期間');
             $table->foreign('student_id')->references('id')->on('students');
         });

--- a/resources/views/AuthenticationConfirmationMail.blade.php
+++ b/resources/views/AuthenticationConfirmationMail.blade.php
@@ -7,6 +7,6 @@
     <p>{{ $fullName }}さん</p>
     <p>あなたの認証コードは{{ $code }}です。認証コード有効時間は１時間です。</p>
     <p>以下のURLにアクセスして、認証を行ってください。</p>
-    <p>{{ config('cache.allow_origin') }}/verification/{{ $token }}</p>
+    <p>{{ config('app.allow_origin') }}/verification/{{ $token }}</p>
 </body>
 </html>

--- a/resources/views/AuthenticationConfirmationMail.blade.php
+++ b/resources/views/AuthenticationConfirmationMail.blade.php
@@ -6,5 +6,7 @@
 <body>
     <p>{{ $fullName }}さん</p>
     <p>あなたの認証コードは{{ $code }}です。認証コード有効時間は１時間です。</p>
+    <p>以下のURLにアクセスして、認証を行ってください。</p>
+    <p>{{ config('cache.allow_origin') }}/verification/{{ $token }}</p>
 </body>
 </html>


### PR DESCRIPTION
「JKA-526：新規登録API改修 ※受講生側」のプルリクを作成しました。
よろしくお願いいたします。

### 確認事項
```
[POST] http://localhost:8080/api/v1/student

Body（Json）
{
  "nick_name": "mic",
  "last_name": "牧野",
  "first_name": "豊司",
  "occupation": "SE",
  "purpose": "スキルアップのため",
  "email": "xxxxxx@yyyyy.com",
  "birth_date": "19xx-03-04",
  "sex": "man",
  "address": "兵庫県"
}
```
をリクエスト力して
```
牧野 豊司さん

あなたの認証コードは2092です。認証コード有効時間は１時間です。

以下のURLにアクセスして、認証を行ってください。

http://localhost:3000/verification/bBzb4hRrow
```
のメールが飛ぶことを確認。
postmanの応答でも`"result": true`を受信。
