### PR TITLE
JKA-574_空の配列を返すルータ・コントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -45,7 +45,7 @@ class CourseController extends Controller
     }
 
     /**
-     * マネージャ講座 管理下講師の講座情報
+     * マネージャ講座 管理下講師の講座情報を取得
      */
     public function show() {
         return response()->json([]);

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -45,6 +45,13 @@ class CourseController extends Controller
     }
 
     /**
+     * マネージャ講座 管理下講師の講座情報
+     */
+    public function show() {
+        return response()->json([]);
+    }
+
+    /**
      * マネージャ講座ステータス一覧更新API
      *
      * @return JsonResponse

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,6 +144,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
                     Route::put('status', 'Api\Manager\CourseController@status');
                     Route::prefix('{course_id}')->group(function () {
+                        Route::get('/', 'Api\Manager\CourseController@show');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
                     });


### PR DESCRIPTION
## issue
 タスク　[JKA-566:Manager配下のinstructorの作成した講座詳細情報を取得できるAPI作成](https://gut-familie.atlassian.net/browse/JKA-566)の内、
 子課題① [JKA-574:空の配列を返すルータ・コントローラの作成](https://gut-familie.atlassian.net/browse/JKA-574)

## 概要
- ルータ
　routes/api.php内 L147に、
　`Route::get('/', 'Api\Manager\CourseController@show');` を追記
- コントローラ
　app/Http/Controllers/Api/Manager/CourseController.php内 L47〜53に
```
/**
 * マネージャ講座 管理下講師の講座情報を取得
 */
 public function show() {
 return response()->json([]);
 }
```
を追記

## 動作確認手順
- Postmanにおいて、【メソッド：GET、URL：http://localhost:8080/api/v1/manager/course/1 】にて下記を確認
1. 非ログイン もしくは 生徒IDログイン下では
```
{
    "message": "Unauthorized"
}
```
が出力されること
2. 講師IDログイン下では
```
[]
```
が出力されること

## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- PRプルリクの記載内容は上記にて問題ございませんでしょうか。