### PR TITLE
#jka-677 ロジックの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\LessonStoreRequest;
 use App\Http\Requests\Instructor\LessonSortRequest;
 use App\Http\Resources\Instructor\LessonStoreResource;
@@ -87,9 +88,39 @@ class LessonController extends Controller
      *
      *
      */
-    public function updateTitle()
+    public function updateTitle(request $request)
     {
-        return response()->json([]);
+        $user = Instructor::find($request->user()->id);
+        $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
+
+        if ($lesson->chapter->course->instructor_id !== $user->id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid instructor_id',
+            ], 403);
+        }
+
+        if ((int) $request->course_id !== $lesson->chapter->course_id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid course_id.',
+            ], 403);
+        }
+
+        if ((int) $request->chapter_id !== $lesson->chapter->id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid chapter_id.',
+            ], 403);
+        }
+
+        $lesson->update([
+            'title' => $request->title,
+        ]);
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-674
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-677
## 概要
- 「講師側 レッスン名前変更APIの作成」における、ロジックの作成
## 動作確認手順
- PATCHリクエスト
- URL
/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title
- body
```
{
  "title": "レッスンタイトル"
}
```
- レスポンス
```
{
  "result": true
}
```
を確認。
- また、course_id, chapter_id, lesson_idの整合性を確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません