### PR TITLE
講師ログインユーザのIDを取得するよう変更

### DIFF
--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -10,6 +10,8 @@ use App\Http\Resources\Instructor\InstructorPatchResource;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
+
 
 
 class InstructorController extends Controller
@@ -72,11 +74,9 @@ class InstructorController extends Controller
      *
      * @return InstructorEditResource
      */
-    public function edit()
+    public function edit(Request $request)
     {   
-        // TODO 認証機能ができるまで、講師IDを固定値で設定
-        $instructorId = 1;
-        $instructor = Instructor::findOrFail($instructorId);
+        $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
         return new InstructorEditResource($instructor);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -10,8 +10,6 @@ use App\Http\Resources\Instructor\InstructorPatchResource;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Http\Request;
-
 
 
 class InstructorController extends Controller
@@ -74,7 +72,7 @@ class InstructorController extends Controller
      *
      * @return InstructorEditResource
      */
-    public function edit(Request $request)
+    public function edit()
     {   
         $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
         return new InstructorEditResource($instructor);

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述
         Route::prefix('instructor')->group(function () {
+            Route::get('edit', 'Api\Instructor\InstructorController@edit');
             Route::prefix('{instructor_id}')->group(function () {
                 Route::post('/', 'Api\Instructor\InstructorController@update');
             });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-500

## 概要
- プロフィール画像表示機能【講師情報編集画面】※講師側

## 動作確認手順
- ポストマンで講師ログイン
- POST => http://localhost:8080/login/instructor
実行、ログイン
-  GET => localhost:8080/api/v1/instructor/edit  リターン表示確認
 ```
{
    "data": {
        "id": 1,
        "nick_name": "ニックネーム",
        "last_name": "山田",
        "first_name": "太郎",
        "email": "test_instructor@example.com"
    }
}
```
- POST => http://localhost:8080/logout/instructor  実行、ログアウト
- GET => localhost:8080/api/v1/instructor/edit  リターン表示確認
```
 "message": "Trying to get property 'id' of non-object",
    "exception": "ErrorException",
    "file": "/var/www/html/laravelapp/app/Http/Controllers/Api/Instructor/InstructorController.php",
```