### PR TITLE
#jka-678 フォームリクエストの作成(kumiko)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\Instructor\LessonSortRequest;
 use App\Http\Resources\Instructor\LessonStoreResource;
 use App\Http\Requests\Instructor\LessonDeleteRequest;
 use App\Http\Requests\Instructor\LessonUpdateRequest;
+use App\Http\Requests\Instructor\LessonUpdateTitleRequest;
 use App\Http\Resources\Instructor\LessonUpdateResource;
 use App\Model\Lesson;
 use App\Model\Instructor;
@@ -86,11 +87,11 @@ class LessonController extends Controller
     /**
      * レッスンタイトル変更API
      *
-     *
+     *@param  LessonUpdateTitleRequest  $request
      */
-    public function updateTitle(request $request)
+    public function updateTitle(LessonUpdateTitleRequest $request)
     {
-        $user = Instructor::find($request->user()->id);
+        $user = Auth::guard('instructor')->user();
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
 
         if ($lesson->chapter->course->instructor_id !== $user->id) {

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\LessonStoreRequest;
 use App\Http\Requests\Instructor\LessonSortRequest;
 use App\Http\Resources\Instructor\LessonStoreResource;
@@ -52,6 +51,12 @@ class LessonController extends Controller
         }
     }
 
+    /**
+     * レッスン更新API
+     *
+     * @param LessonUpdateRequest $request
+     * @return JsonResponse
+     */
     public function update(LessonUpdateRequest $request)
     {
         $user = Instructor::find($request->user()->id);
@@ -87,7 +92,8 @@ class LessonController extends Controller
     /**
      * レッスンタイトル変更API
      *
-     *@param  LessonUpdateTitleRequest  $request
+     * @param LessonUpdateTitleRequest $request
+     * @return JsonResponse
      */
     public function updateTitle(LessonUpdateTitleRequest $request)
     {

--- a/app/Http/Requests/Instructor/LessonUpdateTitleRequest.php
+++ b/app/Http/Requests/Instructor/LessonUpdateTitleRequest.php
@@ -19,12 +19,11 @@ class LessonUpdateTitleRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
-            'lesson_id' => $this->route('lesson_id'),
             'course_id' => $this->route('course_id'),
             'chapter_id' => $this->route('chapter_id'),
+            'lesson_id' => $this->route('lesson_id'),
         ]);
     }
-
 
     /**
      * Get the validation rules that apply to the request.

--- a/app/Http/Requests/Instructor/LessonUpdateTitleRequest.php
+++ b/app/Http/Requests/Instructor/LessonUpdateTitleRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonUpdateTitleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'lesson_id' => $this->route('lesson_id'),
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'lesson_id' => ['required','integer', 'exists:lessons,id,deleted_at,NULL'],
+            'title' => ['required','string','max:50'],
+        ];
+    }
+}


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-674
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-678
## 概要
- 講師側 レッスン名前変更APIの作成におけるフォームリクエストの作成
## 動作確認手順
- PATCHリクエスト
- URL
/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title
- body
```
{
  "title": "レッスンタイトル"
}
```
- レスポンス
```
{
  "result": true
}
```
を確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません
