### PR TITLE
#584 空の配列を返すルータとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -67,6 +67,15 @@ class CourseController extends Controller
     }
 
     /**
+     * マネージャ講座の受講生一覧取得API
+     * 
+     * @return JsonResponse
+     */
+    public function student_index() {
+        return response()->json([]);
+    }
+    
+    /**
      * マネージャ講座情報更新API
      *
      * @return JsonResponse

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -65,15 +65,6 @@ class CourseController extends Controller
             'result' => 'true'
         ]);
     }
-
-    /**
-     * マネージャ講座の受講生一覧取得API
-     * 
-     * @return JsonResponse
-     */
-    public function student_index() {
-        return response()->json([]);
-    }
     
     /**
      * マネージャ講座情報更新API

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -65,7 +65,7 @@ class CourseController extends Controller
             'result' => 'true'
         ]);
     }
-    
+
     /**
      * マネージャ講座情報更新API
      *

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -9,10 +9,10 @@ use App\Model\Instructor;
 
 class StudentController extends Controller
 {
-    /**マネージャ講座の受講生取得API
-     * 
+    /**
+     * マネージャ講座の受講生取得API
      */
-    public function index() 
+    public function index()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Model\Student;
+use App\Model\Instructor;
+
+class StudentController extends Controller
+{
+    /**マネージャ講座の受講生取得API
+     * 
+     */
+    public function index() 
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,13 +144,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
                     Route::put('status', 'Api\Manager\CourseController@status');
                     Route::prefix('{course_id}')->group(function () {
-                        Route::get('student/index', 'Api\Manager\Coursecontroller@student_index');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
                     
                     // マネージャ-講師-講座-生徒
-                    Route::prefix('student')->group(function () {
-                        Route::get('index', 'Api\Manager\StudentController@index');
+                        Route::prefix('student')->group(function () {
+                            Route::get('index', 'Api\Manager\StudentController@index');
                     });
 
                     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -146,11 +146,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('{course_id}')->group(function () {
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
-                    
-                    // マネージャ-講師-講座-生徒
+
+                        // マネージャー-講座-生徒
                         Route::prefix('student')->group(function () {
                             Route::get('index', 'Api\Manager\StudentController@index');
-                    });
+                        });
 
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,6 +144,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
                     Route::put('status', 'Api\Manager\CourseController@status');
                     Route::prefix('{course_id}')->group(function () {
+                        Route::get('student/index', 'Api\Manager\Coursecontroller@student_index');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
                     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -147,6 +147,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('student/index', 'Api\Manager\Coursecontroller@student_index');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
+                    
+                    // マネージャ-講師-講座-生徒
+                    Route::prefix('student')->group(function () {
+                        Route::get('index', 'Api\Manager\StudentController@index');
+                    });
+
                     });
                 });
             });


### PR DESCRIPTION
## issue
- タスク　JKA-570 新権限マネージャー設立による配下のinstructorの作成した講座の受講生一覧情報を取得できるAPI作成の内、
  子課題　JKA-584 空の配列を返すルータとコントローラの作成

## 概要
- ルータ routes/api.php内 L147に、
　Route::get('student/index', 'Api\Manager\Coursecontroller@student_index'); を追記
- コントローラ app/Http/Controllers/Api/Manager/CourseController.php内 L69〜76に
 /**
     * マネージャ講座の受講生一覧取得API
     * 
     * @return JsonResponse
     */
    public function student_index() {
        return response()->json([]);
    } 
を追記

## 動作確認手順
- Postmanにおいて、講師IDログイン下にて【メソッド：GET、URL：http://localhost:8080/api/v1/manager/course/1 /student/index】にて下記を確認

[]
が出力されること

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし