### PR TITLE
#571 フォームリクストの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -199,7 +199,7 @@ class CourseController extends Controller
      * @param CourseEditRequest $request
      * @return CourseEditResource
      */
-    public function edit(Request $request)
+    public function edit(CourseEditRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $manager= Instructor::with('managings')->find($instructorId);

--- a/app/Http/Requests/Manager/CourseEditRequest.php
+++ b/app/Http/Requests/Manager/CourseEditRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CourseEditRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Manager/CourseEditRequest.php
+++ b/app/Http/Requests/Manager/CourseEditRequest.php
@@ -24,7 +24,7 @@ class CourseEditRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'exists:courses,id', 'integer'],
+            'course_id' => ['required','integer','exists:courses,id,deleted_at,NULL'],
         ];
     }
 

--- a/app/Http/Requests/Manager/CourseEditRequest.php
+++ b/app/Http/Requests/Manager/CourseEditRequest.php
@@ -24,7 +24,7 @@ class CourseEditRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer'],
+            'course_id' => ['required', 'exists:courses,id', 'integer'],
         ];
     }
 


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-571

## 概要
- 新権限マネージャー設立による配下のinstructorの作成した講座の編集情報を取得できるAPI作成
子課題③フォームリクエストの作成
## 動作確認手順
- postmanにて
GETリクエスト
/api/v1/manager/course/{course_id}/editへアクセスする際に、{cose_id}についてバリデーションがかかっているか確認。
- cose_id　に文字列を入れた場合、
```
   {
    "message": "The given data was invalid.",
    "errors": {
        "course_id": [
            "The course id must be an integer."
        ]
    }
```
というレスポンスが返ってきたのを確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません