### PR TITLE
フォームリクエスト&リソースファイル作成（はいしま）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -3,11 +3,9 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Model\Instructor;
-
-// use App\Http\Requests\manager\NotificationUpdateRequest;
-// use App\Http\Resources\manager\NotificationUpdateResource;
+use App\Http\Requests\Manager\NotificationUpdateRequest;
+use App\Http\Resources\Manager\NotificationUpdateResource;
 use App\Model\Notification;
 use Illuminate\Support\Facades\Auth;
 
@@ -20,9 +18,7 @@ class NotificationController extends Controller
      * @return \Illuminate\Http\JsonResponse
      */
 
-    public function update(Request $request)
-    // ※NotificationUpdateRequestは後で作成
-    // public function update(NotificationUpdateRequest $request)
+    public function update(NotificationUpdateRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $manager = Instructor::with('managings')->find($instructorId);
@@ -48,20 +44,9 @@ class NotificationController extends Controller
         ])
         ->save();
 
-        //※仮
-        $testResource = [
-            'type' => $notification->type,
-            'start_date' => $notification->start_date,
-            'end_date' => $notification->end_date,
-            'title' => $notification->title,
-            'content' => $notification->content,
-        ];
-
         return response()->json([
             'result' => true,
-            'data' => $testResource,
-            // ※NotificationUpdateResourceは後で作成
-            // 'data' => new NotificationUpdateResource($notification),
+            'data' => new NotificationUpdateResource($notification),
         ]);
     }
 }

--- a/app/Http/Requests/Instructor/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Instructor/NotificationUpdateRequest.php
@@ -31,7 +31,7 @@ class NotificationUpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'notification_id' => ['required', 'integer'],
+            'notification_id' => ['required', 'integer', 'exists:notifications,id,deleted_at,NULL'],
             'type'            => ['required', new NotificationUpdateStatusRule()],
             'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
             'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],

--- a/app/Http/Requests/Manager/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Manager/NotificationUpdateRequest.php
@@ -3,11 +3,8 @@
 namespace App\Http\Requests\Manager;
 
 use App\Rules\NotificationUpdateStatusRule;
-use App\Model\Notification;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Facades\Log;
+
 class NotificationUpdateRequest extends FormRequest
 {
     /**
@@ -33,39 +30,13 @@ class NotificationUpdateRequest extends FormRequest
      */
     public function rules()
     {
-        //対象のデータがない（論理削除を含む）場合はエラーを返す
-        try {
-            // Log::info('Notification ID: ' . $this->route('notification_id'));
-            $notification = Notification::findOrFail($this->route('notification_id'));
-
-            //対象のデータがある→論理削除されているかチェック
-            if ($notification->trashed()) {
-                if ($notification->deleted_at === null) {
-                    // 論理削除されている→エラーで返す
-                    return response()->json([
-                        'result' => false,
-                        'message' => 'Notification is soft deleted.'
-                    ], 403);
-                }
-            }
-
-            return [
-                'notification_id' => ['required', 'integer'],
-                'type'            => ['required', new NotificationUpdateStatusRule()],
-                'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
-                'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
-                'title'           => ['required', 'string', 'max:50'],
-                'content'         => ['required', 'string', 'max:500'],
-            ];
-
-        //対象のデータがない→エラーで返す
-        } catch (Exception $e) {
-            Log::error($e);
-            return response()->json([
-                'result' => false,
-                // 'message' => "This Notification does not exist."
-            ], 500);
-        }
-
+        return [
+            'notification_id' => ['required', 'integer','exists:notifications,id,deleted_at,NULL'],
+            'type'            => ['required', new NotificationUpdateStatusRule()],
+            'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
+            'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
+            'title'           => ['required', 'string', 'max:50'],
+            'content'         => ['required', 'string', 'max:500'],
+        ];
     }
 }

