### PR TITLE
#JKA606 ロジックの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -2,8 +2,17 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
+use App\Model\Instructor;
+use App\Model\Course;
+use App\Model\Chapter;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
 
 class ChapterController extends Controller
 {
@@ -11,8 +20,29 @@ class ChapterController extends Controller
       * マネージャ配下のチャプター削除API
       *
       */
-    public function delete()
+    public function delete(Request $request)
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        //自分と配下のインストラクターが持っている講座を取得
+        $course = Course::FindOrFail($request->course_id);
+
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
+            // 自分、または配下の講師の講座のチャプターでなければエラー応答
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to delete this chapter.",
+            ], 403);
+        }
+
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+        
+        $chapter->delete();
+        return response()->json([
+            "result" => true
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -23,13 +23,14 @@ class ChapterController extends Controller
     public function delete(Request $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
+        // 配下の講師情報を取得
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
-        //自分と配下のインストラクターが持っている講座を取得
         $course = Course::FindOrFail($request->course_id);
-
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+        
         if (!in_array($course->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座のチャプターでなければエラー応答
             return response()->json([
@@ -37,9 +38,13 @@ class ChapterController extends Controller
                 'message' => "Forbidden, not allowed to delete this chapter.",
             ], 403);
         }
-
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-        
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定したコースに属するチャプターでなければエラー応答
+            return response()->json([
+                'result'  => false,
+                'message' => 'invalid course_id.',
+            ], 403);
+        }
         $chapter->delete();
         return response()->json([
             "result" => true

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -8,10 +8,6 @@ use App\Model\Chapter;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
 
 class ChapterController extends Controller
@@ -30,7 +26,7 @@ class ChapterController extends Controller
 
         $course = Course::FindOrFail($request->course_id);
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-        
+
         if (!in_array($course->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座のチャプターでなければエラー応答
             return response()->json([

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -3,19 +3,17 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Model\Instructor;
-use App\Model\Course;
 use App\Model\Chapter;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class ChapterController extends Controller
 {
     /**
-      * マネージャ配下のチャプター削除API
-      *
-      */
+     * マネージャ配下のチャプター削除API
+     *
+     */
     public function delete(Request $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -33,13 +31,15 @@ class ChapterController extends Controller
                 'message' => "Forbidden, not allowed to delete this chapter.",
             ], 403);
         }
+
         if ((int) $request->course_id !== $chapter->course->id) {
-            // 指定したコースに属するチャプターでなければエラー応答
+            // 指定した講座に属するチャプターでなければエラー応答
             return response()->json([
                 'result'  => false,
-                'message' => 'invalid course_id.',
+                'message' => 'Invalid course_id.',
             ], 403);
         }
+
         $chapter->delete();
         return response()->json([
             "result" => true

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -24,10 +24,9 @@ class ChapterController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
-        $course = Course::FindOrFail($request->course_id);
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
-        if (!in_array($course->instructor_id, $instructorIds, true)) {
+        if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座のチャプターでなければエラー応答
             return response()->json([
                 'result'  => false,


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-604
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-606
## 概要
- 新権限マネージャー設立による配下のinstructorの作成したチャプター削除できるAPI作成における、
- 子課題②ロジックの作成
## 動作確認手順
- postmanにて
deleteリクエストで/api/v1/manager/course/{course_id}/chapter/{chapter_id}にアクセスすると
```
{
  "result": true
}
```
　が返ってくることを確認。
- ログインしているマネージャー自身と配下のインストラクターが持つコースのチャプターでない場合は
```
{
    "result": false,
    "message": "Forbidden, not allowed to delete this chapter."
}
```
　が返ってくることを確認。
- Adminerにて
対象のコースのチャプターの[deleted_at]カラムに反映されていることを確認。
またその際、コースは残り、チャプターのみが消えていることも確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- より良い書き方があればご教授願います。