### PR TITLE
Feature/kumiko/jka 660/form request

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -33,7 +33,7 @@ class LessonController extends Controller
                 'message' => "Forbidden, not allowed to edit this lesson.",
             ], 403);
         }
-        
+
         if ((int) $request->course_id !== $lesson->chapter->course_id) {
             return response()->json([
                 'result' => false,
@@ -52,6 +52,7 @@ class LessonController extends Controller
             'title' => $request->title,
             'url' => $request->url,
             'remarks' => $request->remarks,
+            'status' => $request->status,
         ]);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -33,18 +33,18 @@ class LessonController extends Controller
                 'message' => "Forbidden, not allowed to edit this lesson.",
             ], 403);
         }
+        
+        if ((int) $request->course_id !== $lesson->chapter->course_id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid course_id.',
+            ], 403);
+        }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id ) {
             return response()->json([
                 'result' => false,
                 'message' => 'Invalid chapter_id.',
-            ], 403);
-        }
-
-        if ((int) $request->course_id !== $lesson->chapter->course_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
             ], 403);
         }
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -41,7 +41,7 @@ class LessonController extends Controller
             ], 403);
         }
 
-        if ((int) $request->chapter_id !== $lesson->chapter->id ) {
+        if ((int) $request->chapter_id !== $lesson->chapter->id) {
             return response()->json([
                 'result' => false,
                 'message' => 'Invalid chapter_id.',

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -4,9 +4,8 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Model\Instructor;
-use App\Model\Course;
 use App\Model\Lesson;
-use Illuminate\Http\Request;
+use App\Http\Requests\Manager\LessonUpdateRequest;
 use Illuminate\Support\Facades\Auth;
 
 class LessonController extends Controller
@@ -15,9 +14,9 @@ class LessonController extends Controller
      * マネージャ配下のレッスン更新API
      *
      *
-     *
+     *@param  LessonUpdateRequest $request
      */
-    public function update(Request $request)
+    public function update(LessonUpdateRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         // 配下の講師情報を取得
@@ -35,10 +34,17 @@ class LessonController extends Controller
             ], 403);
         }
 
-        if ((int) $request->chapter_id !== $lesson->chapter->id || (int) $request->course_id !== $lesson->chapter->course_id) {
+        if ((int) $request->chapter_id !== $lesson->chapter->id ) {
             return response()->json([
                 'result' => false,
-                'message' => 'Invalid chapter_id or course_id.',
+                'message' => 'Invalid chapter_id.',
+            ], 403);
+        }
+
+        if ((int) $request->course_id !== $lesson->chapter->course_id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid course_id.',
             ], 403);
         }
 

--- a/app/Http/Requests/Manager/LessonUpdateRequest.php
+++ b/app/Http/Requests/Manager/LessonUpdateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Manager;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\LessonUpdateStatusRule;
 
 class LessonUpdateRequest extends FormRequest
 {
@@ -34,12 +35,13 @@ class LessonUpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'lesson_id' => ['required','integer'],
-            'chapter_id' => ['required', 'integer'],
-            'course_id' => ['required', 'integer'],
-            'title' => ['required','string'],
+            'lesson_id' => ['required','integer', 'exists:lessons,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'title' => ['required','string','max:50'],
             'url' => ['required','string'],
             'remarks' => ['nullable','string'],
+            'status' => ['required', 'string', new LessonUpdateStatusRule()],
         ];
     }
 }

--- a/app/Http/Requests/Manager/LessonUpdateRequest.php
+++ b/app/Http/Requests/Manager/LessonUpdateRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'lesson_id' => $this->route('lesson_id'),
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'lesson_id' => ['required','integer'],
+            'chapter_id' => ['required', 'integer'],
+            'course_id' => ['required', 'integer'],
+            'title' => ['required','string'],
+            'url' => ['required','string'],
+            'remarks' => ['nullable','string'],
+        ];
+    }
+}


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-657
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-660
## 概要
- 新権限マネージャー設立による配下のinstructorの作成した講座・チャプターに紐づくレッスンを更新するAPI作成
における、フォームリクエストの作成
## 動作確認手順
- postmanにて
- PUTリクエスト
/api/v1/manager/course/1/chapter/1/lesson/1
```
{
  "title": "レッスンタイトル",
  "url": "https://www.youtube.com/watch?v=xxxxxxxxxxx",
  "remarks": "備考"
}
```
- レスポンス
```
{
  "result": true
}
```
が返ってくることを確認。
- course_idが一致しない場合のエラー確認。
- chapter_idが一致しない場合のエラー確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません
