### PR TITLE
JKA-685 空の配列を返すルータとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -82,6 +82,17 @@ class LessonController extends Controller
         ]);
     }
 
+ /**
+     * レッスンステータス更新API
+     *
+    //  * @param LessonPatchStatusRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function updateStatus()
+    {
+        return response()->json([]);
+    }
+
     /**
      * レッスン並び替えAPI
      *

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -82,7 +82,7 @@ class LessonController extends Controller
         ]);
     }
 
- /**
+    /**
      * レッスンステータス更新API
      *
      * @param LessonPatchStatusRequest $request

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -85,7 +85,7 @@ class LessonController extends Controller
  /**
      * レッスンステータス更新API
      *
-    //  * @param LessonPatchStatusRequest $request
+     * @param LessonPatchStatusRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function updateStatus()

--- a/routes/api.php
+++ b/routes/api.php
@@ -90,6 +90,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');
+                                    Route::patch('status', 'Api\Instructor\LessonController@updateStatus');
                                 });
                             });
                         });


### PR DESCRIPTION
## issue
- タスク JKA-681 講師のレッスンステータス更新APIの作成のうち、
子課題➀ 空の配列を返すルータとコントローラの作成

## 概要
- routes/api.php 93行目に、
```
Route::patch('status', 'Api\Instructor\LessonController@updateStatus');
```
を追記
- app/Http/Controllers/Api/Instructor/LessonController.phpに、
```
public function updateStatus()
    {
        return response()->json([]);
    }
```
を追記

## 動作確認手順
- Postmanにて、PATCHリクエスト
http://localhost:8080/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/statusを送信
```
[]
```
上記のレスポンスが返ってくることを確認

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし