### PR TITLE
講師、マネージャー側の生徒一覧取得APIの改修

### DIFF
--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -47,16 +47,28 @@ class StudentController extends Controller
             ], 403);
         }
 
-        // 指定した講座の受講生情報と講座情報を取得
-        $attendances = Attendance::with(['course', 'student'])
-            ->where('course_id', $request->course_id)
+        $results = DB::table('attendances')
+            ->select(
+                'attendances.*',
+                'students.nick_name',
+                'students.email',
+                'students.profile_image',
+                'students.last_login_at'
+            )
+            ->where('attendances.course_id', $request->course_id)
             ->join('students', 'attendances.student_id', '=', 'students.id')
-            ->orderBy($sortBy, $order)
+            ->when($sortBy === 'attendanced_at', function ($query) use ($order) {
+                $query->orderBy('attendances.created_at', $order);
+            }, function ($query) use ($sortBy, $order) {
+                $query->orderBy('students.' . $sortBy, $order);
+            })
             ->paginate($perPage, ['*'], 'page', $page);
+
+        $course = Course::find($request->course_id);
 
         return new StudentIndexResource([
             'course' => $course,
-            'attendances' => $attendances,
+            'data' => $results
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Http\Requests\Manager\StudentIndexRequest;
 use App\Http\Resources\Manager\StudentIndexResource;
+use Illuminate\Support\Facades\DB;
 
 class StudentController extends Controller
 {

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Resources\Instructor;
 
+use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 
 class StudentIndexResource extends JsonResource
 {
@@ -14,35 +16,37 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-
+        /** @var \App\Model\Course $course */
         $course = $this->resource['course'];
-        $attendances = $this->resource['attendances'];
+
+        /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
+        $data = $this->resource['data'];
 
         return [
             'course' => [
-                'id' => $course->id,
+                'course_id' => $course->id,
                 'image' => $course->image,
                 'title' => $course->title,
             ],
             'pagination' => [
-                'page' => $attendances->currentPage(),
-                'total' => $attendances->total(),
+                'page' => $data->currentPage(),
+                'total' => $data->total(),
             ],
-            'students' => $this->mapStudents($attendances),
+            'students' => $this->mapStudents($data->getCollection(), $course),
         ];
     }
 
-    protected function mapStudents($attendances)
+    private function mapStudents(Collection $results, Course $course)
     {
-        return $attendances->map(function ($attendance) {
+        return $results->map(function ($result) use ($course) {
             return [
-                'id' => $attendance->student->id,
-                'nick_name' => $attendance->student->nick_name,
-                'email' => $attendance->student->email,
-                'profile_image' => $attendance->student->profile_image,
-                'course_title' => $attendance->course->title,
-                'last_login_at' => $attendance->student->last_login_at->format('Y/m/d  H:i:s'),
-                'attendanced_at' => $attendance->created_at->format('Y/m/d'),
+                'student_id' => $result->student_id,
+                'nick_name' => $result->nick_name,
+                'email' => $result->email,
+                'profile_image' => $result->profile_image,
+                'course_title' => $course->title,
+                'last_login_at' => $result->last_login_at,
+                'attendanced_at' => $result->created_at,
             ];
         });
     }

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Resources\Manager;
 
+use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 
 class StudentIndexResource extends JsonResource
 {
@@ -14,34 +16,37 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
+        /** @var \App\Model\Course $course */
         $course = $this->resource['course'];
-        $attendances = $this->resource['attendances'];
+
+        /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
+        $data = $this->resource['data'];
 
         return [
             'course' => [
-                'id' => $course->id,
+                'course_id' => $course->id,
                 'image' => $course->image,
                 'title' => $course->title,
             ],
             'pagination' => [
-                'page' => $attendances->currentPage(),
-                'total' => $attendances->total(),
+                'page' => $data->currentPage(),
+                'total' => $data->total(),
             ],
-            'students' => $this->mapStudents($attendances),
+            'students' => $this->mapStudents($data->getCollection(), $course),
         ];
     }
 
-    protected function mapStudents($attendances)
+    private function mapStudents(Collection $results, Course $course)
     {
-        return $attendances->map(function ($attendance) {
+        return $results->map(function ($result) use ($course) {
             return [
-                'id' => $attendance->student->id,
-                'nick_name' => $attendance->student->nick_name,
-                'email' => $attendance->student->email,
-                'profile_image' => $attendance->student->profile_image,
-                'course_title' => $attendance->course->title,
-                'last_login_at' => $attendance->student->last_login_at->format('Y/m/d  H:i:s'),
-                'attendanced_at' => $attendance->created_at->format('Y/m/d'),
+                'student_id' => $result->student_id,
+                'nick_name' => $result->nick_name,
+                'email' => $result->email,
+                'profile_image' => $result->profile_image,
+                'course_title' => $course->title,
+                'last_login_at' => $result->last_login_at,
+                'attendanced_at' => $result->created_at,
             ];
         });
     }

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -5,14 +5,15 @@ namespace App\Model;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
  * @property int $course_id
  * @property int $student_id
  * @property int $progress
- * @property string $created_at
- * @property string $updated_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property string|null $deleted_at
  * @property Student $student
  * @property Course $course
@@ -36,7 +37,11 @@ class Attendance extends Model
     ];
 
     protected $casts = [
-        'student_id' => 'int'
+        'student_id' => 'int',
+        'course_id' => 'int',
+        'progress' => 'int',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
     ];
 
     // 受講状態初期値
@@ -83,7 +88,7 @@ class Attendance extends Model
     //ソート項目
     const SORT_BY_NICK_NAME = 'nick_name';
     const SORT_BY_EMAIL = 'email';
-    const SORT_BY_CREATED_AT = 'created_at';
+    const SORT_BY_ATTENDANCED_AT = 'attendanced_at';
     const SORT_BY_LAST_LOGIN_AT = 'last_login_at';
 
     //$periodのバリデーションに利用する定数

--- a/app/Rules/IndexSortByRule.php
+++ b/app/Rules/IndexSortByRule.php
@@ -32,7 +32,7 @@ class IndexSortByRule implements Rule
                 [
                 Attendance::SORT_BY_NICK_NAME,
                 Attendance::SORT_BY_EMAIL,
-                Attendance::SORT_BY_CREATED_AT,
+                Attendance::SORT_BY_ATTENDANCED_AT,
                 Attendance::SORT_BY_LAST_LOGIN_AT,
                 ],
                 true


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-715

## やったこと
- Eloquentの取得からQueryBuliderによる取得に修正

## 理由
- ソートするときにEloquentのjoinでは、意図せずカラム同士(=created_at)が競合して正常にソート処理がされていなかったため。
- 難易度が少し高いと判断したため、私の方で対応しました。