### PR TITLE
JKA-549：JKA-536：1.講座一覧画面（講師側）（まきの）

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+use App\Http\Resources\Manager\CourseIndexResource;
+use App\Http\Controllers\Controller;
+
+use App\Model\Course;
+use App\Model\Instructor;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+
+class CourseController extends Controller
+{
+    /**
+     * 講師側マネージャ講座一覧取得API
+     *
+     * @return CourseIndexResource
+     */
+    public function index(Request $request)
+    {
+        $instructorId = $request->user()->id;
+
+        // 配下のinstructor情報を取得
+        $instructor = Instructor::with('managings')->find($instructorId);
+
+        $managingIds = $instructor->managings->pluck('id')->toArray();
+        $managingIds[] = $instructorId;
+
+        // 自分と配下instructorのコース情報を取得
+        $courses = Course::with('instructor')
+                    ->whereIn('instructor_id', $managingIds)
+                    ->get();
+
+        return new CourseIndexResource($courses);
+    }
+
+}

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -8,7 +8,6 @@ use App\Model\Course;
 use App\Model\Instructor;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 
 
 class CourseController extends Controller
@@ -23,14 +22,14 @@ class CourseController extends Controller
         $instructorId = $request->user()->id;
 
         // 配下のinstructor情報を取得
-        $instructor = Instructor::with('managings')->find($instructorId);
+        $manager = Instructor::with('managings')->find($instructorId);
 
-        $managingIds = $instructor->managings->pluck('id')->toArray();
-        $managingIds[] = $instructorId;
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
 
         // 自分と配下instructorのコース情報を取得
         $courses = Course::with('instructor')
-                    ->whereIn('instructor_id', $managingIds)
+                    ->whereIn('instructor_id', $instructorIds)
                     ->get();
 
         return new CourseIndexResource($courses);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -66,6 +66,7 @@ class Kernel extends HttpKernel
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'student' => \App\Http\Middleware\EnsureIsStudent::class,
         'instructor' => \App\Http\Middleware\EnsureIsInstructor::class,
+        'manager' => \App\Http\Middleware\EnsureIsManager::class,
     ];
 
     /**

--- a/app/Http/Middleware/EnsureIsManager.php
+++ b/app/Http/Middleware/EnsureIsManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use App\Model\Instructor;
+use Illuminate\Support\Facades\Log;
+
+class EnsureIsManager
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $instructor = Instructor::find(Auth::guard('instructor')->id());
+        if ($instructor->type !== 'manager') {
+            return new JsonResponse([
+                'message' => 'Forbidden, not allowed to use manager api.'
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureIsManager.php
+++ b/app/Http/Middleware/EnsureIsManager.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use App\Model\Instructor;
-use Illuminate\Support\Facades\Log;
 
 class EnsureIsManager
 {
@@ -19,9 +18,8 @@ class EnsureIsManager
      */
     public function handle($request, Closure $next)
     {
-
         $instructor = Instructor::find(Auth::guard('instructor')->id());
-        if ($instructor->type !== 'manager') {
+        if ($instructor->type !== Instructor::TYPE_MANAGER) {
             return new JsonResponse([
                 'message' => 'Forbidden, not allowed to use manager api.'
             ], 403);

--- a/app/Http/Requests/Instructor/InstructorPatchRequest.php
+++ b/app/Http/Requests/Instructor/InstructorPatchRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Instructor;
 
+use App\Rules\InstructorTypeRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class InstructorPatchRequest extends FormRequest

--- a/app/Http/Requests/Instructor/InstructorPatchRequest.php
+++ b/app/Http/Requests/Instructor/InstructorPatchRequest.php
@@ -37,7 +37,7 @@ class InstructorPatchRequest extends FormRequest
             'email' => ['required', 'email'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id'],
             'profile_image' => ['mimes:jpg,png', 'max:2048'],
-            'type' => ['required', 'string', 'max:30'],
+            'type' => ['required', 'string', 'max:30', new InstructorTypeRule()]
         ];
     }
 }

--- a/app/Http/Resources/Instructor/InstructorEditResource.php
+++ b/app/Http/Resources/Instructor/InstructorEditResource.php
@@ -21,6 +21,7 @@ class InstructorEditResource extends JsonResource
             'first_name' => $this->resource->first_name,
             'email' => $this->resource->email,
             'profile_image' => $this->resource->profile_image,
+            'type' => $this->resource->type,
         ];
     }
 }

--- a/app/Http/Resources/Instructor/InstructorPatchResource.php
+++ b/app/Http/Resources/Instructor/InstructorPatchResource.php
@@ -20,6 +20,7 @@ class InstructorPatchResource extends JsonResource
             'first_name' => $this->first_name,
             'email' => $this->email,
             'profile_image' => $this->profile_image,
+            'type' => $this->type,
         ];
     }
 }

--- a/app/Http/Resources/Manager/CourseIndexResource.php
+++ b/app/Http/Resources/Manager/CourseIndexResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CourseIndexResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->resource->map(function($course) {
+            return [
+                "course_id" => $course->id,
+                "title" => $course->title,
+                "image" => $course->image,
+                "status" => $course->status,
+                "instructor" => [
+                  "instructor_id" => $course->instructor_id,
+                  "nick_name" => $course->instructor->nick_name,
+                  "last_name" => $course->instructor->last_name,
+                  "first_name" => $course->instructor->first_name,
+                  "email" => $course->instructor->email,
+                  "profile_image" => $course->instructor->profile_image,
+                ]
+            ];
+        });
+    }
+}

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -13,6 +13,11 @@ class Instructor extends Authenticatable
      */
     protected $table = 'instructors';
 
