### PR TITLE
空の配列を返すルーター・コントラーの作成(yasuyuki)

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -188,4 +188,10 @@ class CourseController extends Controller
 
         }
     }
+    //マネージャー講座登録API
+    public function store()
+    {
+       return response()->json([]);
+    }
 }
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -143,6 +143,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
                     Route::put('status', 'Api\Manager\CourseController@status');
+                    Route::post('store','Api\Manager\CourseController@store');
                     Route::prefix('{course_id}')->group(function () {
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');


### PR DESCRIPTION
## issue
 JKA-572空の配列を返すルーター・コントローラーの作成

## 概要
JKA-572空の配列を返すルーター・コントローラーの作成
• ルータ  
routes/apiに
/**
Route::post('store','Api\Manager\CourseController@store'); を追記

• コントローラ  
   　app/Http/Controllers/Api/Manager/CourseController.phpに

/**
      public function store()
    {
       return response()->json([]);
    }
}
を追記

## 動作確認手順
postmanにて【メソッド：POST、URL：http://localhost:8080/api/v1/manager/course/store　】で
[]を確認

## 考慮してほしいこと
なし
## 確認してほしいこと
なし