### PR TITLE
フォームリクエストの作成(yasuyuki)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -15,8 +15,8 @@ class LessonController extends Controller
    /**
     * レッスン新規作成API
     *
-    *@param LessonStoreRequest $request
-    *@return \Illuminate\Http\JsonResponse
+    * @param LessonStoreRequest $request
+    * @return \Illuminate\Http\JsonResponse
     */
     public function store(LessonStoreRequest $request)
     {

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -8,6 +8,7 @@ use App\Model\Lesson;
 use App\Model\Course;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use App\Http\Requests\Manager\LessonStoreRequest;
 use Illuminate\Support\Facades\Auth;
 
 class LessonController extends Controller
@@ -16,7 +17,7 @@ class LessonController extends Controller
     * レッスン新規作成API
     *
     */
-    public function store(Request $request)
+    public function store(LessonStoreRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         // 配下の講師情報を取得

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\Course;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use App\Http\Requests\Manager\LessonStoreRequest;
 use Illuminate\Support\Facades\Auth;
@@ -16,6 +15,8 @@ class LessonController extends Controller
    /**
     * レッスン新規作成API
     *
+    *@param LessonStoreRequest $request
+    *@return \Illuminate\Http\JsonResponse
     */
     public function store(LessonStoreRequest $request)
     {

--- a/app/Http/Requests/Manager/LessonStoreRequest.php
+++ b/app/Http/Requests/Manager/LessonStoreRequest.php
@@ -15,11 +15,12 @@ class LessonStoreRequest extends FormRequest
     {
         return true;
     }
+
     protected function prepareForValidation()
     {
         $this->merge([
-        'chapter_id' => $this->route('chapter_id'),
-        'course_id' => $this->route('course_id'),
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
         ]);
     }
 
@@ -31,9 +32,9 @@ class LessonStoreRequest extends FormRequest
     public function rules()
     {
         return [
-        'chapter_id' => ['required','integer','exists:chapters,id'],
-        'course_id' => ['required','integer','exists:courses,id'],
-        'title' => ['required','string', 'max:50'],
+            'course_id' => ['required','integer','exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required','integer','exists:chapters,id,deleted_at,NULL'],
+            'title' => ['required','string', 'max:50'],
         ];
     }
 }

--- a/app/Http/Requests/Manager/LessonStoreRequest.php
+++ b/app/Http/Requests/Manager/LessonStoreRequest.php
@@ -15,6 +15,13 @@ class LessonStoreRequest extends FormRequest
     {
         return true;
     }
+    protected function prepareForValidation()
+{
+    $this->merge([
+        'chapter_id' => $this->route('chapter_id'),
+        'course_id' => $this->route('course_id'),
+    ]);
+}
 
     /**
      * Get the validation rules that apply to the request.

--- a/app/Http/Requests/Manager/LessonStoreRequest.php
+++ b/app/Http/Requests/Manager/LessonStoreRequest.php
@@ -27,6 +27,6 @@ class LessonStoreRequest extends FormRequest
         'chapter_id' => ['required','integer','exists:chapters,id'],
         'course_id' => ['required','integer','exists:courses,id'],
         'title' => ['required','string', 'max:50'],
-        ]; 
+        ];
     }
 }

--- a/app/Http/Requests/Manager/LessonStoreRequest.php
+++ b/app/Http/Requests/Manager/LessonStoreRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+        'chapter_id' => ['required','integer','exists:chapters,id'],
+        'course_id' => ['required','integer','exists:courses,id'],
+        'title' => ['required','string', 'max:50'],
+        ]; 
+    }
+}

--- a/app/Http/Requests/Manager/LessonStoreRequest.php
+++ b/app/Http/Requests/Manager/LessonStoreRequest.php
@@ -16,12 +16,12 @@ class LessonStoreRequest extends FormRequest
         return true;
     }
     protected function prepareForValidation()
-{
-    $this->merge([
+    {
+        $this->merge([
         'chapter_id' => $this->route('chapter_id'),
         'course_id' => $this->route('course_id'),
-    ]);
-}
+        ]);
+    }
 
     /**
      * Get the validation rules that apply to the request.
@@ -34,6 +34,6 @@ class LessonStoreRequest extends FormRequest
         'chapter_id' => ['required','integer','exists:chapters,id'],
         'course_id' => ['required','integer','exists:courses,id'],
         'title' => ['required','string', 'max:50'],
-        ]; 
+        ];
     }
 }


### PR DESCRIPTION


## issue
新権限マネージャー設立による配下のinstructorの作成した講座・チャプターに紐づくレッスンを新規登録できるAPI作成のうち
子課題③フォームリクエストの作成
## 概要
マネジャー下のLessonController内の20行目をLessonStoreRequestに変更。
その後新たにLessonStoreRequestファイルを新規作成。
LessonStoreRequest内にバリデーションを追記
## 動作確認手順
POSTMANにて　POSTリクエスト送信　
送信先:```http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson```
```
{
    "result": true,
    "data": {
        "chapter_id": "1",
        "title": "Lesson Title",
        "status": "private",
        "order": 2,
        "updated_at": "2024-01-20 22:15:17",
        "created_at": "2024-01-20 22:15:17",
        "id": 9
    }
}
```
が返ってくる。
## 考慮してほしいこと
なし
## 確認してほしいこと
LessonStoreRequestに書きのコードは要りますでしょうか

```
protected function prepareForValidation()
    {
        $this->merge([
            'chapter_id' => $this->route('chapter_id'),
            'course_id' => $this->route('course_id'),
        ]);
    }
```
