### PR TITLE
#jka-619 空の配列を返すルーターとコントローラの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -18,7 +18,6 @@ class ChapterController extends Controller
     public function store()
     {
         return response()->json([]);
-        
     }
     /**
      * マネージャ配下のチャプター削除API

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -12,6 +12,15 @@ use Illuminate\Support\Facades\Auth;
 class ChapterController extends Controller
 {
     /**
+     * チャプター新規作成API
+     *
+     */
+    public function store()
+    {
+        return response()->json([]);
+        
+    }
+    /**
      * マネージャ配下のチャプター削除API
      *
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,6 +151,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
+                            Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
                             });


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-610
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-619
## 概要
- 「新権限マネージャー設立による配下のinstructorの作成した講座にチャプターを新規登録できるAPI作成」
における空の配列を返すルーターとコントローラーの作成
## 動作確認手順
- postリクエストにて
http://localhost:8080/api/v1/manager/course/1/chapter
にアクセスし、空の配列が返ってくることを確認
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません
