### PR TITLE
講師側チャプター削除APIの修正

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -158,7 +158,7 @@ class ChapterController extends Controller
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
                 return response()->json([
                     'result' => false,
-                    'message' => 'invalid instructor_id.'
+                    'message' => 'Invalid instructor_id.'
                 ], 403);
             }
 
@@ -170,7 +170,7 @@ class ChapterController extends Controller
                 ], 403);
             }
 
-            // 削除対象チャプターのorderカラムを0に設定し、他のチャプターの順番を更新する。
+            // 削除対象チャプターのorderカラムを0に設定する
             $chapter->update(['order' => 0]);
 
             $chapter->delete();
@@ -187,7 +187,7 @@ class ChapterController extends Controller
             return response()->json([
                 "result" => true
             ]);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -163,16 +163,15 @@ class ChapterController extends Controller
     
             // 削除対象チャプターのorderカラムを0に設定し、他のチャプターの順番を更新する。
             $chapter->update(['order' => 0]);
+
+            $chapter->delete();
     
             Chapter::where('course_id', $chapter->course_id)
-                ->where('id', '!=', $chapter->id)
                 ->orderBy('order')
                 ->get()
                 ->each(function ($chapter, $index) {
                     $chapter->update(['order' => $index + 1]);
                 });
-    
-            $chapter->delete();
     
             DB::commit();
     

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -142,14 +142,14 @@ class ChapterController extends Controller
     public function delete(ChapterDeleteRequest $request)
     {
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-
+    
         if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
             return response()->json([
                 'result' => false,
-                "message" => 'invalid instructor_id.'
+                'message' => 'invalid instructor_id.'
             ], 403);
         }
-
+    
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
             return response()->json([
@@ -157,13 +157,24 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-
+    
+        $chapter->update(['order' => 0]);
+    
+        Chapter::where('course_id', $chapter->course_id)
+            ->where('id', '!=', $chapter->id)
+            ->orderBy('order')
+            ->get()
+            ->each(function ($chapterToUpdate, $index) {
+                $chapterToUpdate->update(['order' => $index + 1]);
+            });
+    
         $chapter->delete();
-
+    
         return response()->json([
             "result" => true
         ]);
     }
+    
 
     /**
      * チャプター並び替えAPI

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -174,14 +174,14 @@ class ChapterController extends Controller
             $chapter->update(['order' => 0]);
 
             $chapter->delete();
-    
+
             Chapter::where('course_id', $chapter->course_id)
                 ->orderBy('order')
                 ->get()
                 ->each(function ($chapter, $index) {
                     $chapter->update(['order' => $index + 1]);
                 });
-    
+
 
             $chapter->delete();
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -181,9 +181,6 @@ class ChapterController extends Controller
                 ->each(function ($chapter, $index) {
                     $chapter->update(['order' => $index + 1]);
                 });
-    
-
-            $chapter->delete();
 
             DB::commit();
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -141,40 +141,53 @@ class ChapterController extends Controller
      */
     public function delete(ChapterDeleteRequest $request)
     {
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-
-        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
+        DB::beginTransaction();
+    
+        try {
+            $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+    
+            if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'invalid instructor_id.'
+                ], 403);
+            }
+    
+            if ((int) $request->course_id !== $chapter->course->id) {
+                // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
+                return response()->json([
+                    'result'  => false,
+                    'message' => 'Invalid course_id.',
+                ], 403);
+            }
+    
+            // 削除対象チャプターのorderカラムを0に設定し、他のチャプターの順番を更新する。
+            $chapter->update(['order' => 0]);
+    
+            Chapter::where('course_id', $chapter->course_id)
+                ->where('id', '!=', $chapter->id)
+                ->orderBy('order')
+                ->get()
+                ->each(function ($chapter, $index) {
+                    $chapter->update(['order' => $index + 1]);
+                });
+    
+            $chapter->delete();
+    
+            DB::commit();
+    
+            return response()->json([
+                "result" => true
+            ]);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            Log::error($e);
             return response()->json([
                 'result' => false,
-                'message' => 'invalid instructor_id.'
-            ], 403);
+            ], 500);
         }
