### PR TITLE
#609 講師のチャプター関連APIで、講座作成した講師のみしかチャプターのステータス更新・削除できないように制限する(ごめ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -141,14 +141,16 @@ class ChapterController extends Controller
      */
     public function delete(ChapterDeleteRequest $request)
     {
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-        
-        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
+        $course = Course::findOrFail($request->course_id);
+
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
             return response()->json([
                 'result' => false,
                 "message" => 'invalid instructor_id.'
             ], 403);
         }
+
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -125,16 +125,9 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-<<<<<<< HEAD
         
         $chapter->update([
             'status' => $request->status
-=======
-
-        Chapter::findOrFail($request->chapter_id)
-            ->update([
-                'status' => $request->status
->>>>>>> 889b49f520a518843e4b8ce5902cfe65523dd46f
         ]);
 
         return response()->json([
@@ -168,12 +161,7 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-<<<<<<< HEAD
-        
-=======
 
-        $chapter = Chapter::findOrFail($request->chapter_id);
->>>>>>> 889b49f520a518843e4b8ce5902cfe65523dd46f
         $chapter->delete();
 
         return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -107,16 +107,14 @@ class ChapterController extends Controller
      */
     public function updateStatus(ChapterPatchStatusRequest $request)
     {
-        $course = Course::findOrFail($request->course_id);
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
-        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
             return response()->json([
-                'result' => 'false',
+                'result' => false,
                 "message" => 'invalid instructor_id.'
             ], 403);
         }
-
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
@@ -143,16 +141,14 @@ class ChapterController extends Controller
      */
     public function delete(ChapterDeleteRequest $request)
     {
-        $course = Course::findOrFail($request->course_id);
-
-        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+        
+        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
             return response()->json([
-                'result' => 'false',
+                'result' => false,
                 "message" => 'invalid instructor_id.'
             ], 403);
         }
-
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -107,6 +107,15 @@ class ChapterController extends Controller
      */
     public function updateStatus(ChapterPatchStatusRequest $request)
     {
+        $course = Course::findOrFail($request->course_id);
+
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+            return response()->json([
+                'result' => 'false',
+                "message" => "Not authorized."
+            ], 403);
+        }
+        
         Chapter::findOrFail($request->chapter_id)
             ->update([
                 'status' => $request->status
@@ -125,6 +134,15 @@ class ChapterController extends Controller
      */
     public function delete(ChapterDeleteRequest $request)
     {
+        $course = Course::findOrFail($request->course_id);
+
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+            return response()->json([
+                'result' => 'false',
+                "message" => "Not authorized."
+            ], 403);
+        }
+        
         $chapter = Chapter::findOrFail($request->chapter_id);
         $chapter->delete();
         return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -115,7 +115,7 @@ class ChapterController extends Controller
                 "message" => "Not authorized."
             ], 403);
         }
-        
+
         Chapter::findOrFail($request->chapter_id)
             ->update([
                 'status' => $request->status
@@ -142,7 +142,7 @@ class ChapterController extends Controller
                 "message" => "Not authorized."
             ], 403);
         }
-        
+
         $chapter = Chapter::findOrFail($request->chapter_id);
         $chapter->delete();
         return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -112,13 +112,22 @@ class ChapterController extends Controller
         if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
             return response()->json([
                 'result' => 'false',
-                "message" => "Not authorized."
+                "message" => 'invalid instructor_id.'
+            ], 403);
+        }
+
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
+            return response()->json([
+                'result'  => false,
+                'message' => 'Invalid course_id.',
             ], 403);
         }
         
-        Chapter::findOrFail($request->chapter_id)
-            ->update([
-                'status' => $request->status
+        $chapter->update([
+            'status' => $request->status
         ]);
 
         return response()->json([
@@ -139,12 +148,22 @@ class ChapterController extends Controller
         if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
             return response()->json([
                 'result' => 'false',
-                "message" => "Not authorized."
+                "message" => 'invalid instructor_id.'
+            ], 403);
+        }
+
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
+            return response()->json([
+                'result'  => false,
+                'message' => 'Invalid course_id.',
             ], 403);
         }
         
-        $chapter = Chapter::findOrFail($request->chapter_id);
         $chapter->delete();
+
         return response()->json([
             "result" => true
         ]);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -141,16 +141,14 @@ class ChapterController extends Controller
      */
     public function delete(ChapterDeleteRequest $request)
     {
-        $course = Course::findOrFail($request->course_id);
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
-        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
             return response()->json([
                 'result' => false,
                 "message" => 'invalid instructor_id.'
             ], 403);
         }
-
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -123,7 +123,7 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-        
+
         $chapter->update([
             'status' => $request->status
         ]);


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-609

## 概要
- 講師のチャプター関連APIで、講座作成した講師のみしかチャプターのステータス更新・削除できないように制限する
## 動作確認手順
- RLのchapter_idが、講座作成した講師のチャプターであれば以下のレスポンスが返ってくること。
```
{
    "result": true,
    "data": {
        "chapter_id": 1,
        "title": "チャプタータイトル"
    }
}
```
## 考慮して欲しいこと
- 今回参考にした「Swagge」はhttp://localhost:8080//api/v1/instructor/course/{course_id}/chapter/{chapter_id}
　
## 確認して欲しいこと
- 今回は「URLのchapter_idが本当にURLの講座(couse)の所属のチャプターなのかの照合」はしておりませんが、する必要はありますでしょうか？
- またupdateStatusとdeleteでは若干コードが違いますが、揃えるべきか、このままの方が適切か教えてください
```
Chapter::findOrFail($request->chapter_id)
            ->update([
                'status' => $request->status
        ]);

        return response()->json([
            'result' => true,
        ]);
```
```
$chapter = Chapter::findOrFail($request->chapter_id);
        $chapter->delete();
        return response()->json([
            "result" => true
        ]);
```