### PR TITLE
JKA-723空の配列を返すルータとコントローラの作成(かずふみ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+
 //use App\Http\Requests\Manager\InstructorPatchRequest;
 //use App\Http\Resources\Manager\InstructorEditResource;
 //use App\Http\Resources\Manager\InstructorPatchResource;


### PR DESCRIPTION
## 概要
 - 新権限マネージャー設立による配下のinstructorの講師情報取得(編集)API作成の
子課題
空の配列を返すルータとコントローラの作成

## 動作確認
- GETリクエストで
/api/v1/manager/instructor/{instructor_id}/を実行
instructor_idを変えても
[](空の配列)が返ってきた。

## 考慮して欲しいこと
- 特にありません。

## 確認して欲しいこと
- 特にありません。