### PR TITLE
#jka605 空の配列を返すルーターとコントローラの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ChapterController extends Controller
+{
+    /**
+      * マネージャ配下のチャプター削除API
+      *
+      */
+      public function delete()
+      {
+          return response()->json([]);
+      }
+}

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -11,8 +11,8 @@ class ChapterController extends Controller
       * マネージャ配下のチャプター削除API
       *
       */
-      public function delete()
-      {
-          return response()->json([]);
-      }
+    public function delete()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -147,13 +147,13 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('edit', 'Api\Manager\CourseController@edit');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
-                        
+
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
                             Route::prefix('{chapter_id}')->group(function () {
-                                Route::delete('/', 'Api\Manager\ChapterController@delete'); 
+                                Route::delete('/', 'Api\Manager\ChapterController@delete');
                             });
-                        });   
+                        });
                     });
                 });
             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -147,6 +147,13 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('edit', 'Api\Manager\CourseController@edit');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
+                        
+                        // マネージャー-講座-チャプター
+                        Route::prefix('chapter')->group(function () {
+                            Route::prefix('{chapter_id}')->group(function () {
+                                Route::delete('/', 'Api\Manager\ChapterController@delete'); 
+                            });
+                        });   
                     });
                 });
             });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-605
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-604
## 概要
- 「新権限マネージャー設立による配下のinstructorの作成したチャプター削除できるAPI作成」における
- 子課題「空の配列を返すルーターとコントローラの作成」
## 動作確認手順
- DELETEリクエストにて下記URLにアクセスすると、空の配列が返ってくることを確認。
- /api/v1/manager/course/{course_id}/chapter/{chapter_id}

## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません