### PR TITLE
JKA-661 講師レッスン更新処理でタイトルを文字数上限以上で入力した際にバリデーションエラーを返すように変更

### DIFF
--- a/app/Http/Requests/Instructor/LessonStoreRequest.php
+++ b/app/Http/Requests/Instructor/LessonStoreRequest.php
@@ -32,8 +32,8 @@ class LessonStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'chapter_id' => ['required','integer', 'exists:chapters,id'],
-            'course_id' => ['required','integer', 'exists:courses,id'],
+            'chapter_id' => ['required','integer', 'exists:chapters,id,deleted_at,NULL'],
+            'course_id' => ['required','integer', 'exists:courses,id,deleted_at,NULL'],
             'title' => ['required','string', 'max:50'],
         ];
     }

--- a/app/Http/Requests/Instructor/LessonUpdateRequest.php
+++ b/app/Http/Requests/Instructor/LessonUpdateRequest.php
@@ -38,7 +38,7 @@ class LessonUpdateRequest extends FormRequest
             'lesson_id' => ['required','integer'],
             'chapter_id' => ['required', 'integer'],
             'course_id' => ['required', 'integer'],
-            'title' => ['required','string'],
+            'title' => ['required','string','max:50'],
             'url' => ['required','string'],
             'remarks' => ['nullable','string'],
             'status' => ['required', 'string', new LessonUpdateStatusRule()],

--- a/app/Http/Requests/Instructor/LessonUpdateRequest.php
+++ b/app/Http/Requests/Instructor/LessonUpdateRequest.php
@@ -35,9 +35,9 @@ class LessonUpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'lesson_id' => ['required','integer'],
-            'chapter_id' => ['required', 'integer'],
-            'course_id' => ['required', 'integer'],
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'lesson_id' => ['required','integer', 'exists:lessons,id,deleted_at,NULL'],
             'title' => ['required','string','max:50'],
             'url' => ['required','string'],
             'remarks' => ['nullable','string'],


### PR DESCRIPTION
## issue
- JKA-661 講師レッスン更新処理でタイトルを文字数上限以上で入力した際にバリデーションエラーを返すように変更

## 概要
- RessonUpdateRequestの41行目を
'title' => ['required','string','max:50'],に変更

## 動作確認手順
- Postmanにて、インストラクターでログイン後、PUTメソッド
[http://localhost:8080/api/v1/instructor/course/{corse_id}/chapter/{chapter_id}/lesson/{lesson_id}]
で、paramsにてtitleを50文字以上で送信し、
```
"title": [
            "The title may not be greater than 50 characters."
        ],
```
上記のバリデーションエラーが返ってくることを確認。

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし