### PR TITLE
＃541 講師が作成した講座に紐づく受講生のみ取得する改修（ごめ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -13,6 +13,7 @@ use App\Http\Resources\Instructor\StudentShowResource;
 use App\Http\Requests\Instructor\StudentStoreRequest;
 use App\Http\Resources\Instructor\StudentStoreResource;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
 
 class StudentController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -47,8 +47,25 @@ class StudentController extends Controller
      */
     public function show(StudentShowRequest $request)
     {
-        // TODO 講師が作成した講座に紐づく受講生のみ取得
-        $student = Student::with(['attendances.course.chapters.lessons.lessonAttendances'])->findOrFail($request->student_id);
+        // 認証された講師のIDを取得
+        $instructorCourseIds = Auth::guard('instructor')->user()->id;
+
+        // 認証された講師が作成した講座のIDを取得
+        $courseIds = Course::where('instructor_id', $instructorCourseIds)->pluck('id');
+
+        // リクエストされた受講生を取得
+        $student = Student::with(['attendances.course.chapters.lessons.lessonAttendances'])
+                            ->findOrFail($request->student_id);
+
+        // 受講生が講師の講座に所属しているか確認
+        $studentCourseIds = $student->attendances->pluck('course_id')->unique();
+        if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Not authorized to access this student.'
+            ], 403);
+        }
+
         return new StudentShowResource($student);
     }
 

--- a/app/Http/Resources/Instructor/StudentShowResource.php
+++ b/app/Http/Resources/Instructor/StudentShowResource.php
@@ -17,46 +17,44 @@ class StudentShowResource extends JsonResource
         $student = $this->resource; 
         
         return [
-            'student' => [
-                'given_name_by_instructor' => $student->given_name_by_instructor,
-                'student_id' => $student->id,
-                'nick_name' => $student->nick_name,
-                'last_name' => $student->last_name,
-                'first_name' => $student->first_name,
-                'occupation' => $student->occupation,
-                'email' => $student->email,
-                'purpose' => $student->purpose,
-                'birth_date' => $student->birth_date->format('Y/m/d'),
-                'sex' => $student->sex,
-                'address' => $student->address,
-                'created_at' => $student->created_at->format('Y/m/d'),
-                'last_login_at' => $student->last_login_at->format('Y/m/d'),
-                'courses' => $student->attendances->map(function ($attendance) {
-                    return [
-                        'course_id' => $attendance->course->id,
-                        'image' => $attendance->course->image,
-                        'title' => $attendance->course->title,
-                        'progress' => $attendance->progress,
-                        'chapters' => $attendance->course->chapters->map(function ($chapter) {
-                            return [
-                                'chapter_id' => $chapter->id,
-                                'title' => $chapter->title,
-                                'lessons' => $chapter->lessons->map(function ($lesson) {
-                                    return [
-                                        'lesson_id' => $lesson->id,
-                                        'lesson_attendance' => $lesson->lessonAttendances->map(function ($attendance) {
-                                            return [
-                                                'lesson_attendance_id' => $attendance->id,
-                                                'status' => $attendance->status,
-                                            ];
-                                        }),
-                                    ];
-                                }),
-                            ];
-                        }),
-                    ];
-                }),
-            ],
-        ];
+            'given_name_by_instructor' => $student->given_name_by_instructor,
+            'student_id' => $student->id,
+            'nick_name' => $student->nick_name,
+            'last_name' => $student->last_name,
+            'first_name' => $student->first_name,
+            'occupation' => $student->occupation,
+            'email' => $student->email,
+            'purpose' => $student->purpose,
+            'birth_date' => $student->birth_date->format('Y/m/d'),
+            'sex' => $student->sex,
+            'address' => $student->address,
+            'created_at' => $student->created_at->format('Y/m/d'),
+            'last_login_at' => $student->last_login_at->format('Y/m/d'),
+            'courses' => $student->attendances->map(function ($attendance) {
+                return [
+                    'course_id' => $attendance->course->id,
+                    'image' => $attendance->course->image,
+                    'title' => $attendance->course->title,
+                    'progress' => $attendance->progress,
+                    'chapters' => $attendance->course->chapters->map(function ($chapter) {
+                        return [
+                            'chapter_id' => $chapter->id,
+                            'title' => $chapter->title,
+                            'lessons' => $chapter->lessons->map(function ($lesson) {
+                                return [
+                                    'lesson_id' => $lesson->id,
+                                    'lesson_attendance' => $lesson->lessonAttendances->map(function ($attendance) {
+                                        return [
+                                            'lesson_attendance_id' => $attendance->id,
+                                            'status' => $attendance->status,
+                                        ];
+                                    }),
+                                ];
+                            }),
+                        ];
+                    }),
+                ];
+            }),
+        ],
     }
 }

--- a/app/Http/Resources/Instructor/StudentShowResource.php
+++ b/app/Http/Resources/Instructor/StudentShowResource.php
@@ -55,6 +55,6 @@ class StudentShowResource extends JsonResource
                     }),
                 ];
             }),
-        ],
+        ];
     }
 }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-541

## 概要
- ログイン中の講師の講座に紐づく受講生のみ取得するように変更【受講生詳細画面】※講師側

## 動作確認手順
- ポストマンで講師ログイン
- Postmanによる認証検証方法(https://unleashed-store-3db.notion.site/Postman-4aa9fc1b82e64e4ca1b75d29259f0cc9)
- POST => http://localhost:8080/login/instructor
実行、ログイン
-  GET => localhost:8080/api/v1/instructor/student/1
リターン表示確認

## 考慮して欲しいこと
特にありません。


## 確認して欲しいこと
確認方法があっているか確認よろしくお願いします。


検証①
講師（instructor_id）１の山田太郎さんでログインした場合

山田太郎さんが持つコースは１.5の(①PHP入門講座,⑤Python入門講座）

①PHP入門講座⑤Python入門講座に出席する生徒は(student_id)1.2.6.7のみ

なので、山田太郎さんの講座で見れるのは(student_id)1.2.6.7のみであることを確認

検証②
それ以外の
生徒（student_id）3.4.5.8がログインした場合

{
    “result”: false,
    “message”: “Not authorized to access this student.”
}

表示されていることを確認。
