### PR TITLE
#645 フォームリクエストの作成(ごめ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\ChapterShowRequest;
 use App\Http\Requests\Manager\ChapterPatchRequest;
 use App\Http\Requests\Manager\ChapterDeleteRequest;
+use App\Http\Requests\Manager\ChapterPatchStatusRequest;
 use App\Http\Resources\Manager\ChapterShowResource;
 use Illuminate\Support\Facades\Auth;
 
@@ -130,7 +131,7 @@ class ChapterController extends Controller
        * マネージャ配下のチャプター更新API
        *
        */
-    public function updateStatus(Request $request)
+    public function updateStatus(ChapterPatchStatusRequest $request)
     {
         // 現在のユーザーを取得（講師の場合）
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
+++ b/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
@@ -34,7 +34,7 @@ class ChapterPatchStatusRequest extends FormRequest
     {
         return [
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
-            'chapter_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'status' => ['required', 'string', new ChapterStatusRule()],
         ];
     }

--- a/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
+++ b/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\ChapterStatusRule;
+
+class ChapterPatchStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer'],
+            'chapter_id' => ['required', 'integer'],
+            'status' => ['required', 'string',new ChapterStatusRule()],
+        ];
+    }
+}

--- a/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
+++ b/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
@@ -33,9 +33,9 @@ class ChapterPatchStatusRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer'],
-            'chapter_id' => ['required', 'integer'],
-            'status' => ['required', 'string',new ChapterStatusRule()],
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'status' => ['required', 'string', new ChapterStatusRule()],
         ];
     }
 }


### PR DESCRIPTION
## タスク
- JKA642
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-642
- JKA645
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-645
## 概要
- 新権限マネージャー設立による配下のinstructorの作成したチャプター公開状態変更API作成
- 「フォームリクエストの作成」
## 動作確認手順
- POSTリクエスト
api/v1/manager/course/1/chapter/1/status
- body
```
{
  "status": "public"
}
```
- レスポンス
```
{
  "result": true
}
```
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません
