### PR TITLE
続きのレッスン取得機能のためにchapterIdのレスポンスを返すよう変更【チャプター&レッスン一覧画面】※受講生側（DAIKI）

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Student;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Model\Attendance;
 use App\Http\Requests\Student\AttendanceCourseProgressRequest;
 use App\Http\Resources\Student\AttendanceCourseProgressResource;
@@ -125,6 +124,10 @@ class AttendanceController extends Controller
             'lesson_id' => null,
         ];
         $attendance->course->chapters->each(function ($chapter) use ($attendance, &$youngestUnCompletedLesson) {
+            if ($youngestUnCompletedLesson['lesson_id'] !== null) {
+                return;
+            }
+
             $chapter->lessons->each(function ($lesson) use ($attendance, &$youngestUnCompletedLesson, $chapter) {
                 $lessonAttendance = $attendance->lessonAttendances->where('lesson_id', $lesson->id)->first();
                 if ($lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
@@ -137,9 +140,6 @@ class AttendanceController extends Controller
                     }
                 }
             });
-            if ($youngestUnCompletedLesson['lesson_id'] !== null) {
-                return;
-            }
         });
         if ($youngestUnCompletedLesson['lesson_id'] === null) {
             return null;

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -128,14 +128,16 @@ class AttendanceController extends Controller
             $chapter->lessons->each(function ($lesson) use ($attendance, &$youngestUnCompletedLesson, $chapter) {
                 $lessonAttendance = $attendance->lessonAttendances->where('lesson_id', $lesson->id)->first();
                 if ($lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
-                    if ($youngestUnCompletedLesson['lesson_id'] === null && $youngestUnCompletedLesson['chapter_id'] === null) {
-                        $youngestUnCompletedLesson['lesson_id'] = $lesson->id;
-                        $youngestUnCompletedLesson['chapter_id'] = $chapter->id;
+                    if ($youngestUnCompletedLesson['lesson_id'] === null) {
+                        $youngestUnCompletedLesson = [
+                            'lesson_id' => $lesson->id,
+                            'chapter_id' => $chapter->id,
+                        ];
                         return;
                     }
                 }
             });
-            if ($youngestUnCompletedLesson['lesson_id'] !== null && $youngestUnCompletedLesson['chapter_id'] !== null) {
+            if ($youngestUnCompletedLesson['lesson_id'] !== null) {
                 return;
             }
         });

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -39,7 +39,7 @@ class AttendanceController extends Controller
             'totalChaptersCount' => $this->getTotalChaptersCount($attendance),
             'completedLessonsCount' => $this->getCompletedLessonsCount($attendance),
             'totalLessonsCount' => $this->getTotalLessonsCount($attendance),
-            'youngestUnCompletedLessonId' => $this->getYoungestUnCompletedLessonId($attendance)
+            'youngestUnCompletedLesson' => $this->getYoungestUnCompletedLesson($attendance)
         ];
 
         return new AttendanceCourseProgressResource([
@@ -115,31 +115,33 @@ class AttendanceController extends Controller
      * 続きのレッスンIDと、それを含むチャプターのIDを取得する
      *
      * @param Attendance $attendance
-     * @return array $continueLesson
+     * @return array | null
      */
-    private function getYoungestUnCompletedLessonId($attendance)
+    private function getYoungestUnCompletedLesson($attendance)
     {
         // IDが最も若い未完了のチャプターの内、IDが最も若い未完了のレッスン
-        $youngestUnCompletedLessonId = null;
-        $youngestUnCompletedChapterId = null;
-        $attendance->course->chapters->each(function ($chapter) use ($attendance, &$youngestUnCompletedLessonId, &$youngestUnCompletedChapterId) {
-            $chapter->lessons->each(function ($lesson) use ($attendance, &$youngestUnCompletedLessonId, $chapter, &$youngestUnCompletedChapterId) {
+        $youngestUnCompletedLesson = [
+            'chapter_id' => null,
+            'lesson_id' => null,
+        ];
+        $attendance->course->chapters->each(function ($chapter) use ($attendance, &$youngestUnCompletedLesson) {
+            $chapter->lessons->each(function ($lesson) use ($attendance, &$youngestUnCompletedLesson, $chapter) {
                 $lessonAttendance = $attendance->lessonAttendances->where('lesson_id', $lesson->id)->first();
                 if ($lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
-                    if ($youngestUnCompletedLessonId === null) {
-                        $youngestUnCompletedLessonId = $lesson->id;
-                        $youngestUnCompletedChapterId = $chapter->id;
+                    if ($youngestUnCompletedLesson['lesson_id'] === null && $youngestUnCompletedLesson['chapter_id'] === null) {
+                        $youngestUnCompletedLesson['lesson_id'] = $lesson->id;
+                        $youngestUnCompletedLesson['chapter_id'] = $chapter->id;
                         return;
-                    }
-                    if ($youngestUnCompletedLessonId > $lesson->id) {
-                        $youngestUnCompletedLessonId = $lesson->id;
                     }
                 }
             });
+            if ($youngestUnCompletedLesson['lesson_id'] !== null && $youngestUnCompletedLesson['chapter_id'] !== null) {
+                return;
+            }
         });
-        return $continueLesson = [
-            'chapter_id' => $youngestUnCompletedChapterId,
-            'lesson_id' => $youngestUnCompletedLessonId,
-        ];
+        if ($youngestUnCompletedLesson['lesson_id'] === null) {
+            return null;
+        }
+        return $youngestUnCompletedLesson;
     }
 }

--- a/app/Http/Resources/Student/AttendanceCourseProgressResource.php
+++ b/app/Http/Resources/Student/AttendanceCourseProgressResource.php
@@ -30,7 +30,7 @@ class AttendanceCourseProgressResource extends JsonResource
             "number_of_total_chapters" => $progressData['totalChaptersCount'],
             "number_of_completed_lessons" => $progressData['completedLessonsCount'],
             "number_of_total_lessons" => $progressData['totalLessonsCount'],
-            "continue_lesson" => $progressData['youngestUnCompletedLessonId'],
+            "continue_lesson" => $progressData['youngestUnCompletedLesson'],
         ];
     }
 }

--- a/app/Http/Resources/Student/AttendanceCourseProgressResource.php
+++ b/app/Http/Resources/Student/AttendanceCourseProgressResource.php
@@ -16,7 +16,6 @@ class AttendanceCourseProgressResource extends JsonResource
     {
         $attendance = $this->resource['attendance'];
         $progressData = $this->resource['progressData'];
-
         return [
             'attendance' => [
                 'attendance_id' => $attendance->id,
@@ -31,7 +30,7 @@ class AttendanceCourseProgressResource extends JsonResource
             "number_of_total_chapters" => $progressData['totalChaptersCount'],
             "number_of_completed_lessons" => $progressData['completedLessonsCount'],
             "number_of_total_lessons" => $progressData['totalLessonsCount'],
-            "continue_lesson_id" => $progressData['youngestUnCompletedLessonId'],
+            "continue_lesson" => $progressData['youngestUnCompletedLessonId'],
         ];
     }
 }


### PR DESCRIPTION
やったこと
未完了かつ、Lessonidが一番小さいLessonidと一緒に、それを含むチャプターidも返せるように実装。
progressメソッドのResourceクラスの戻り値を微修正。

確認方法
Postmanで受講生1のデータでログインし、以下URLをSend。
http://localhost:8080/api/v1/attendance/1/progress

実行結果
{
    "data": {
        "attendance": {
            "attendance_id": 1,
            "progress": 10,
            "course": {
                "course_id": 1,
                "title": "PHP入門講座",
                "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png"
            }
        },
        "number_of_completed_chapters": 1,
        "number_of_total_chapters": 3,
        "number_of_completed_lessons": 2,
        "number_of_total_lessons": 6,
        "continue_lesson": {
            "chapter_id": 2,
            "lesson_id": 3
        }
    }
}
