### PR TITLE
#KA-642 空の配列を返すルーターとコントローラの作成(ごめ) 

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -129,7 +129,7 @@ class ChapterController extends Controller
        * マネージャ配下のチャプター更新API
        *
        */
-      public function status()
+      public function updateStatus()
       {
           return response()->json([]);
       }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -124,4 +124,13 @@ class ChapterController extends Controller
             "result" => true
         ]);
     }
+
+    /**
+       * マネージャ配下のチャプター更新API
+       *
+       */
+      public function status()
+      {
+          return response()->json([]);
+      }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -129,8 +129,8 @@ class ChapterController extends Controller
        * マネージャ配下のチャプター更新API
        *
        */
-      public function updateStatus()
-      {
-          return response()->json([]);
-      }
+    public function updateStatus()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -163,7 +163,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
-                                Route::patch('status', 'Api\Manager\ChapterController@status');
+                                Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
                             });
                         });
                     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -163,6 +163,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
+                                Route::patch('status', 'Api\Manager\ChapterController@status');
                             });
                         });
                     });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-642
## 概要
- 新権限マネージャー設立による配下のinstructorの作成したチャプター公開状態変更API作成
　１.空の配列を返すルーターとコントローラーの作成
## 動作確認手順
- ルーター、コントローラー作成後、postmanによる確認にて空の配列が返ってきたことを確認
## 考慮して欲しいこと
- 特になし
## 確認して欲しいこと
- 特になし