### PR TITLE
#JKA-590 空の配列を返すルーターとコントローラの作成(ごめ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ChapterController extends Controller
+{
+    /**
+      * マネージャ配下のチャプター更新API
+      *
+      */
+      public function update()
+      {
+          return response()->json([]);
+      }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -139,7 +139,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
 
-                // マネージャー講師-講座
+                // マネージャー-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
                     Route::put('status', 'Api\Manager\CourseController@status');
@@ -147,7 +147,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
 
-                        // マネージャー講師-講座-チャプター
+                        // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::patch('/', 'Api\Manager\ChapterController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -146,14 +146,19 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('{course_id}')->group(function () {
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
+
+                        // マネージャー講師-講座-チャプター
+                        Route::prefix('chapter')->group(function () {
+                            Route::prefix('{chapter_id}')->group(function () {
+                                Route::patch('/', 'Api\Manager\ChapterController@update');
+                            });
+                        });
                     });
                 });
             });
         });
-
     });
 });
-
 
 Route::prefix('v1')->group(function () {
     Route::prefix('student')->group(function () {


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-590
## 概要
- 新権限マネージャー設立による配下のinstructorの作成したチャプターを更新できるAPI作成
　１.空の配列を返すルーターとコントローラーの作成
## 動作確認手順
- ルーター、コントローラー作成後、postmanによる確認にて空の配列が返ってきたことを確認
## 考慮して欲しいこと
- 特になし
## 確認して欲しいこと
- 特になし