### PR TITLE
Topic/jka 662/manager lesson delete

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -45,7 +45,7 @@ class LessonController extends Controller
                 ], 403);
             }
             // 指定したコースIDがレッスンのコースIDと一致しない場合は許可しない
-            if ((int)$request->course_id !== $lesson->chapter->course->id) {
+            if ((int)$request->course_id !== $lesson->chapter->course_id) {
                 return response()->json([
                     'result' => false,
                     'message' => 'Invalid course_id.',

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -18,7 +18,8 @@ use Exception;
 
 class LessonController extends Controller
 {
-    /* マネージャ配下のレッスン更新API
+    /**
+     * マネージャ配下のレッスン更新API
      *
      * @param  LessonUpdateRequest $request
      * @return \Illuminate\Http\JsonResponse

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use App\Model\Lesson;
+use App\Model\Instructor;
+use App\Model\LessonAttendance;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class LessonController extends Controller
+{
+    /**
+     * レッスン削除API
+     *
+     * @param LessonDeleteRequest $request
+     * @return JsonResponse
+     */
+    public function delete(Request $request)
+    {
+        DB::beginTransaction();
+        try{
+            // 自身と配下のinstructor情報を取得
+            $userId = $request->user()->id;
+            $lesson = Lesson::with('chapter')->findOrFail($request->lesson_id);
+            $manager = Instructor::with('managings')->find($userId);
+            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds[] = $userId;
+            // 自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない
+            if (!in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
+                return response()->json([
+                    'result'  => false,
+                    'message' => 'Invalid instructor_id.',
+                ], 403);
+            }
+            // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
+            if ((int)$request->chapter_id !== $lesson->chapter->id) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Invalid chapter_id.',
+                ], 403);
+            }
+            // 受講情報が登録されている場合は許可しない
+            if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'This lesson has attendance.',
+                ], 403);
+            }
+            // 対象レッスンの削除処理
+            $lesson->update(['order' => 0]);
+            $lesson->delete();
+            Lesson::where('chapter_id', $lesson->chapter_id)
+                ->orderBy('order')
+                ->get()
+                ->each(function ($lesson, $index) {
+                    $lesson->update(['order' => $index + 1]);
+                });
+            DB::commit();
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -44,6 +44,13 @@ class LessonController extends Controller
                     'message' => 'Invalid chapter_id.',
                 ], 403);
             }
+            // 指定したコースIDがレッスンのコースIDと一致しない場合は許可しない
+            if ((int)$request->course_id !== $lesson->chapter->course->id) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Invalid course_id.',
+                ], 403);
+            }
             // 受講情報が登録されている場合は許可しない
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
                 return response()->json([

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\LessonDeleteRequest;
 use App\Model\Lesson;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
 use Exception;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -20,7 +20,7 @@ class LessonController extends Controller
      * @param LessonDeleteRequest $request
      * @return JsonResponse
      */
-    public function delete(Request $request)
+    public function delete(LessonDeleteRequest $request)
     {
         DB::beginTransaction();
         try {

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -23,7 +23,7 @@ class LessonController extends Controller
     public function delete(Request $request)
     {
         DB::beginTransaction();
-        try{
+        try {
             // 自身と配下のinstructor情報を取得
             $userId = $request->user()->id;
             $lesson = Lesson::with('chapter')->findOrFail($request->lesson_id);

--- a/app/Http/Requests/Manager/LessonDeleteRequest.php
+++ b/app/Http/Requests/Manager/LessonDeleteRequest.php
@@ -19,6 +19,8 @@ class LessonDeleteRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
             'lesson_id' => $this->route('lesson_id'),
         ]);
     }
@@ -31,6 +33,8 @@ class LessonDeleteRequest extends FormRequest
     public function rules()
     {
         return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
         ];
     }

--- a/app/Http/Requests/Manager/LessonDeleteRequest.php
+++ b/app/Http/Requests/Manager/LessonDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'lesson_id' => $this->route('lesson_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,7 +135,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
-
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
@@ -147,12 +146,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('edit', 'Api\Manager\CourseController@edit');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
-
                         // マネージャー-講座-生徒
                         Route::prefix('student')->group(function () {
                             Route::get('index', 'Api\Manager\StudentController@index');
                         });
-
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
                             Route::post('/', 'Api\Manager\ChapterController@store');
@@ -161,6 +158,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::patch('/', 'Api\Manager\ChapterController@update');
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
+                                // マネージャー-講座-チャプター-レッスン
+                                Route::prefix('lesson')->group(function () {
+                                    Route::prefix('{lesson_id}')->group(function () {
+                                        Route::delete('/', 'Api\Manager\LessonController@delete');
+                                    });
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
## issue
 タスク　[(JKA-662)新権限マネージャー設立による配下のinstructorの作成した講座・チャプターに紐づくレッスンを削除できるAPI作成](https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-662)

## 概要
1. ルート設定
　　URLを`/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}`として、
　　`routes/api.php`へ追記
2. フォームリクエスト作成
　　`Requests/Manager/LessonDeleteRequest.php`を新規作成
3. ロジック作成
　　配下のinstructorの講座・チャプターに紐づくレッスンを削除可、
　　マネージャ自身が作成した講座・チャプターに紐づくレッスンを削除可、としてdeleteメソッド作成

## 動作確認手順
1. 自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合
　　instructor_id：４(test_instructor4@example.com)としてログインの上、
　　instructor_id：１が担当の講座・チャプターに紐づくレッスンを削除実行すると、
　　（URLは`/api/v1/manager/course/1/chapter/1/lesson/1`）
```
{
    "result": false,
    "message": "Invalid instructor_id."
}
```
　　が出力されることを確認

2. 指定したチャプターIDがレッスンのチャプターIDと一致しない場合
　　instructor_id：１(test_instructor@example.com)としてログインの上、
　　レッスンのチャプターIDとして存在しない形として削除実行すると、
　　（URLは`/api/v1/manager/course/1/chapter/5/lesson/4` 等）
```
{
    "result": false,
    "message": "Invalid chapter_id."
}
```
　　が出力されることを確認

3. 受講情報が登録されている場合
　　instructor_id：１(test_instructor@example.com)としてログインの上、
　　受講情報が登録されているレッスンを削除実行すると、
　　（URLは`/api/v1/manager/course/1/chapter/1/lesson/1` 等）
```
{
    "result": false,
    "message": "This lesson has attendance."
}
```
　　が出力されることを確認

4. 正常削除処理
　　instructor_id：１(test_instructor@example.com)としてログインの上、
　　1・2・3の条件を除くレッスンにて削除実行すると、
　　（URLは`/api/v1/manager/course/2/chapter/5/lesson/8` 等）
```
{
    "result": true
}
```
　　が出力されることを確認

## 考慮して欲しいこと
　　無し

## 確認したいこと
　　無し