### PR TITLE
空の配列を返すルーターとコントローラ実装

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -91,6 +91,10 @@ class AttendanceController extends Controller
         ]);
     }
 
+    public function delete() {
+        return response()->json([]);
+    }
+
     /**
      * 受講生ログイン率取得API
      *

--- a/routes/api.php
+++ b/routes/api.php
@@ -124,9 +124,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('student')->group(function () {
                 Route::get('{student_id}', 'Api\Instructor\StudentController@show');
                 Route::post('/', 'Api\Instructor\StudentController@store');
-            // 受講生削除
-                Route::delete('delete/{id}', 'Api\Instructor\StudentController@delete')->name('student.delete');
-            });
 
             // 講師
             Route::prefix('{instructor_id}')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -117,12 +117,15 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-受講
             Route::prefix('attendance')->group(function () {
                 Route::post('/', 'Api\Instructor\AttendanceController@store');
+                Route::delete('{attendance_id}', 'Api\Instructor\AttendanceController@delete');
             });
 
             // 講師-生徒
             Route::prefix('student')->group(function () {
                 Route::get('{student_id}', 'Api\Instructor\StudentController@show');
                 Route::post('/', 'Api\Instructor\StudentController@store');
+            // 受講生削除
+                Route::delete('delete/{id}', 'Api\Instructor\StudentController@delete')->name('student.delete');
             });
 
             // 講師

--- a/routes/api.php
+++ b/routes/api.php
@@ -124,7 +124,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('student')->group(function () {
                 Route::get('{student_id}', 'Api\Instructor\StudentController@show');
                 Route::post('/', 'Api\Instructor\StudentController@store');
-
+            });
+            
             // 講師
             Route::prefix('{instructor_id}')->group(function () {
                 Route::post('/', 'Api\Instructor\InstructorController@update');


### PR DESCRIPTION
## 概要
- 「この受講生を講座から退会」させるAPI新規作成【受講生詳細画面】※講師側
空の配列を返すようルーターとコントローラー実装しました。

## 動作確認手順
- postmanを使ってhttp://localhost:8080/api/v1/instructor/attendance/1
にアクセス。
空の配列が返ってくることを確認しました。
