### PR TITLE
#jka-647 try~catchを追加(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -53,13 +53,12 @@ class ChapterController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-            
-            } catch (Exception $e) {
-                Log::error($e);
-                return response()->json([
-                    'result' => false
-                ], 500);
-            }
+        } catch (Exception $e) {
+            Log::error($e);
+            return response()->json([
+                'result' => false
+            ], 500);
+        }
     }
 
     /**
@@ -87,7 +86,7 @@ class ChapterController extends Controller
         }
         return new ChapterShowResource($chapter);
     }
-    
+
     /**
      * マネージャー配下のチャプター更新API
      *

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Manager\ChapterPatchRequest;
 use App\Http\Requests\Manager\ChapterDeleteRequest;
 use App\Http\Resources\Manager\ChapterShowResource;
 use Illuminate\Support\Facades\Auth;
+use Exception;
 
 class ChapterController extends Controller
 {
@@ -19,6 +20,7 @@ class ChapterController extends Controller
      * チャプター新規作成API
      *
      * @param ChapterStoreRequest $request
+     * @return \Illuminate\Http\JsonResponse
      */
     public function store(ChapterStoreRequest $request)
     {
@@ -78,7 +80,7 @@ class ChapterController extends Controller
         $chapter = Chapter::with(['lessons','course'])->findOrFail($request->chapter_id);
         // 自身もしくは配下のinstructorでない場合はエラー応答
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
-             return response()->json([
+            return response()->json([
                 'result' => false,
                 'message' => "Forbidden, not allowed to edit this course.",
             ], 403);


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-610
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-647
## 概要
- 新権限マネージャー設立による配下のinstructorの作成した講座にチャプターを新規登録できるAPI作成のtry~catchを追加
## 動作確認手順
- ログイン中のマネージャーが自分と配下のインストラクターが持つ講座のチャプターを新規登録する
- POSTリクエストにて  
/api/v1/manager/course/{course_id}/chapter/
- body  
```
{  
   "title": "Hello Worldを出力する"  
}
```
- レスポンス  
```
{  
   "result": true  
}
```
を確認。
## 考慮して欲しいこと
- コンフリクトが起こった際にshowメソッドを触ったためインデントの調整を行っています。
## 確認して欲しいこと
- 特にありません  