### PR TITLE
#jka-658 空の配列を返すルーターとコントローラーの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -9,10 +9,11 @@ class LessonController extends Controller
     /**
      * マネージャ配下のレッスン更新API
      *
-     * 
-     * 
+     *
+     *
      */
-    public function update(){
+    public function update()
+    {
         return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+
+class LessonController extends Controller
+{
+    /**
+     * マネージャ配下のレッスン更新API
+     *
+     * 
+     * 
+     */
+    public function update(){
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -168,7 +168,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 // マネージャー-講師-講座-チャプター-レッスン
                                 Route::prefix('lesson')->group(function () {
                                     Route::prefix('{lesson_id}')->group(function () {
-                                    Route::put('/', 'Api\Manager\LessonController@update');
+                                        Route::put('/', 'Api\Manager\LessonController@update');
                                     });
                                 });
                             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -165,6 +165,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::patch('/', 'Api\Manager\ChapterController@update');
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
+                                // マネージャー-講師-講座-チャプター-レッスン
+                                Route::prefix('lesson')->group(function () {
+                                    Route::prefix('{lesson_id}')->group(function () {
+                                    Route::put('/', 'Api\Manager\LessonController@update');
+                                    });
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-657
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-658
## 概要
- 新権限マネージャー設立による配下のinstructorの作成した講座・チャプターに紐づくレッスンを更新するAPI作成
における、空の配列を返すルーターとコントローラーの作成
## 動作確認手順
- postmanにて
- PUTリクエスト
/api/v1/manager/course/1/chapter/1/lesson/1
```
{
  "title": "レッスンタイトル",
  "url": "https://www.youtube.com/watch?v=xxxxxxxxxxx",
  "remarks": "備考"
}
```
- レスポンス
```
[ ]
```
を確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません