### PR TITLE
講師側レッスン更新・レッスン削除APIの修正

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -163,7 +163,6 @@ class LessonController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-
         } catch (Exception $e) {
             Log::error($e);
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -162,6 +162,8 @@ class LessonController extends Controller
                 ], 403);
             }
 
+            $lesson->delete();
+
             return response()->json([
                 'result' => true,
             ]);

--- a/app/Http/Requests/Instructor/LessonDeleteRequest.php
+++ b/app/Http/Requests/Instructor/LessonDeleteRequest.php
@@ -6,32 +6,32 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class LessonDeleteRequest extends FormRequest
 {
-  /**
-   * Determine if the user is authorized to make this request.
-   *
-   * @return bool
-   */
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
     public function authorize()
     {
         return true;
     }
 
-  /**
-   * Get the validation rules that apply to the request.
-   *
-   * @return array
-   */
-    public function rules()
-    {
-        return [
-        'lesson_id' => ['required', 'integer'],
-        ];
-    }
-
     protected function prepareForValidation()
     {
         $this->merge([
-        'lesson_id' => $this->route('lesson_id'),
+            'lesson_id' => $this->route('lesson_id'),
         ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+        ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -87,7 +87,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::prefix('{lesson_id}')->group(function () {
-                                    Route::patch('/', 'Api\Instructor\LessonController@update');
+                                    Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');
                                 });
                             });


### PR DESCRIPTION
## issue
- jka-635 講師側レッスン更新・レッスン削除APIの修正。
## 概要
- レッスン更新API
HTTPメソッドをpatch → putに変更
- レッスン削除API
コントローラーに次の処理を記述
$lesson->delete();
## 動作確認手順
- postmanにて、putリクエスト
http://localhost:8080/api/v1/instructor/course/{couse_id}/chapter/{chapter_id}/lesson/{leeson_id} にアクセスしレスポンスが返ってくることを確認。
- postmanにて、deleteリクエスト
http://localhost:8080/api/v1/instructor/course/{couse_id}/chapter/{chapter_id}/lesson/{leeson_id} にアクセスしレスポンスが返ってくることを確認。
DB上で lessons_idが論理削除されていることを確認。
## 考慮して欲しいこと
- なし
## 確認してほしいこと
- なし