--- a/app/Http/Requests/Manager/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Manager/NotificationUpdateRequest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Log;
+
 class NotificationUpdateRequest extends FormRequest
 {
     /**
@@ -66,6 +67,5 @@ class NotificationUpdateRequest extends FormRequest
                 // 'message' => "This Notification does not exist."
             ], 500);
         }
-
     }
 }

--- a/app/Http/Requests/Manager/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Manager/NotificationUpdateRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use App\Rules\NotificationUpdateStatusRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_id' => $this->route('notification_id'),
+        ]);
+    }
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'notification_id' => ['required', 'integer'],
+            'type'            => ['required', new NotificationUpdateStatusRule()],
+            'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
+            'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
+            'title'           => ['required', 'string', 'max:50'],
+            'content'         => ['required', 'string', 'max:500'],
+        ];
+    }
+}

--- a/app/Http/Requests/Manager/NotificationUpdateRequest.php
+++ b/app/Http/Requests/Manager/NotificationUpdateRequest.php
@@ -3,8 +3,11 @@
 namespace App\Http\Requests\Manager;
 
 use App\Rules\NotificationUpdateStatusRule;
+use App\Model\Notification;
 use Illuminate\Foundation\Http\FormRequest;
-
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Log;
 class NotificationUpdateRequest extends FormRequest
 {
     /**
@@ -30,13 +33,39 @@ class NotificationUpdateRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'notification_id' => ['required', 'integer'],
-            'type'            => ['required', new NotificationUpdateStatusRule()],
-            'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
-            'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
-            'title'           => ['required', 'string', 'max:50'],
-            'content'         => ['required', 'string', 'max:500'],
-        ];
+        //対象のデータがない（論理削除を含む）場合はエラーを返す
+        try {
+            // Log::info('Notification ID: ' . $this->route('notification_id'));
+            $notification = Notification::findOrFail($this->route('notification_id'));
+
+            //対象のデータがある→論理削除されているかチェック
+            if ($notification->trashed()) {
+                if ($notification->deleted_at === null) {
+                    // 論理削除されている→エラーで返す
+                    return response()->json([
+                        'result' => false,
+                        'message' => 'Notification is soft deleted.'
+                    ], 403);
+                }
+            }
+
+            return [
+                'notification_id' => ['required', 'integer'],
+                'type'            => ['required', new NotificationUpdateStatusRule()],
+                'start_date'      => ['required', 'date_format:Y-m-d H:i:s'],
+                'end_date'        => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
+                'title'           => ['required', 'string', 'max:50'],
+                'content'         => ['required', 'string', 'max:500'],
+            ];
+
+        //対象のデータがない→エラーで返す
+        } catch (Exception $e) {
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+                // 'message' => "This Notification does not exist."
+            ], 500);
+        }
+
     }
 }

--- a/app/Http/Resources/Instructor/NotificationUpdateResource.php
+++ b/app/Http/Resources/Instructor/NotificationUpdateResource.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class NotificationUpdateResource extends JsonResource
 {
+    /** @var \App\Model\Notification */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *

--- a/app/Http/Resources/Manager/NotificationUpdateResource.php
+++ b/app/Http/Resources/Manager/NotificationUpdateResource.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class NotificationUpdateResource extends JsonResource
 {
+    /** @var \App\Model\Notification */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *

--- a/app/Http/Resources/Manager/NotificationUpdateResource.php
+++ b/app/Http/Resources/Manager/NotificationUpdateResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class NotificationUpdateResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'type'       => $this->resource->type,
+            'start_date' => $this->resource->start_date,
+            'end_date'   => $this->resource->end_date,
+            'title'      => $this->resource->title,
+            'content'    => $this->resource->content,
+        ];
+    }
+}

--- a/database/seeds/NotificationSeeder.php
+++ b/database/seeds/NotificationSeeder.php
@@ -36,6 +36,17 @@ class NotificationSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'course_id' => 4,
+                'instructor_id' => 4,
+                'title' => 'TypeScript入門講座の更新について',
+                'type' => Notification::TYPE_ONCE_INT,
+                'start_date' => '2023-08-01 00:00:00',
+                'end_date' => '2023-10-10 23:59:59',
+                'content' => 'TypeScript入門講座の内容が一部追加されました。確認をお願いします。',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-700
新権限マネージャー設立による配下のinstructorに紐づくお知らせ更新API作成
- 子課題　JKA-704

## 概要
フォームリクエスト&リソースファイル作成

## 動作確認手順

- マネージャー権限を持つinstructor(id:1)でログインし、以下のレスポンスを確認

1. 自身のお知らせ更新（Id: 1）
http://localhost:8080/api/v1/manager/notification/1
2. 配下のinstructorのお知らせ更新（Id: 2）
http://localhost:8080/api/v1/manager/notification/2
  `"result": true,`  
  `"data": {`
  `     "type": "once",`
  `     "start_date": "2024-10-01 00:00:00",`
  `     "end_date": "2024-10-10 00:00:00",`
  `     "title": "レッスン「変数とは？」閲覧について",`
  `     "content": "10月1日〜10日の間、レッスン「変数とは？」がメンテナンスにつき閲覧できなくなります。"`
   `   }`

3. その他のinstructorのお知らせ更新（Id: 3）
http://localhost:8080/api/v1/manager/notification/3
  `"result": false,`
  `"message": "Forbidden, not allowed to update this notification."`
に
## 考慮して欲しいこと

- NotificationSeederに１件データを追加しました。
その他のinstructorのお知らせ更新（Id: 3）の確認のため。

- フォームリクエスト&リソースファイルは、それぞれ Instractor側のファイルをそのまま流用し、namespace のみManagerに変更しました。