### PR TITLE
JKA-550（JKA-536-2）2.講座一覧画面（講師側）のステータス「一括変更」処理を追加（まきの）

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api\Manager;
 use App\Http\Resources\Manager\CourseIndexResource;
-use App\Http\Requests\Instructor\CoursePutStatusRequest;
+use App\Http\Requests\Manager\CoursePutStatusRequest;
 use App\Http\Controllers\Controller;
 
 use App\Model\Course;

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Manager;
 use App\Http\Resources\Manager\CourseIndexResource;
+use App\Http\Requests\Instructor\CoursePutStatusRequest;
 use App\Http\Controllers\Controller;
 
 use App\Model\Course;
@@ -33,6 +34,28 @@ class CourseController extends Controller
                     ->get();
 
         return new CourseIndexResource($courses);
+    }
+
+    /**
+     * 講師側マネージャ講座ステータス一覧更新API
+     *
+     * @return JsonResponse
+     */
+    public function status(CoursePutStatusRequest $request)
+    {
+        $instructorId = $request->user()->id;
+
+        // 配下のinstructor情報を取得
+        $instructor = Instructor::with('managings')->find($instructorId);
+
+        $managingIds = $instructor->managings->pluck('id')->toArray();
+        $managingIds[] = $instructorId;
+
+        // 自分と配下instructorのコースのステータスを一括更新
+        Course::whereIn('instructor_id', $managingIds)->update(['status' => $request->status]);
+        return response()->json([
+            'result' => 'true'
+        ]);
     }
 
 }

--- a/app/Http/Requests/Manager/CoursePutStatusRequest.php
+++ b/app/Http/Requests/Manager/CoursePutStatusRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\CourseStatusRule;
+
+class CoursePutStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return True;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'status' => ['required', 'string', new CourseStatusRule()],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -142,6 +142,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー講師-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
+                    Route::put('status', 'Api\Manager\CourseController@status');
                 });
             });
         });


### PR DESCRIPTION
表題の件を作成しましたのでプルリクします。
よろしくお願いいたします。

## 確認したこと
(1) instructor_id=1でログインして、自分と配下のinstructorのコースのstatusが一括更新されること。
　その時に、配下でないinstructorのコースは更新されていないこと。
(2) instructor_id=2でログインして、/api/v1/manager/course/status の応答が Forbiddenになること
(3) instructor_id=3（managerで配下instructorはいない）でログインして、自分のコースだけステータスが更新されること

## 前提条件
- manage_instructorsテーブルで instructor_id=2 を Instructor_id=1の配下にしている。
- instructor_id=3をSeederで追加し、courseの一つをinstructor_id=3の講座として試験を実施。