### PR TITLE
バックエンド修正→認証者とおしらせ作成者の認可処理とバリデーション修正（DAIKI）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -41,7 +41,15 @@ class NotificationController extends Controller
      */
     public function show(NotificationShowRequest $request)
     {
+        $loginId = Auth::guard('instructor')->user()->id;
         $notification = Notification::findOrFail($request->notification_id);
+
+        if ($loginId !== $notification->instructor_id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Not authorized',
+            ], 403);
+        }
 
         return new NotificationShowResource($notification);
     }
@@ -76,7 +84,16 @@ class NotificationController extends Controller
      * @return \Illuminate\Http\JsonResponse
      */
     public function update(NotificationUpdateRequest $request) {
+        $loginId = Auth::guard('instructor')->user()->id;
         $notification = Notification::findOrFail($request->notification_id);
+
+        if ($loginId !== $notification->instructor_id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Not authorized',
+            ], 403);
+        }
+
         $notification->fill([
             'type'  => $request->type,
             'start_date' => $request->start_date,

--- a/app/Http/Requests/Instructor/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Instructor/NotificationUpdateRequest.php
@@ -31,7 +31,7 @@ class NotificationUpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'notification_id' => ['required', 'integer'],
+            'notification_id' => ['required', 'integer', 'exists:notifications,id'],
             'type'            => ['required', new NotificationUpdateStatusRule()],
             'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
             'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],

--- a/routes/api.php
+++ b/routes/api.php
@@ -126,6 +126,14 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('{instructor_id}')->group(function () {
                 Route::post('/', 'Api\Instructor\InstructorController@update');
             });
+
+            //講師-お知らせ
+            Route::prefix('notification')->group(function () {
+                Route::prefix('{notification_id}')->group(function () {
+                    Route::get('/', 'Api\Instructor\NotificationController@show');
+                    Route::patch('/', 'Api\Instructor\NotificationController@update');
+                });
+            });
         });
     });
 });
@@ -142,9 +150,5 @@ Route::prefix('instructor')->group(function () {
     Route::get('edit', 'Api\Instructor\InstructorController@edit');
     Route::prefix('notification')->group(function () {
         Route::get('index', 'Api\Instructor\NotificationController@index');
-        Route::prefix('{notification_id}')->group(function () {
-            Route::get('/', 'Api\Instructor\NotificationController@show');
-            Route::patch('/', 'Api\Instructor\NotificationController@update');
-        });
     });
 });


### PR DESCRIPTION
やったこと
・showメソッドに認可機能を実装。
・updateメソッドに認可機能と、ルートパラメータで受け取るnotifications_idの存在チェックのバリデーションを実装。

確認方法
Postmanで下記URLをSend。

Patch
http://localhost:8080/api/v1/instructor/notification/100（存在しないnotification_id）
http://localhost:8080/api/v1/instructor/notification/2(講師1でログインしているのに講師2のお知らせを更新)

Get
http://localhost:8080/api/v1/instructor/notification/2(講師1でログインしているのに講師2のお知らせを開く)



