### PR TITLE
jka-630 新権限マネージャー設立による配下のinstructorの作成したチャプター並び順変更API作成(ふるさわ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -137,7 +137,6 @@ class ChapterController extends Controller
      *
      * @param ChapterSortRequest $request
      * @return \Illuminate\Http\JsonResponse
-     *
      */
     public function sort(ChapterSortRequest $request)
     {
@@ -147,12 +146,14 @@ class ChapterController extends Controller
             $courseId = $request->input('course_id');
             $chapters = $request->input('chapters');
             $course = Course::findOrFail($courseId);
+
             if ($user->id !== $course->instructor_id) {
                 return response()->json([
                     'result' => false,
-                    'message' => 'You are not authorized to perform this action',
+                    'message' => 'Invalid instructor_id.',
                 ], 403);
             }
+
             foreach ($chapters as $chapter) {
                 Chapter::where('id', $chapter['chapter_id'])
                 ->where('course_id', $courseId)
@@ -161,6 +162,7 @@ class ChapterController extends Controller
                     'order' => $chapter['order']
                 ]);
             }
+
             DB::commit();
             return response()->json([
                 'result' => true,
@@ -169,8 +171,8 @@ class ChapterController extends Controller
             DB::rollBack();
             return response()->json([
                 'result' => false,
-                'message' => 'Not found course.'
-            ], 500);
+                'message' => 'Not found.',
+            ], 404);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -101,8 +101,6 @@ class ChapterController extends Controller
             "result" => true
         ]);
     }
-<<<<<<< Updated upstream
-=======
 
     /**
      * チャプター並び替えAPI
@@ -162,5 +160,4 @@ class ChapterController extends Controller
             ], 500);
         }
     }
->>>>>>> Stashed changes
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -9,7 +9,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\ChapterPatchRequest;
 use App\Http\Requests\Manager\ChapterDeleteRequest;
 use App\Http\Requests\Manager\ChapterSortRequest;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -107,11 +106,9 @@ class ChapterController extends Controller
      *
      * @param ChapterSortRequest $request
      * @return \Illuminate\Http\JsonResponse
-     *
      */
     public function sort(ChapterSortRequest $request)
     {
-        // チャプターをソートする
         DB::beginTransaction();
         try {
             // 現在のユーザーを取得
@@ -130,9 +127,10 @@ class ChapterController extends Controller
                 // 失敗結果を返す
                 return response()->json([
                     'result'  => false,
-                    'message' => "Forbidden, not allowed to edit this chapter.",
+                    'message' => "Forbidden, not allowed to edit this course.",
                 ], 403);
             }
+
             foreach ($chapters as $chapter) {
                 Chapter::where('id', $chapter['chapter_id'])
                 ->where('course_id', $courseId)
@@ -141,17 +139,17 @@ class ChapterController extends Controller
                     'order' => $chapter['order']
                 ]);
             }
+
             DB::commit();
             return response()->json([
                 'result' => true,
             ]);
         } catch (ModelNotFoundException $e) {
             DB::rollBack();
-            Log::error($e);
             return response()->json([
                 'result' => false,
-                'message' => 'Not found course.'
-            ], 500);
+                'message' => 'Not found.'
+            ], 404);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Requests/Instructor/ChapterSortRequest.php
+++ b/app/Http/Requests/Instructor/ChapterSortRequest.php
@@ -16,26 +16,25 @@ class ChapterSortRequest extends FormRequest
         return true;
     }
 
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array
-     */
-
-    public function rules()
-    {
-        return [
-            'course_id' => ['required', 'integer'],
-            'chapters' => ['required', 'array'],
-            'chapters.*.chapter_id' => ['required', 'integer'],
-            'chapters.*.order' => ['required', 'integer'],
-        ];
-    }
-
     protected function prepareForValidation()
     {
         $this->merge([
             'course_id' => $this->route('course_id'),
         ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapters' => ['required', 'array'],
+            'chapters.*.chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'chapters.*.order' => ['required', 'integer'],
+        ];
     }
 }

--- a/app/Http/Requests/Manager/ChapterSortRequest.php
+++ b/app/Http/Requests/Manager/ChapterSortRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChapterSortRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true; // ここで認証は行わないのでtrueを返す
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapters' => ['required', 'array'],
+            'chapters.*.chapter_id' => ['required', 'integer'],
+            'chapters.*.order' => ['required', 'integer'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        // 講座IDはリクエストのURLから取得
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Manager/ChapterSortRequest.php
+++ b/app/Http/Requests/Manager/ChapterSortRequest.php
@@ -13,7 +13,14 @@ class ChapterSortRequest extends FormRequest
      */
     public function authorize()
     {
-        return true; // ここで認証は行わないのでtrueを返す
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
     }
 
     /**
@@ -21,22 +28,13 @@ class ChapterSortRequest extends FormRequest
      *
      * @return array
      */
-
     public function rules()
     {
         return [
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'chapters' => ['required', 'array'],
-            'chapters.*.chapter_id' => ['required', 'integer'],
+            'chapters.*.chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'chapters.*.order' => ['required', 'integer'],
         ];
-    }
-
-    protected function prepareForValidation()
-    {
-        // 講座IDはリクエストのURLから取得
-        $this->merge([
-            'course_id' => $this->route('course_id'),
-        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,6 +153,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
+                            Route::post('sort', 'Api\Manager\ChapterController@sort');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::patch('/', 'Api\Manager\ChapterController@update');
                                 Route::delete('/', 'Api\Manager\ChapterController@delete');


### PR DESCRIPTION
## 概要
-  新権限マネージャー設立による配下のinstructorの作成したチャプター並び順変更API作成(ふるさわ)

## 動作確認手順
- POSTリクエスト
/api/v1/manager/course/1/chapter/sort
- body
```
{
  "chapters": [
    {
      "chapter_id": 1,
      "order": 2
    },
    {
      "chapter_id": 2,
      "order": 1
    }
  ]
}
```
- レスポンス
```
{
    "result": true
}
```
## 考慮して欲しいこと
- 配下ではないインストラクターのチャプターをソートした場合のエラー確認は
chaptersテーブルにテスト用のレコードを追加する必要があります。

## 確認して欲しいこと
- api.phpのルーティング追加がローカルリポジトリにマージされていなかった（？）ため
今回のプルリクエストに変更が含まれていますが、原因がわかりません。
