### PR TITLE
Feature/yasuyuki/jka 572/formrequest(yasuyuki)

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -6,6 +6,7 @@ use App\Http\Resources\Manager\CourseUpdateResource;
 use App\Http\Requests\Manager\CoursePutStatusRequest;
 use App\Http\Requests\Manager\CourseUpdateRequest;
 use App\Http\Requests\Manager\CourseDeleteRequest;
+use App\Http\Requests\Manager\CourseStoreRequest;
 use App\Http\Controllers\Controller;
 use App\Model\Course;
 use App\Model\Attendance;
@@ -70,7 +71,7 @@ class CourseController extends Controller
      *
      * @return JsonResponse
      */
-    public function store(Request $request)
+    public function store(CourseStoreRequest $request)
     {
         $managerId = $request->user()->id;
         $file = $request->file('image');

--- a/app/Http/Requests/Manager/CourseStoreRequest.php
+++ b/app/Http/Requests/Manager/CourseStoreRequest.php
@@ -25,7 +25,7 @@ class CourseStoreRequest extends FormRequest
     {
         return [
             'title' =>['required','string','max:30'],
-            'image' =>['required','mimes:jpg,png'],
+            'image' =>['required','mimes:jpg,png','max:2048'],
         ];
     }
 }

--- a/app/Http/Requests/Manager/CourseStoreRequest.php
+++ b/app/Http/Requests/Manager/CourseStoreRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CourseStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' =>['required','string','max:30'],
+            'image' =>['required','mimes:jpg,png'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue

子課題③フォームリクエストの作成
## 概要
フォームリクエストの作成
     ```app/Http/Requests/Manager/CourseStoreRequest.php``` を新規作成
   CourseController内に
```use App\Http\Requests\Manager\CourseStoreRequest;```を追記
   また74行目の箇所の所を```Requst```から```CoursestoreRequest```に変更
## 動作確認手順
postman　にてpost リクエストを送信　送信先：```http://localhost:8080/api/v1/manager/course```
```
{
    "result": true,
    "data": {
        "instructor_id": 1,
        "title": "aaaa",
        "image": "course/aa6a23ab-f30f-4f14-8398-3e78af13c19f.jpg",
        "status": "private",
        "created_at": "2023-12-16 22:13:01",
        "updated_at": "2023-12-16 22:13:01",
        "id": 13
    }
}
```
が返ってくる

## 考慮してほしいこと
なし
## 確認してほしいこと
なし