### PR TITLE
#644 ロジックの作成（ごめ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -130,7 +130,7 @@ class ChapterController extends Controller
        * マネージャ配下のチャプター更新API
        *
        */
-      public function updateStatus(Request $request)
+    public function updateStatus(Request $request)
     {
         // 現在のユーザーを取得（講師の場合）
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -161,11 +161,11 @@ class ChapterController extends Controller
 
         // チャプターのstatusをリクエストのstatusで更新
         $chapter->update([
-            'status' => $request->status
+          'status' => $request->status
         ]);
 
         return response()->json([
-            'result' => true,
+          'result' => true,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Model\Instructor;
 use App\Model\Chapter;
+use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\ChapterShowRequest;
 use App\Http\Requests\Manager\ChapterPatchRequest;
@@ -129,8 +130,42 @@ class ChapterController extends Controller
        * マネージャ配下のチャプター更新API
        *
        */
-      public function updateStatus()
-      {
-          return response()->json([]);
-      }
+      public function updateStatus(Request $request)
+    {
+        // 現在のユーザーを取得（講師の場合）
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        // マネージャーが管理する講師を取得
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        // 指定されたチャプターを取得
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+
+        // 自分、または配下の講師の講座のチャプターでなければエラー応答
+        if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Unauthorized access to update chapter status.'
+            ], 403);
+        }
+
+        // リクエストのcourse_idとチャプターのcourse_idが一致するか確認
+        if ((int) $request->course_id !== $chapter->course->id) {
+            return response()->json([
+                'result'  => false,
+                'message' => 'Invalid course_id.',
+            ], 403);
+        }
+
+        // チャプターのstatusをリクエストのstatusで更新
+        $chapter->update([
+            'status' => $request->status
+        ]);
+
+        return response()->json([
+            'result' => true,
+        ]);
+    }
 }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-642
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-644
## 概要
- 新権限マネージャー設立による配下のinstructorの作成したチャプター公開状態変更API作成、
- 子課題②ロジックの作成
## 動作確認手順
- postmanにて
PATCHリクエストで/api/v1/manager/course/{course_id}/chapter/{chapter_id}/statusにアクセスすると
```
{
  "result": true
}
```
　が返ってくることを確認。
- ログインしているマネージャー自身と配下のインストラクターが持つコースのチャプターでない場合は
```
 'result' => false,
 'message' => 'Unauthorized access to update chapter status.'
```
　が返ってくることを確認。
- リクエストのcourse_idとチャプターのcourse_idが一致しない場合は
```
 ''result'  => false,
 'message' => 'Invalid course_id.',
```
　が返ってくることを確認。

## 考慮して欲しいこと
- 特にありません。
## 確認して欲しいこと
- より良い書き方があればご教授願います。