+
+    // ステータス定数
+    const TYPE_MANAGER = 'manager';
+    const TYPE_INSTRUCTOR = 'instructor';
+
     /**
      * @var array<string>
      */
@@ -22,6 +27,7 @@ class Instructor extends Authenticatable
         'first_name',
         'email',
         'profile_image',
+        'type',
     ];
 
     /**
@@ -44,5 +50,10 @@ class Instructor extends Authenticatable
     {
         // public/を削除
         return str_replace('public/', '', $filePath);
+    }
+
+    public function managings()
+    {
+        return $this->belongsToMany('App\Model\Instructor', 'manage_instructors', 'manager_id', 'instructor_id');
     }
 }

--- a/app/Rules/InstructorTypeRule.php
+++ b/app/Rules/InstructorTypeRule.php
@@ -3,7 +3,7 @@
 namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
-use App\Model\Course;
+use App\Model\Instructor;
 
 class InstructorTypeRule implements Rule
 {
@@ -20,8 +20,8 @@ class InstructorTypeRule implements Rule
             in_array(
                 $value,
                 [
-                Course::TYPE_MANAGER,
-                Course::TYPE_INSTRUCTOR
+                Instructor::TYPE_MANAGER,
+                Instructor::TYPE_INSTRUCTOR
                 ],
                 true
             )

--- a/app/Rules/InstructorTypeRule.php
+++ b/app/Rules/InstructorTypeRule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Model\Course;
+
+class InstructorTypeRule implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (
+            in_array(
+                $value,
+                [
+                Course::TYPE_MANAGER,
+                Course::TYPE_INSTRUCTOR
+                ],
+                true
+            )
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'Invalid Type.';
+    }
+} 

--- a/database/migrations/2022_10_19_215031_create_courses_table.php
+++ b/database/migrations/2022_10_19_215031_create_courses_table.php
@@ -22,6 +22,7 @@ class CreateCoursesTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
+            $table->foreign('instructor_id')->references('id')->on('instructors');
         });
     }
 

--- a/database/migrations/2023_11_11_214009_create_manage_instructors_table.php
+++ b/database/migrations/2023_11_11_214009_create_manage_instructors_table.php
@@ -16,12 +16,12 @@ class CreateManageInstructorsTable extends Migration
         Schema::create('manage_instructors', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('instructor_id')->unsigned()->comment('通常講師');
-            $table->bigInteger('managerid')->unsigned()->comment('マネージャ');
+            $table->bigInteger('manager_id')->unsigned()->comment('マネージャ');
             $table->datetime('created_at');
             $table->datetime('updated_at');
             $table->softDeletes();
             $table->foreign('instructor_id')->references('id')->on('instructors');
-            $table->foreign('managerid')->references('id')->on('instructors');
+            $table->foreign('manager_id')->references('id')->on('instructors');
         });
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -134,12 +134,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             });
         });
 
-        // 講師側マネージャAPI
+        // マネージャーAPI
         Route::middleware('manager')->group(function () {
-            // TODO 講師側マネージャAPIはここに記述
+            // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
 
-                // 講師-講座
+                // マネージャー講師-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -133,8 +133,22 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', 'Api\Instructor\NotificationController@index');
             });
         });
+
+        // 講師側マネージャAPI
+        Route::middleware('manager')->group(function () {
+            // TODO 講師側マネージャAPIはここに記述
+            Route::prefix('manager')->group(function () {
+
+                // 講師-講座
+                Route::prefix('course')->group(function () {
+                    Route::get('index', 'Api\Manager\CourseController@index');
+                });
+            });
+        });
+
     });
 });
+
 
 Route::prefix('v1')->group(function () {
     Route::prefix('student')->group(function () {


### PR DESCRIPTION
マネージャによる講座一覧取得機能を作成しましたので、プルリクさせていただきます。
ご確認をお願い致します。

## 事前準備
manage_instructorsテーブルにseederは作成していないため、確認するにあたり、
Adminerを使って手動で図のように設定しました。
![image](https://github.com/yukihiroLaravel/juko_laravel/assets/115435795/b1e8c6dd-e8a6-4c00-9912-a46b731b898e)

## 確認したこと
①instructor_id = 1(manager) でログインして、自分と配下のinstructorの講座一覧を取得できることを確認
②instructor_id = 2(instructor：1の配下) でログインして、forbiddenが返ることを確認
③instructor_id = 3(manager) を作成し、course の一つを instructor_id = 3 のコースに変更し、再度①を実行し、instructor_id = 3となったコース情報以外を取得できることを確認
④instructor_id = 3(manager：配下なし)でログインし、自分のコース情報のみ取得できることを確認。

## 確認事項
今日のMTGで、type の追加に関連するところを修正しておきましたと言いましたが、その修正に対する試験ができない（やり方をわかっていない）ことに気が付きました。
一旦プルリクに入ってしまっているのでご確認願います。外した方がよければ外します。

app/Http/Requests/Instructor/InstructorPatchRequest.php
app/Http/Resources/Instructor/InstructorEditResource.php
app/Http/Resources/Instructor/InstructorPatchResource.php