### PR TITLE
空の配列を返すルーターとコントローラーの作成(鈴木)

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -3,36 +3,14 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\NotificationIndexRequest;
-use App\Http\Resources\Instructor\NotificationIndexResource;
+
 use App\Http\Requests\Instructor\NotificationShowRequest;
 use App\Http\Resources\Instructor\NotificationShowResource;
-use App\Http\Requests\Instructor\NotificationStoreRequest;
-use App\Http\Requests\Instructor\NotificationUpdateRequest;
-use App\Http\Resources\Instructor\NotificationUpdateResource;
-use App\Model\Notification;
-use Illuminate\Support\Facades\Auth;
+
 
 class NotificationController extends Controller
 {
-    // /**
-    //  * マネージャー側お知らせ一覧取得API
-    //  *
-    //  * @param NotificationIndexRequest $request
-    //  * @return NotificationIndexResource
-    //  */
-    // public function index(NotificationIndexRequest $request)
-    // {
-    //     $perPage = $request->input('per_page', 20);
-    //     $page = $request->input('page', 1);
-
-    //     $notifications = Notification::with(['course'])
-    //                                     ->where('instructor_id', Auth::guard('instructor')->user()->id)
-    //                                     ->paginate($perPage, ['*'], 'page', $page);
-
-    //     return new NotificationIndexResource($notifications);
-    // }
-
+    
     /**
      * お知らせ詳細
      *
@@ -44,50 +22,5 @@ class NotificationController extends Controller
         return response()->json([]);    //空の配列を返すメソッド
     }
 
-    // /**
-    //  * お知らせ登録
-    //  *
-    //  * @param NotificationStoreRequest $request
-    //  * @return \Illuminate\Http\JsonResponse
-    //  */
-    // public function store(NotificationStoreRequest $request)
-    // {
-    //     Notification::create([
-    //         'course_id'     => $request->course_id,
-    //         'instructor_id' => Auth::guard('instructor')->user()->id,
-    //         'title'         => $request->title,
-    //         'type'          => $request->type,
-    //         'start_date'    => $request->start_date,
-    //         'end_date'      => $request->end_date,
-    //         'content'       => $request->content,
-    //     ]);
-
-    //     return response()->json([
-    //         'result' => true,
-    //     ]);
-    // }
-
-    // /**
-    //  * お知らせ更新API
-    //  *
-    //  * @param   NotificationUpdateRequest $request
-    //  * @return \Illuminate\Http\JsonResponse
-    //  */
-    // public function update(NotificationUpdateRequest $request)
-    // {
-    //     $notification = Notification::findOrFail($request->notification_id);
-    //     $notification->fill([
-    //         'type'  => $request->type,
-    //         'start_date' => $request->start_date,
-    //         'end_date' => $request->end_date,
-    //         'title' => $request->title,
-    //         'content' => $request->content,
-    //     ])
-    //     ->save();
-
-    //     return response()->json([
-    //         'result' => true,
-    //         'data' => new NotificationUpdateResource($notification),
-    //     ]);
-    // }
+    
 }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\NotificationIndexRequest;
+use App\Http\Resources\Instructor\NotificationIndexResource;
+use App\Http\Requests\Instructor\NotificationShowRequest;
+use App\Http\Resources\Instructor\NotificationShowResource;
+use App\Http\Requests\Instructor\NotificationStoreRequest;
+use App\Http\Requests\Instructor\NotificationUpdateRequest;
+use App\Http\Resources\Instructor\NotificationUpdateResource;
+use App\Model\Notification;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationController extends Controller
+{
+    // /**
+    //  * マネージャー側お知らせ一覧取得API
+    //  *
+    //  * @param NotificationIndexRequest $request
+    //  * @return NotificationIndexResource
+    //  */
+    // public function index(NotificationIndexRequest $request)
+    // {
+    //     $perPage = $request->input('per_page', 20);
+    //     $page = $request->input('page', 1);
+
+    //     $notifications = Notification::with(['course'])
+    //                                     ->where('instructor_id', Auth::guard('instructor')->user()->id)
+    //                                     ->paginate($perPage, ['*'], 'page', $page);
+
+    //     return new NotificationIndexResource($notifications);
+    // }
+
+    /**
+     * お知らせ詳細
+     *
+     * @param NotificationShowRequest $request
+     * @return NotificationShowResource
+     */
+    public function show()
+    {
+        return response()->json([]);    //空の配列を返すメソッド
+    }
+
+    // /**
+    //  * お知らせ登録
+    //  *
+    //  * @param NotificationStoreRequest $request
+    //  * @return \Illuminate\Http\JsonResponse
+    //  */
+    // public function store(NotificationStoreRequest $request)
+    // {
+    //     Notification::create([
+    //         'course_id'     => $request->course_id,
+    //         'instructor_id' => Auth::guard('instructor')->user()->id,
+    //         'title'         => $request->title,
+    //         'type'          => $request->type,
+    //         'start_date'    => $request->start_date,
+    //         'end_date'      => $request->end_date,
+    //         'content'       => $request->content,
+    //     ]);
+
+    //     return response()->json([
+    //         'result' => true,
+    //     ]);
+    // }
+
+    // /**
+    //  * お知らせ更新API
+    //  *
+    //  * @param   NotificationUpdateRequest $request
+    //  * @return \Illuminate\Http\JsonResponse
+    //  */
+    // public function update(NotificationUpdateRequest $request)
+    // {
+    //     $notification = Notification::findOrFail($request->notification_id);
+    //     $notification->fill([
+    //         'type'  => $request->type,
+    //         'start_date' => $request->start_date,
+    //         'end_date' => $request->end_date,
+    //         'title' => $request->title,
+    //         'content' => $request->content,
+    //     ])
+    //     ->save();
+
+    //     return response()->json([
+    //         'result' => true,
+    //         'data' => new NotificationUpdateResource($notification),
+    //     ]);
+    // }
+}

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -3,14 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-
 use App\Http\Requests\Instructor\NotificationShowRequest;
 use App\Http\Resources\Instructor\NotificationShowResource;
 
-
 class NotificationController extends Controller
 {
-    
     /**
      * お知らせ詳細
      *
@@ -21,6 +18,4 @@ class NotificationController extends Controller
     {
         return response()->json([]);    //空の配列を返すメソッド
     }
-
-    
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -177,6 +177,13 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('attendance')->group(function () {
                     Route::post('/', 'Api\Manager\AttendanceController@store');
                 });
+
+                //マネージャー-お知らせ
+                Route::prefix('notification')->group(function () {
+                    Route::prefix('{notification_id}')->group(function () {
+                        Route::post('/', 'Api\Manager\NotificationController@show');
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
## issue

## 概要
- お知らせの詳細表示の前段階として、空の配列を返すルーターとコントローラーを作成

## 動作確認手順
- postmanでsendし、空の配列が返されることを確認
　URL　http://localhost:8080/api/v1/manager/notification/{notification_id}
　body　Key　notification_id、Value　1

## 考慮してほしいこと
特になし

## 確認してほしいこと
特になし
