### PR TITLE
JKA-669_(dera)_フォームリクエスト作成_JKA-662

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -45,7 +45,7 @@ class LessonController extends Controller
                 ], 403);
             }
             // 指定したコースIDがレッスンのコースIDと一致しない場合は許可しない
-            if ((int)$request->course_id !== $lesson->chapter->course->id) {
+            if ((int)$request->course_id !== $lesson->chapter->course_id) {
                 return response()->json([
                     'result' => false,
                     'message' => 'Invalid course_id.',

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -44,6 +44,13 @@ class LessonController extends Controller
                     'message' => 'Invalid chapter_id.',
                 ], 403);
             }
+            // 指定したコースIDがレッスンのコースIDと一致しない場合は許可しない
+            if ((int)$request->course_id !== $lesson->chapter->course->id) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Invalid course_id.',
+                ], 403);
+            }
             // 受講情報が登録されている場合は許可しない
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
                 return response()->json([

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\LessonDeleteRequest;
 use App\Model\Lesson;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
 use Exception;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -20,7 +20,7 @@ class LessonController extends Controller
      * @param LessonDeleteRequest $request
      * @return JsonResponse
      */
-    public function delete(Request $request)
+    public function delete(LessonDeleteRequest $request)
     {
         DB::beginTransaction();
         try {

--- a/app/Http/Requests/Manager/LessonDeleteRequest.php
+++ b/app/Http/Requests/Manager/LessonDeleteRequest.php
@@ -19,6 +19,8 @@ class LessonDeleteRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
             'lesson_id' => $this->route('lesson_id'),
         ]);
     }
@@ -31,6 +33,8 @@ class LessonDeleteRequest extends FormRequest
     public function rules()
     {
         return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
         ];
     }

--- a/app/Http/Requests/Manager/LessonDeleteRequest.php
+++ b/app/Http/Requests/Manager/LessonDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'lesson_id' => $this->route('lesson_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
 タスク　[(JKA-662)新権限マネージャー設立による配下のinstructorの作成した講座・チャプターに紐づくレッスンを削除できるAPI作成](https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-662)の内、
子課題②(JKA-669)フォームリクエスト作成

## 概要
1. フォームリクエスト作成
　　`Requests/Manager/LessonDeleteRequest.php`を新規作成
2. フォームリクエストをコントローラへ反映
　　`Requests/Manager/LessonDeleteRequest.php`を
　　`Controllers/Api/Manager/LessonController.php`へ反映

## 動作確認手順
1. 自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合
　　instructor_id：４(test_instructor4@example.com)としてログインの上、
　　instructor_id：１が担当の講座・チャプターに紐づくレッスンを削除実行すると、
　　（URLは`/api/v1/manager/course/1/chapter/1/lesson/1`）
```
{
    "result": false,
    "message": "Invalid instructor_id."
}
```
　　が出力されることを確認

2. 指定したチャプターIDがレッスンのチャプターIDと一致しない場合
　　instructor_id：１(test_instructor@example.com)としてログインの上、
　　レッスンのチャプターIDとして存在しない形として削除実行すると、
　　（URLは`/api/v1/manager/course/1/chapter/5/lesson/4` 等）
```
{
    "result": false,
    "message": "Invalid chapter_id."
}
```
　　が出力されることを確認

3. 受講情報が登録されている場合
　　instructor_id：１(test_instructor@example.com)としてログインの上、
　　受講情報が登録されているレッスンを削除実行すると、
　　（URLは`/api/v1/manager/course/1/chapter/1/lesson/1` 等）
```
{
    "result": false,
    "message": "This lesson has attendance."
}
```
　　が出力されることを確認

4. 正常削除処理
　　instructor_id：１(test_instructor@example.com)としてログインの上、
　　1・2・3の条件を除くレッスンにて削除実行すると、
　　（URLは`/api/v1/manager/course/2/chapter/5/lesson/8` 等）
```
{
    "result": true
}
```
　　が出力されることを確認

## 考慮して欲しいこと
　　無し

## 確認したいこと
　　無し