### PR TITLE
jka-575_（featureブランチ再作成）_ロジック作成(でら)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -106,16 +106,8 @@ class CourseController extends Controller
         $file = $request->file('image');
 
         try {
-            $user = Instructor::find(Auth::guard('instructor')->user()->id);
             $course = Course::FindOrFail($request->course_id);
             $imagePath = $course->image;
-
-            if ($user->id !== $course->instructor_id) {
-                return new JsonResponse([
-                    "result" => false,
-                    "message" => "Not authorized."
-                ], 403);
-            }
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -106,8 +106,16 @@ class CourseController extends Controller
         $file = $request->file('image');
 
         try {
+            $user = Instructor::find(Auth::guard('instructor')->user()->id);
             $course = Course::FindOrFail($request->course_id);
             $imagePath = $course->image;
+
+            if ($user->id !== $course->instructor_id) {
+                return new JsonResponse([
+                    "result" => false,
+                    "message" => "Not authorized."
+                ], 403);
+            }
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -47,9 +47,26 @@ class CourseController extends Controller
     /**
      * マネージャ講座 管理下講師の講座情報を取得
      */
-    public function show() {
-        return response()->json([]);
-    }
+    public function show(Request $request, int $course_id)
+    {
+        // ユーザID取得
+        $userId = $request->user()->id;
+        // $course_id から chapters・lessons含めてデータ取得
+        $course = Course::with(['chapters.lessons'])->findOrFail($course_id);    
+        // 配下のinstructor情報を取得
+        $manager = Instructor::with('managings')->find($userId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $userId;
+
+        // 自身 もしくは 配下のinstrctorでない場合はエラー応答
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
+            return response()->json([
+                'result' => false,
+                'message' => "Forbidden, not allowed to edit this course.",
+            ], 403);
+        }
+        return response()->json($course);
+    } 
 
     /**
      * マネージャ講座ステータス一覧更新API


### PR DESCRIPTION
## issue
 タスク　[JKA-566:Manager配下のinstructorの作成した講座詳細情報を取得できるAPI作成](https://gut-familie.atlassian.net/browse/JKA-566)の内、
 子課題② [JKA-575:ロジックの作成](https://gut-familie.atlassian.net/browse/JKA-575)

## 概要
- コントローラ
　app/Http/Controllers/Api/Manager/CourseController.php内に、以下ロジック作成
```
public function show(Request $request, int $course_id)
    {
        // ユーザID取得
        $userId = $request->user()->id;
        // $course_id から chapters・lessons含めてデータ取得
        $course = Course::with(['chapters.lessons'])->findOrFail($course_id);    
        // 配下のinstructor情報を取得
        $manager = Instructor::with('managings')->find($userId);
        $instructorIds = $manager->managings->pluck('id')->toArray();
        $instructorIds[] = $userId;

        // 自身 もしくは 配下のinstrctorでない場合はエラー応答
        if (!in_array($course->instructor_id, $instructorIds, true)) {
            return response()->json([
                'result' => false,
                'message' => "Forbidden, not allowed to edit this course.",
            ], 403);
        }
        return response()->json($course);
    } 
```

## 考慮して欲しいこと
- 今後、子課題③フォームリクエストの作成 子課題④レスポンス整形のリソースファイル作成 にて修正いたします。