### PR TITLE
#595 自分と配下のinstructorの作成したチャプターを更新できるロジック作成（ごめ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -41,8 +41,6 @@ class ChapterController extends Controller
             ], 403);
         }
 
-        Log::info('Request Data:', $request->all());
-
         // チャプターを更新する
         $chapter->update([
             'title' => $request->title,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -29,8 +29,8 @@ class ChapterController extends Controller
         // チャプターを取得
         $chapter = Chapter::findOrFail($request->chapter_id);
 
-        // チャプターを作成した講師IDを取得
-        $chapterInstructorId = $chapter->id;
+         // チャプター作成者のIDを取得
+         $chapterInstructorId = $chapter->id;
 
         // マネージャー自身が作成したチャプターか、または配下の講師が作成したチャプターなら更新を許可
         if (!in_array($chapterInstructorId, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -5,22 +5,19 @@ namespace App\Http\Controllers\Api\Manager;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
-
 use App\Model\Instructor;
 use App\Model\Chapter;
 
 class ChapterController extends Controller
 {
     /**
-      * マネージャ配下のチャプター更新API
-      *
+      * マネージャー配下のチャプター更新API
       */
     public function update(Request $request)
     {
         // 現在のユーザーを取得
         $instructorId = Auth::guard('instructor')->user()->id;
-        
+
         // マネージャーが管理する講師を取得
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
@@ -29,11 +26,8 @@ class ChapterController extends Controller
         // チャプターを取得
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
-         // チャプター作成者のIDを取得
-        $chapterInstructorId = $chapter->course->instructor_id;
-
         // マネージャー自身が作成したチャプターか、または配下の講師が作成したチャプターなら更新を許可
-        if (!in_array($chapterInstructorId, $instructorIds, true)) {
+        if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
             // 失敗結果を返す
             return response()->json([
                 'result'  => false,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -30,7 +30,7 @@ class ChapterController extends Controller
         $chapter = Chapter::findOrFail($request->chapter_id);
 
          // チャプター作成者のIDを取得
-         $chapterInstructorId = $chapter->id;
+        $chapterInstructorId = $chapter->course->instructor_id;
 
         // マネージャー自身が作成したチャプターか、または配下の講師が作成したチャプターなら更新を許可
         if (!in_array($chapterInstructorId, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -27,7 +27,7 @@ class ChapterController extends Controller
         $instructorIds[] = $instructorId;
 
         // チャプターを取得
-        $chapter = Chapter::findOrFail($request->chapter_id);
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
          // チャプター作成者のIDを取得
         $chapterInstructorId = $chapter->course->instructor_id;

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -33,18 +33,24 @@ class ChapterController extends Controller
         $chapterInstructorId = $chapter->id;
 
         // マネージャー自身が作成したチャプターか、または配下の講師が作成したチャプターなら更新を許可
-        if ($chapterInstructorId === $instructorId || in_array($chapterInstructorId, $instructorIds, true)) {
-            return response()->json([
-                'result'  => true,
-                'message' => "Chapter updated successfully.",
-                'data'    => $chapter, // 更新されたチャプター情報を返す
-            ]);
-        } else {
-            // エラー応答（権限がない場合）
+        if (!in_array($chapterInstructorId, $instructorIds, true)) {
+            // 失敗結果を返す
             return response()->json([
                 'result'  => false,
                 'message' => "Forbidden, not allowed to edit this chapter.",
             ], 403);
         }
+
+        Log::info('Request Data:', $request->all());
+
+        // チャプターを更新する
+        $chapter->update([
+            'title' => $request->title,
+        ]);
+
+        // 成功結果を返す
+        return response()->json([
+            'result'  => true,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -4,6 +4,11 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+use App\Model\Instructor;
+use App\Model\Chapter;
+
 
 class ChapterController extends Controller
 {
@@ -11,8 +16,26 @@ class ChapterController extends Controller
       * マネージャ配下のチャプター更新API
       *
       */
-      public function update()
-      {
-          return response()->json([]);
-      }
+      public function update(Request $request)
+    {
+        // 現在のユーザーを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        
+        // マネージャーが管理する講師を取得
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        //自分と配下のnstructorのチャプターでなければエラー応答
+        $chapter = Chapter::FindOrFail($request->chapter_id);
+        if (!in_array($chapter->instructor_id, $instructorIds, true)) {
+            // エラー応答
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to edit this course.",
+            ], 403);
+        }  
+
+        return response()->json($chapter); // 更新されたコース情報を返す
+    }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -16,7 +16,7 @@ class ChapterController extends Controller
       * マネージャ配下のチャプター更新API
       *
       */
-      public function update(Request $request)
+    public function update(Request $request)
     {
         // 現在のユーザーを取得
         $instructorId = Auth::guard('instructor')->user()->id;


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-595

## 概要
- 自分と配下のinstructorの作成したチャプターを更新できるロジック作成

## 動作確認手順
- GETリクエストにて
　/api/v1/manager/course/{course_id}/chapter/{chapter_id}
　にアクセスすると、
　自分（ログイン中の講師[兼マネージャー]）の持っているチャプターと配下の講師が持っているチャプターの情報を取得できる。
- 配下にない講師の講座のidを入れるとエラーが返ってくる。

## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません