### PR TITLE
#632 講師のチャプター更新APIで、更新対象のチャプターが本当にその講座の所属かを照合する

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -132,7 +132,7 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-        
+
         $chapter->update([
             'status' => $request->status
         ]);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -89,6 +89,15 @@ class ChapterController extends Controller
                 'message' => 'Invalid instructor_id',
             ], 403);
         }
+
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
+            return response()->json([
+                'result'  => false,
+                'message' => 'Invalid course_id.',
+            ], 403);
+        }
+
         $chapter->update([
             'title' => $request->title
         ]);


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-632

## 概要
- 講師のチャプター更新APIで、更新対象のチャプターが本当にその講座の所属かを照合する
## 動作確認手順
- RLのchapter_idが、更新対象のチャプターであれば以下のレスポンスが返ってくること。
```
{
    "result": true,
    "data": {
        "chapter_id": 1,
        "title": "チャプタータイトル"
    }
}
```
- RLのchapter_idが、違った場合は以下のレスポンスが返ってくること。
```
return response()->json([
                'result'  => false,
                'message' => 'Invalid course_id.',
            ], 403);
```

## 考慮して欲しいこと
- 特にありません
　
## 確認して欲しいこと
- 特にありません