### PR TITLE
#jka-676 空の配列を返すルーターとコントローラーの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -81,15 +81,15 @@ class LessonController extends Controller
             'data' => new LessonUpdateResource($lesson->refresh())
         ]);
     }
-    
+
     /**
      * レッスンタイトル変更API
      *
-     * 
+     *
      */
     public function updateTitle()
     {
-        return response()->json([]);   
+        return response()->json([]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -81,6 +81,16 @@ class LessonController extends Controller
             'data' => new LessonUpdateResource($lesson->refresh())
         ]);
     }
+    
+    /**
+     * レッスンタイトル変更API
+     *
+     * 
+     */
+    public function updateTitle()
+    {
+        return response()->json([]);   
+    }
 
     /**
      * レッスン並び替えAPI

--- a/routes/api.php
+++ b/routes/api.php
@@ -90,6 +90,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');
+                                    Route::patch('title', 'Api\Instructor\LessonController@updateTitle');
                                 });
                             });
                         });


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-674
## 概要
- 講師側 レッスン名前変更APIの作成
における空の配列を返すルーターとコントローラーの作成
## 動作確認手順
- patchリクエスト
- URL
/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title
- body
```
{
  "title": "レッスンタイトル"
}
```
- レスポンス
```
{
[ ]
}
```
を確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません
