### PR TITLE
#640 講師のチャプター新規登録APIで、講座を本当にその講師が作ったものかを照合する(ごめ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -34,7 +34,7 @@ class ChapterController extends Controller
     {
         try {
             // 講師の情報を取得
-            $user = Auth::user();
+            $user = Auth::guard('instructor')->user();
 
             // リクエストに含まれる講座IDを使用して対応する講座を取得
             $course = Course::with('chapters')->findOrFail($request->input('course_id'));

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -57,9 +57,6 @@ class ChapterController extends Controller
                 'status' => Chapter::STATUS_PUBLIC,
             ]);
 
-            // 新しいチャプターが作成された後、更新されたチャプター情報を含む講座を再取得する
-            $course = $course->fresh('chapters');
-
             return response()->json([
                 'result' => true,
                 'data' => new ChapterStoreResource($chapter),

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -35,7 +35,7 @@ class ChapterController extends Controller
         try {
             // 講師の情報を取得
             $user = Auth::user();
-            
+
             // リクエストに含まれる講座IDを使用して対応する講座を取得
             $course = Course::findOrFail($request->input('course_id'));
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -48,12 +48,15 @@ class ChapterController extends Controller
                 ], 403);
             }
     
-            // チャプターを作成
+            $order = $course->chapters->count();
+            $newOrder = $order + 1;
             $chapter = Chapter::create([
                 'course_id' => $course->id,
                 'title' => $request->input('title'),
+                'order' => $newOrder,
+                'status' => Chapter::STATUS_PUBLIC,
             ]);
-
+    
             return response()->json([
                 'result' => true,
                 'data' => new ChapterStoreResource($chapter),
@@ -148,7 +151,7 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-        
+
         $chapter->update([
             'status' => $request->status
         ]);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -33,8 +33,24 @@ class ChapterController extends Controller
     public function store(ChapterStoreRequest $request)
     {
         try {
+            // 講師の情報を取得
+            $user = Instructor::find($request->user()->id);
+            
+            // リクエストに含まれる講座IDを使用して対応する講座を取得
+            $course = Course::findOrFail($request->input('course_id'));
+    
+            // 講座の作成者が現在の講師であるかどうかを確認
+            if ($course->instructor_id !== $user->id) {
+                // 講座の作成者が現在の講師と一致しない場合はエラーを返す
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Invalid instructor_id for this course.',
+                ], 403);
+            }
+    
+            // チャプターを作成
             $chapter = Chapter::create([
-                'course_id' => $request->input('course_id'),
+                'course_id' => $course->id,
                 'title' => $request->input('title'),
             ]);
 
@@ -132,7 +148,7 @@ class ChapterController extends Controller
                 'message' => 'Invalid course_id.',
             ], 403);
         }
-
+        
         $chapter->update([
             'status' => $request->status
         ]);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -35,10 +35,10 @@ class ChapterController extends Controller
         try {
             // 講師の情報を取得
             $user = Instructor::find($request->user()->id);
-            
+
             // リクエストに含まれる講座IDを使用して対応する講座を取得
             $course = Course::findOrFail($request->input('course_id'));
-    
+
             // 講座の作成者が現在の講師であるかどうかを確認
             if ($course->instructor_id !== $user->id) {
                 // 講座の作成者が現在の講師と一致しない場合はエラーを返す
@@ -47,7 +47,7 @@ class ChapterController extends Controller
                     'message' => 'Invalid instructor_id for this course.',
                 ], 403);
             }
-    
+
             $order = $course->chapters->count();
             $newOrder = $order + 1;
             $chapter = Chapter::create([
@@ -56,7 +56,7 @@ class ChapterController extends Controller
                 'order' => $newOrder,
                 'status' => Chapter::STATUS_PUBLIC,
             ]);
-    
+
             return response()->json([
                 'result' => true,
                 'data' => new ChapterStoreResource($chapter),

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -34,7 +34,7 @@ class ChapterController extends Controller
     {
         try {
             // 講師の情報を取得
-            $user = Instructor::find($request->user()->id);
+            $user = Auth::user();
             
             // リクエストに含まれる講座IDを使用して対応する講座を取得
             $course = Course::findOrFail($request->input('course_id'));

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -37,7 +37,7 @@ class ChapterController extends Controller
             $user = Auth::user();
             
             // リクエストに含まれる講座IDを使用して対応する講座を取得
-            $course = Course::findOrFail($request->input('course_id'));
+            $course = Course::with('chapters')->findOrFail($request->input('course_id'));
 
             // 講座の作成者が現在の講師であるかどうかを確認
             if ($course->instructor_id !== $user->id) {
@@ -56,6 +56,9 @@ class ChapterController extends Controller
                 'order' => $newOrder,
                 'status' => Chapter::STATUS_PUBLIC,
             ]);
+
+            // 新しいチャプターが作成された後、更新されたチャプター情報を含む講座を再取得する
+            $course = $course->fresh('chapters');
 
             return response()->json([
                 'result' => true,


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-640

## 概要
- 講師のチャプター新規登録APIで、講座を本当にその講師が作ったものかを照合する
## 動作確認手順
- RLのcourse_idが、講座作成した講師のであれば以下のレスポンスが返ってくること。
```
{
        return [
            'course_id' => $this->course_id,
            'chapter' => [
                'chapter_id' => $this->id,
                'title' => $this->title,
            ]
        ];
    }
```
- 違った場合
```
return response()->json([
                    'result' => false,
                    'message' => 'Invalid instructor_id for this course.',
                ], 403);
```

## 考慮して欲しいこと
- 特になし
　
## 確認して欲しいこと
- 特になし