### PR TITLE
#568 自分と配下のinstructorの講座情報のみにアクセスできるロジックの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -206,24 +206,18 @@ class CourseController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
-        // 自分と配下instructorのコース情報を取得
-        $courses = Course::with('instructor')
-                ->whereIn('instructor_id', $instructorIds)
-                ->get();
-
         //自分と配下のnstructorのコースでなければエラー応答
         $course = Course::FindOrFail($request->course_id);
-        if (!in_array($course->instructor_id, $instructorIds, true)) {
+            if (!in_array($course->instructor_id, $instructorIds, true)) {
 
         // エラー応答
             return response()->json([
                 'result'  => false,
-                'message' => "Not allowed to edit this course.",
+                'message' => "Forbidden,not allowed to edit this course.",
             ], 403);
-
-        } else{ 
-            return response()->json($courses);
-        } 
+            
+            }  
+            return response()->json($course);
 
         //return new CourseEditResource($courses);
     }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -208,15 +208,15 @@ class CourseController extends Controller
 
         //自分と配下のnstructorのコースでなければエラー応答
         $course = Course::FindOrFail($request->course_id);
-            if (!in_array($course->instructor_id, $instructorIds, true)) {
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
 
         // エラー応答
             return response()->json([
                 'result'  => false,
-                'message' => "Forbidden,not allowed to edit this course.",
+                'message' => "Forbidden, not allowed to edit this course.",
             ], 403);
             
-            }  
+        }  
             return response()->json($course);
 
         //return new CourseEditResource($courses);

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 use App\Http\Resources\Manager\CourseIndexResource;
 use App\Http\Resources\Manager\CourseUpdateResource;
+use App\Http\Resources\Manager\CourseEditResource;
 use App\Http\Requests\Manager\CoursePutStatusRequest;
 use App\Http\Requests\Manager\CourseUpdateRequest;
 use App\Http\Requests\Manager\CourseDeleteRequest;
+use App\Http\Requests\Manager\CourseEditRequest;
 use App\Http\Controllers\Controller;
 
 use App\Model\Course;
@@ -18,6 +20,8 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+
 
 class CourseController extends Controller
 {
@@ -192,9 +196,35 @@ class CourseController extends Controller
     /**
      * マネージャ講座情報編集API
      *
+     * @param CourseEditRequest $request
+     * @return CourseEditResource
      */
-    public function edit()
+    public function edit(Request $request)
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+        $manager= Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        // 自分と配下instructorのコース情報を取得
+        $courses = Course::with('instructor')
+                ->whereIn('instructor_id', $instructorIds)
+                ->get();
+
+        //自分と配下のnstructorのコースでなければエラー応答
+        $course = Course::FindOrFail($request->course_id);
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
+
+        // エラー応答
+            return response()->json([
+                'result'  => false,
+                'message' => "Not allowed to edit this course.",
+            ], 403);
+
+        } else{ 
+            return response()->json($courses);
+        } 
+
+        //return new CourseEditResource($courses);
     }
 }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -210,14 +210,14 @@ class CourseController extends Controller
         $course = Course::FindOrFail($request->course_id);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
 
-        // エラー応答
+            // エラー応答
             return response()->json([
                 'result'  => false,
                 'message' => "Forbidden, not allowed to edit this course.",
             ], 403);
             
         }  
-            return response()->json($course);
+        return response()->json($course);
 
         //return new CourseEditResource($courses);
     }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-568

## 概要
- 自分と配下のinstructorの講座情報のみにアクセスできるロジックの作成

## 動作確認手順
- GETリクエストにて
　/api/v1/manager/course/{course_id}/edit
　にアクセスすると、
　自分（ログイン中の講師[兼マネージャー]）の持っている講座と配下の講師が持っている講座の情報を取得できる。
- 配下にない講師の講座のidを入れるとエラーが返ってくる。

## 考慮して欲しいこと
- コードについて完全に理解はしていませんが他のメソッドに使われている内容を真似して書きました。

## 確認して欲しいこと
- エラー文を返すやり方がわかりませんでした。合っているか、またはより明瞭な書き方があればご教授いただきたいです。
