### PR TITLE
受講生情報更新処理のとき、他の受講生のメールアドレスと重複する場合のバリデーション(yasuyuki)

### DIFF
--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -161,9 +161,9 @@ class StudentController extends Controller
                 $imagePath = Student::convertImagePath($imagePath);
             }
 
-            $request->validate([
-                'email' => [new UniqueEmailRule($student->email)],
-            ]);
+            // $request->validate([
+            //     'email' => [new UniqueEmailRule($student->email)],
+            // ]);
 
 
             $student->fill([

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -161,11 +161,6 @@ class StudentController extends Controller
                 $imagePath = Student::convertImagePath($imagePath);
             }
 
-            // $request->validate([
-            //     'email' => [new UniqueEmailRule($student->email)],
-            // ]);
-
-
             $student->fill([
                 'nick_name' => $request->nick_name,
                 'last_name' => $request->last_name,

--- a/app/Http/Requests/Student/StudentPatchRequest.php
+++ b/app/Http/Requests/Student/StudentPatchRequest.php
@@ -28,7 +28,7 @@ class StudentPatchRequest extends FormRequest
             'nick_name' => ['required', 'string'],
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
-            'email' => ['required', 'email','unique:users'],
+            'email' => ['required', 'email','unique:students'],
             'occupation' => ['required', 'string'],
             'purpose' => ['required', 'string'],
             'birth_date' => ['required', 'date_format:Y-m-d'],

--- a/app/Http/Requests/Student/StudentPatchRequest.php
+++ b/app/Http/Requests/Student/StudentPatchRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Student;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 use App\Rules\SexRule;
 
 class StudentPatchRequest extends FormRequest
@@ -28,7 +29,7 @@ class StudentPatchRequest extends FormRequest
             'nick_name' => ['required', 'string'],
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
-            'email' => ['required', 'email','unique:students'],
+            'email' => ['required', 'email',Rule::unique('students')->ignore($this->route('student'))],
             'occupation' => ['required', 'string'],
             'purpose' => ['required', 'string'],
             'birth_date' => ['required', 'date_format:Y-m-d'],

--- a/app/Http/Requests/Student/StudentPatchRequest.php
+++ b/app/Http/Requests/Student/StudentPatchRequest.php
@@ -29,7 +29,7 @@ class StudentPatchRequest extends FormRequest
             'nick_name' => ['required', 'string'],
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
-            'email' => ['required', 'email', new UniqueEmailRule('test_student_1@example.com')],
+            'email' => ['required', 'email', new UniqueEmailRule($this->email)],
             'occupation' => ['required', 'string'],
             'purpose' => ['required', 'string'],
             'birth_date' => ['required', 'date_format:Y-m-d'],

--- a/app/Http/Requests/Student/StudentPatchRequest.php
+++ b/app/Http/Requests/Student/StudentPatchRequest.php
@@ -28,7 +28,7 @@ class StudentPatchRequest extends FormRequest
             'nick_name' => ['required', 'string'],
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
-            'email' => ['required', 'email'],
+            'email' => ['required', 'email',Rule::unique('users')->ignore(Auth::id())],
             'occupation' => ['required', 'string'],
             'purpose' => ['required', 'string'],
             'birth_date' => ['required', 'date_format:Y-m-d'],

--- a/app/Http/Requests/Student/StudentPatchRequest.php
+++ b/app/Http/Requests/Student/StudentPatchRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Student;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
+use App\Rules\UniqueEmailRule;
 use App\Rules\SexRule;
 
 class StudentPatchRequest extends FormRequest
@@ -29,7 +29,7 @@ class StudentPatchRequest extends FormRequest
             'nick_name' => ['required', 'string'],
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
-            'email' => ['required', 'email',Rule::unique('students')->ignore($this->route('student'))],
+            'email' => ['required', 'email', new UniqueEmailRule('test_student_1@example.com')],
             'occupation' => ['required', 'string'],
             'purpose' => ['required', 'string'],
             'birth_date' => ['required', 'date_format:Y-m-d'],

--- a/app/Http/Requests/Student/StudentPatchRequest.php
+++ b/app/Http/Requests/Student/StudentPatchRequest.php
@@ -25,11 +25,12 @@ class StudentPatchRequest extends FormRequest
      */
     public function rules()
     {
+        $user = $this->user();
         return [
             'nick_name' => ['required', 'string'],
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
-            'email' => ['required', 'email', new UniqueEmailRule($this->email)],
+            'email' => ['required', 'email', new UniqueEmailRule($user->email)],
             'occupation' => ['required', 'string'],
             'purpose' => ['required', 'string'],
             'birth_date' => ['required', 'date_format:Y-m-d'],

--- a/app/Http/Requests/Student/StudentPatchRequest.php
+++ b/app/Http/Requests/Student/StudentPatchRequest.php
@@ -28,7 +28,7 @@ class StudentPatchRequest extends FormRequest
             'nick_name' => ['required', 'string'],
             'last_name' => ['required', 'string'],
             'first_name' => ['required', 'string'],
-            'email' => ['required', 'email',Rule::unique('users')->ignore(Auth::id())],
+            'email' => ['required', 'email','unique:users'],
             'occupation' => ['required', 'string'],
             'purpose' => ['required', 'string'],
             'birth_date' => ['required', 'date_format:Y-m-d'],


### PR DESCRIPTION
## issue
受講生情報更新処理のとき、他の受講生のメールアドレスと重複する場合のバリデーション
## 概要
studentpatchrequestに```Rule::unique('users')->ignore(Auth::id())```を追記

## 動作確認手順
postmanにて生徒でログイン後、POST requestでhttp://localhost:8080/api/v1/student　に送信
```
"email": [
            "The email has already been taken."
        ],
```
が返ってくる。
## 考慮してほしいこと
なし
## 確認してほしいこと
student controoler 内の164行目〜167行目をコメントアウトしましたが
削除した方がよいでしょうか。
```
// $request->validate([
//     'email' => [new UniqueEmailRule($student->email)],
// ]);
```
