### PR TITLE
#jka-659 ロジックの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -34,14 +34,14 @@ class LessonController extends Controller
                 'message' => "Forbidden, not allowed to edit this lesson.",
             ], 403);
         }
-        
+
         if ((int) $request->chapter_id !== $lesson->chapter->id || (int) $request->course_id !== $lesson->chapter->course_id) {
             return response()->json([
                 'result' => false,
                 'message' => 'Invalid chapter_id or course_id.',
             ], 403);
         }
-        
+
         $lesson->update([
             'title' => $request->title,
             'url' => $request->url,


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-657
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-659
## 概要
- 新権限マネージャー設立による配下のinstructorの作成した講座・チャプターに紐づくレッスンを更新するAPI作成
における、ロジックの作成
## 動作確認手順
-  postmanにて
- PUTリクエスト  
 /api/v1/manager/course/1/chapter/1/lesson/1
```
{
  "title": "レッスンタイトル",
  "url": "https://www.youtube.com/watch?v=xxxxxxxxxxx",
  "remarks": "備考"
}
```
- レスポンス
```
{
  "result": true
}
```
が返ってくることを確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません