### PR TITLE
JKA-579　空の配列を返すルータ・コントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ChapterController extends Controller
+{
+ /**
+ * マネージャ講座 管理下講師のチャプター情報を取得
+ */
+ public function index() {
+    return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -148,6 +148,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::delete('/', 'Api\Manager\CourseController@delete');
                     });
                 });
+
+                // マネージャ-講師-チャプター
+                Route::prefix('course')->group(function () {
+                    Route::get('{course_id}', 'Api\Manager\ChapterController@index');
+                });
             });
         });
 


### PR DESCRIPTION
## issue 

- #355  jka-579 空の配列を返すルータ・コントローラの作成

  

## 概要 

- jka-579 空の配列を返すルータ・コントローラの作成
- api.phpに
```
 // マネージャ-講師-チャプター
                Route::prefix('course')->group(function () {
                    Route::get('{course_id}', 'Api\Manager\ChapterController@index');
                });
```
　を記述
- ChapterControllerを作成し、下記を記述
```
class ChapterController extends Controller
{
 /**
 * マネージャ講座 管理下講師のチャプター情報を取得
 */
 public function index() {
    return response()->json([]);
    }
}
```
  

## 動作確認手順 

- Postmanで、メソッド：GET  URL：http://localhost:8080/api/v1/manager/course/{course_id}
　で、出力。
　なお、インストラクターのログイン後に、実行する。

- Adminerでusersテーブルに５個のレコードが保存されていることを確認 

  

## 考慮してほしいこと 

- 特にございません。

  

## 確認してほしいこと 

- 特にございません。