### PR TITLE
JKA-591_(でら)_講師のチャプター更新API_チャプター作成した講師のみしか更新できないように制限

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -81,7 +81,14 @@ class ChapterController extends Controller
      */
     public function update(ChapterPatchRequest $request)
     {
+        $user_id = Instructor::find($request->user()->id);
         $chapter = Chapter::findOrFail($request->chapter_id);
+        if ($chapter->coourse->instructor_id !== $user_id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid instructor_id',
+            ], 403);
+        }
         $chapter->update([
             'title' => $request->title
         ]);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -81,9 +81,9 @@ class ChapterController extends Controller
      */
     public function update(ChapterPatchRequest $request)
     {
-        $user_id = Instructor::find($request->user()->id);
+        $user = Instructor::find($request->user()->id);
         $chapter = Chapter::findOrFail($request->chapter_id);
-        if ($chapter->coourse->instructor_id !== $user_id) {
+        if ($chapter->course->instructor_id !== $user->id) {
             return response()->json([
                 'result' => false,
                 'message' => 'Invalid instructor_id',


### PR DESCRIPTION
## issue
 タスク　[JKA-591:講師のチャプター更新APIで、チャプター作成した講師のみしか更新できないように制限する](https://gut-familie.atlassian.net/browse/JKA-591)

## 概要
- コントローラ内 updateメソッドに条件式追記
```app/Http/Controllers/Api/Instructor/ChapterController.php```

## 動作確認手順
/api/v1/instructor/course/{course_id}/chapter/{chapter_id}　において、
{course_id} : 1 , {chapter_id} : 1 をクエリパラメータ、　title : *****(任意)をリクエストボディとして以下にて実行。
- 講師１(instructor_id：1)にてログイン（email : test_instructor@example.com、PASS : password）の上、実行
```
{
    "result": true,
    "data": {
        "chapter_id": 1,
        "title": "sampleeeeeee"
    }
}
```
が出力される

- 講師４(instructor_id：4)にてログイン（email : test_instructor4@example.com、PASS : password）の上、実行
```
{
    "result": false,
    "message": "Invalid instructor_id"
}
```
が出力される