### PR TITLE
#jka-664 講師更新文字数制限(kumiko)

### DIFF
--- a/app/Http/Requests/Instructor/InstructorPatchRequest.php
+++ b/app/Http/Requests/Instructor/InstructorPatchRequest.php
@@ -33,10 +33,10 @@ class InstructorPatchRequest extends FormRequest
     public function rules()
     {
         return [
-            'nick_name' => ['required', 'string'],
-            'last_name' => ['required', 'string'],
-            'first_name' => ['required', 'string'],
-            'email' => ['required', 'email', new InstructorUniqueEmailRule(Auth::user()->email)],
+            'nick_name' => ['required', 'string','max:50'],
+            'last_name' => ['required', 'string','max:50'],
+            'first_name' => ['required', 'string','max:50'],
+            'email' => ['required', 'email', new InstructorUniqueEmailRule(Auth::user()->email),'max:255'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
             'profile_image' => ['mimes:jpg,png', 'max:2048'],
         ];


### PR DESCRIPTION
## タスク
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-664
## 概要
- Laravel 講師情報更新の講師名・姓・名・メールアドレスなどで文字数上限を超える場合にエラーが出ない問題の解消
## 動作確認手順
- POSTリクエスト
- URL
http://localhost:8080/api/v1/instructor/update
- body
```
{
  "nick_name": "ニックネーム",
  "last_name": "名字",
  "first_name": "名前",
  "email": "test@example.com",
  "profile_image": "/instructor/xxx.png"
}
```
- それぞれ文字数を超えた場合にエラーが出ることを確認。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません