### PR TITLE
空の配列を返すルーターとコントローラの作成(yasuyuki)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -170,4 +170,14 @@ class ChapterController extends Controller
           'result' => true,
         ]);
     }
+    /**
+     * マネージャー
+     * チャプター新規作成API
+     *
+     */
+    public function store()
+    {
+        return response()->json([]);
+    }
+
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -170,14 +170,5 @@ class ChapterController extends Controller
           'result' => true,
         ]);
     }
-    /**
-     * マネージャー
-     * チャプター新規作成API
-     *
-     */
-    public function store()
-    {
-        return response()->json([]);
-    }
-
+   
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -170,13 +170,4 @@ class ChapterController extends Controller
           'result' => true,
         ]);
     }
-    /**
-     * マネージャー
-     * チャプター新規作成API
-     *
-     */
-    public function store()
-    {
-        return response()->json([]);
-    }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -179,5 +179,4 @@ class ChapterController extends Controller
     {
         return response()->json([]);
     }
-
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class LessonController extends Controller
+{
+   /**
+     * マネージャー
+     * チャプター新規作成API
+     *
+     */
+    public function store()
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -166,7 +166,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
                                  // マネージャー-講座-チャプター-レッスン
                                  Route::prefix('lesson')->group(function() {
-                                     Route::post('/', 'Api\Manager\ChapterController@store');
+                                     Route::post('/', 'Api\Manager\LessonController@store');
                                  });
                              });
                         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -166,10 +166,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
                                  // マネージャー-講座-チャプター-レッスン
-                                 Route::prefix('lesson')->group(function() {
+                                 Route::prefix('lesson')->group(function () {
                                      Route::post('/', 'Api\Manager\ChapterController@store');
                                  });
-                             });
+                            });
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -160,7 +160,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
                             Route::prefix('{chapter_id}')->group(function () {
-                                Route::post('/', 'Api\Manager\ChapterController@store');
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -165,10 +165,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
                                  // マネージャー-講座-チャプター-レッスン
-                                 Route::prefix('lesson')->group(function() {
+                                 Route::prefix('lesson')->group(function () {
                                      Route::post('/', 'Api\Manager\ChapterController@store');
                                  });
-                             });
+                            });
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -165,7 +165,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
                                  // マネージャー-講座-チャプター-レッスン
-                                 Route::prefix('lesson')->group(function() {
+                                 Route::prefix('lesson')->group(function () {
                                      Route::post('/', 'Api\Manager\LessonController@store');
                                  });
                             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -160,11 +160,16 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
                             Route::prefix('{chapter_id}')->group(function () {
+                                Route::post('/', 'Api\Manager\ChapterController@store');
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
-                            });
+                                 // マネージャー-講座-チャプター-レッスン
+                                 Route::prefix('lesson')->group(function() {
+                                     Route::post('/', 'Api\Manager\ChapterController@store');
+                                 });
+                             });
                         });
                     });
                 });


### PR DESCRIPTION
## issue
JKA-656 空の配列を返す配列とコントーラーの作成

## 概要
新権限マネージャー設立による配下のinstructorの作成した講座・チャプターに紐づくレッスンを新規登録できるAPI作成のうち
子課題①空の配列を返す配列とコントーラーの作成
api.phpに
```Route::post('/', 'Api\Manager\ChapterController@store');```
を追記
ChapterControllerに
```
public function store()
    {
        return response()->json([]);
    }
```
を追記

## 動作確認手順
postmanにて　POSTリクエストで　```http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson```に送信
```[]```
が返ってくることを確認。
## 考慮してほしいこと
 なし
## 確認してほしいこと
なし