### PR TITLE
JKA-666 空の配列を返すルータとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class AttendanceController extends Controller
+{
+    public function store()
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -169,6 +169,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         });
                     });
                 });
+
+                // マネージャー-受講
+                Route::prefix('attendance')->group(function () {
+                    Route::post('/', 'Api\Manager\AttendanceController@store');
+                });
             });
         });
     });


### PR DESCRIPTION
## issue
- JKA-666 空の配列を返すルータとコントローラの作成

## 概要
新権限マネージャー設立による配下のinstructorの作成した講座に受講情報を登録するAPI作成のうち、
子課題➀ 空の配列を返すルータとコントローラの作成

- api.phpに、
```
Route::prefix('attendance')->group(function () {
                    Route::post('/', 'Api\Manager\AttendanceController@store');
                });
```
を追記

- Api/Manager/AttendanceControllerに、
```
public function store()
    {
        return response()->json([]);
    }
```
を追記

## 動作確認手順
- Postmanにて、POSTリクエスト　http://localhost:8080/api/v1/manager/attendanceを送信
```
[]
```
が結果として帰ってくることを確認

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし