### PR TITLE
（講師側）Lesson の並べ替え用の数字をlessonsテーブルに登録できるように実装（DAIKI）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -29,12 +29,13 @@ class LessonController extends Controller
      */
     public function store(LessonStoreRequest $request)
     {
+        $maxOrder = Lesson::where('chapter_id', $request->input('chapter_id'))->max('order');
         try {
             $lesson = Lesson::create([
                 'chapter_id' => $request->input('chapter_id'),
                 'title' => $request->input('title'),
                 'status' => Lesson::STATUS_PRIVATE,
-                'order' => Lesson::where('chapter_id', $request->input('chapter_id'))->get()->count() + 1
+                'order' => (int)$maxOrder + 1,
             ]);
 
             return response()->json([
@@ -48,7 +49,7 @@ class LessonController extends Controller
             ], 500);
         }
     }
-
+    
     public function update(LessonUpdateRequest $request)
     {
         $user = Instructor::find(1);

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -34,6 +34,7 @@ class LessonController extends Controller
                 'chapter_id' => $request->input('chapter_id'),
                 'title' => $request->input('title'),
                 'status' => Lesson::STATUS_PRIVATE,
+                'order' => Lesson::where('chapter_id', $request->input('chapter_id'))->get()->count() + 1
             ]);
 
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -28,13 +28,15 @@ class LessonController extends Controller
      */
     public function store(LessonStoreRequest $request)
     {
-        $maxOrder = Lesson::where('chapter_id', $request->input('chapter_id'))->max('order');
+        $maxOrder = Lesson::where('chapter_id', $request->chapter_id)->max('order');
+
         try {
+
             $lesson = Lesson::create([
-                'chapter_id' => $request->input('chapter_id'),
-                'title' => $request->input('title'),
+                'chapter_id' => $request->chapter_id,
+                'title' => $request->title,
                 'status' => Lesson::STATUS_PRIVATE,
-                'order' => (int)$maxOrder + 1,
+                'order' => (int) $maxOrder + 1,
             ]);
 
             return response()->json([
@@ -48,7 +50,7 @@ class LessonController extends Controller
             ], 500);
         }
     }
-    
+
     public function update(LessonUpdateRequest $request)
     {
         $user = Instructor::find($request->user()->id);

--- a/app/Http/Requests/Instructor/LessonStoreRequest.php
+++ b/app/Http/Requests/Instructor/LessonStoreRequest.php
@@ -20,6 +20,7 @@ class LessonStoreRequest extends FormRequest
     {
         $this->merge([
             'chapter_id' => $this->route('chapter_id'),
+            'course_id' => $this->route('course_id'),
         ]);
     }
 
@@ -31,8 +32,9 @@ class LessonStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'chapter_id' => ['required','integer'],
-            'title' => ['required','string'],
+            'chapter_id' => ['required','integer', 'exists:chapters,id'],
+            'course_id' => ['required','integer', 'exists:courses,id'],
+            'title' => ['required','string', 'max:50'],
         ];
     }
 }

--- a/app/Http/Resources/Instructor/LessonStoreResource.php
+++ b/app/Http/Resources/Instructor/LessonStoreResource.php
@@ -17,7 +17,7 @@ class LessonStoreResource extends JsonResource
         return [
             'lesson_id' => $this->resource->id,
             'title' => $this->resource->title,
-            'order' => $this->order,
+            'order' => $this->resource->order,
         ];
     }
 }

--- a/app/Http/Resources/Instructor/LessonStoreResource.php
+++ b/app/Http/Resources/Instructor/LessonStoreResource.php
@@ -15,12 +15,9 @@ class LessonStoreResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'chapter_id' => $this->resource->chapter_id,
-            'lesson' => [
-                'lesson_id' => $this->resource->id,
-                'title' => $this->resource->title,
-                'order' => $this->order,
-            ],
+            'lesson_id' => $this->resource->id,
+            'title' => $this->resource->title,
+            'order' => $this->order,
         ];
     }
 }

--- a/app/Http/Resources/Instructor/LessonStoreResource.php
+++ b/app/Http/Resources/Instructor/LessonStoreResource.php
@@ -19,6 +19,7 @@ class LessonStoreResource extends JsonResource
             'lesson' => [
                 'lesson_id' => $this->resource->id,
                 'title' => $this->resource->title,
+                'order' => $this->order,
             ],
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -72,9 +72,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::delete('/', 'Api\Instructor\ChapterController@delete');
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
+                                Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::prefix('{lesson_id}')->group(function () {
-                                    Route::post('/', 'Api\Instructor\LessonController@store');
                                     Route::patch('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');
                                 });


### PR DESCRIPTION
やったこと
・lessonsテーブル内のorderカラムに入っている一番大きな数字に＋１した値をLesson作成時にテーブルに登録できるように実装。
・ルートパラメータで受け取った講座idをFormリクエストで受け取り、バリーデーションにかけれるように実装。