### PR TITLE
#567 空の配列を返すルーターとコントローラ作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -188,4 +188,13 @@ class CourseController extends Controller
 
         }
     }
+    
+    /**
+     * マネージャ講座情報編集API
+     *
+     */
+    public function edit()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -145,7 +145,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::put('status', 'Api\Manager\CourseController@status');
                     Route::prefix('{course_id}')->group(function () {
                         Route::post('/', 'Api\Manager\CourseController@update');
-                        Route::delete('/', 'Api\Manager\CourseController@delete');
+                        Route::delete('/', 'Api\Manager\CourseController@delete'); 
+                        Route::get('edit', 'Api\Manager\CourseController@edit');
                     });
                 });
             });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-565
## 概要
- 新権限マネージャー設立による配下のinstructorの作成した講座の編集情報を取得できるAPI作成における子課題
　１.空の配列を返すルーターとコントローラーの作成
## 動作確認手順
- ルーター、コントローラー作成後、postmanによる確認にて空の配列が返ってきたことを確認
## 考慮して欲しいこと
- 特になし
## 確認して欲しいこと
- ルーターの記載場所はここ（update,deleteの下）で合っているか確認していただきたいです。
