### PR TITLE
講師の講座詳細取得APIの修正(かずふみ)

### DIFF
--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -23,7 +23,6 @@ class CourseShowResource extends JsonResource
                 return [
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
-                    'order' => $chapter->order,
                     'status' => $chapter->status,
                     'lessons' => $chapter->lessons->map(function ($lesson) {
                         return [
@@ -31,6 +30,7 @@ class CourseShowResource extends JsonResource
                            'url'=>$lesson->url,
                            'title'=>$lesson->title,
                            'remarks'=>$lesson->remarks,
+                           'status' =>$lesson->status,
                         ];
                     })
                 ];

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -79,7 +79,7 @@ class Chapter extends Model
      */
     public function lessons()
     {
-        return $this->hasMany(Lesson::class);
+        return $this->hasMany(Lesson::class)->orderBy('order', 'asc');
     }
 
     /**


### PR DESCRIPTION
## 概要
- 講師の講座詳細取得APIの修正

## 動作確認手順
- Adminer のchaptersデータのorderの順番を変えても
order順に並んでいるか確認
- Adminer のlessonsデータのorderの順番を変えても
order順に並んでいるか確認

- チャプターのorderが削除されているか確認
- レッスンのステータスをレスポンスに追加されているか確認

## 考慮して欲しいこと
- 特にありません

## 確認して欲しいこと
- プルリクをあげる時の表題が出ていなくって
Open a pull requestが出でいます。
どうしてかな？
ちょっと、疑問です。

## メッセージ
- ほぼほぼ、ゆきひろさん、こうさんの言われたコードです。
すみません。
ありがとうございました。