-
-        if ((int) $request->course_id !== $chapter->course->id) {
-            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
-            return response()->json([
-                'result'  => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
-        }
-
-        $chapter->update(['order' => 0]);
-
-        Chapter::where('course_id', $chapter->course_id)
-            ->where('id', '!=', $chapter->id)
-            ->orderBy('order')
-            ->get()
-            ->each(function ($chapterToUpdate, $index) {
-                $chapterToUpdate->update(['order' => $index + 1]);
-            });
-
-        $chapter->delete();
-
-        return response()->json([
-            "result" => true
-        ]);
     }
-
+    
     /**
      * チャプター並び替えAPI
      *

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -142,14 +142,14 @@ class ChapterController extends Controller
     public function delete(ChapterDeleteRequest $request)
     {
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-    
+
         if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
             return response()->json([
                 'result' => false,
                 'message' => 'invalid instructor_id.'
             ], 403);
         }
-    
+
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
             return response()->json([
@@ -157,9 +157,9 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-    
+
         $chapter->update(['order' => 0]);
-    
+
         Chapter::where('course_id', $chapter->course_id)
             ->where('id', '!=', $chapter->id)
             ->orderBy('order')
@@ -167,14 +167,13 @@ class ChapterController extends Controller
             ->each(function ($chapterToUpdate, $index) {
                 $chapterToUpdate->update(['order' => $index + 1]);
             });
-    
+
         $chapter->delete();
-    
+
         return response()->json([
             "result" => true
         ]);
     }
-    
 
     /**
      * チャプター並び替えAPI

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -142,17 +142,17 @@ class ChapterController extends Controller
     public function delete(ChapterDeleteRequest $request)
     {
         DB::beginTransaction();
-    
+
         try {
             $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-    
+
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
                 return response()->json([
                     'result' => false,
                     'message' => 'invalid instructor_id.'
                 ], 403);
             }
-    
+
             if ((int) $request->course_id !== $chapter->course->id) {
                 // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
                 return response()->json([
@@ -160,10 +160,10 @@ class ChapterController extends Controller
                     'message' => 'Invalid course_id.',
                 ], 403);
             }
-    
+
             // 削除対象チャプターのorderカラムを0に設定し、他のチャプターの順番を更新する。
             $chapter->update(['order' => 0]);
-    
+
             Chapter::where('course_id', $chapter->course_id)
                 ->where('id', '!=', $chapter->id)
                 ->orderBy('order')
@@ -171,11 +171,11 @@ class ChapterController extends Controller
                 ->each(function ($chapter, $index) {
                     $chapter->update(['order' => $index + 1]);
                 });
-    
+
             $chapter->delete();
-    
+
             DB::commit();
-    
+
             return response()->json([
                 "result" => true
             ]);
@@ -187,7 +187,7 @@ class ChapterController extends Controller
             ], 500);
         }
     }
-    
+
     /**
      * チャプター並び替えAPI
      *


### PR DESCRIPTION
## issue
- 講師側チャプター削除APIの修正（削除時にすべてのchapterのorderカラムを変更する）

## 概要
- 削除対象のchapterのorderカラムには、0を入れるようにする
- 削除対象ではないchapterのorderカラムには、削除対象を含まない正しい順番を保存しなおす

## 動作確認手順
- postmanにて、DELETEメソッド、http://localhost:8080/api/v1/instructor/course/{corse_id}/chapter/{chapter_id}
にアクセスしレスポンスが返ってることを確認。
- DB上での削除されたchapterのorderカラムは０になり、その他のorderカラムには順番通りに更新されることを確認。

## 考慮して欲しいこと
- なし

## 確認してほしいこと
- 間違った箇所があればご指摘よろしくお願いいたします。