### PR TITLE
JKA-723空の配列を返すルータとコントローラの作成2(かずふみ) 

### DIFF
--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -2,64 +2,10 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
-use RuntimeException;
-use App\Model\Manager;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Storage;
-//use App\Http\Requests\Manager\InstructorPatchRequest;
-//use App\Http\Resources\Manager\InstructorEditResource;
-//use App\Http\Resources\Manager\InstructorPatchResource;
 
 class InstructorController extends Controller
 {
-    /**
-     * インストラクター情報更新API
-     *
-     * @param InstructorPatchRequest $request
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function update(InstructorPatchRequest $request)
-    {
-        try {
-            $instructor = Auth::user();
-
-            // 更新前の画像パスを使用
-            $imagePath = $instructor->profile_image;
-            $file = $request->file('profile_image');
-
-            if (isset($file)) {
-                // 更新前の画像ファイルを削除
-                if (Storage::disk('public')->exists($instructor->profile_image)) {
-                    Storage::disk('public')->delete($instructor->profile_image);
-                }
-
-                // 画像ファイル保存処理
-                $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString() . '.' . $extension;
-                $imagePath = Storage::disk('public')->putFileAs('instructor', $file, $filename);
-            }
-
-            $instructor->update([
-                'nick_name' => $request->nick_name,
-                'last_name' => $request->last_name,
-                'first_name' => $request->first_name,
-                'email' => $request->email,
-                'profile_image' => $imagePath,
-            ]);
-            return response()->json([
-                'result' => true,
-                'data' => new InstructorPatchResource($instructor)
-            ]);
-        } catch (RuntimeException $e) {
-            Log::error($e);
-            return response()->json([
-                "result" => false,
-            ], 500);
-        }
-    }
     /**
      * 講師情報編集API
      *
@@ -68,7 +14,5 @@ class InstructorController extends Controller
     public function edit()
     {
         return response()->json([]);
-        //$instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
-        //return new InstructorEditResource($instructor);
     }
 }

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use RuntimeException;
+use App\Model\Manager;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+//use App\Http\Requests\Manager\InstructorPatchRequest;
+//use App\Http\Resources\Manager\InstructorEditResource;
+//use App\Http\Resources\Manager\InstructorPatchResource;
+
+class InstructorController extends Controller
+{
+    /**
+     * インストラクター情報更新API
+     *
+     * @param InstructorPatchRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(InstructorPatchRequest $request)
+    {
+        try {
+            $instructor = Auth::user();
+
+            // 更新前の画像パスを使用
+            $imagePath = $instructor->profile_image;
+            $file = $request->file('profile_image');
+
+            if (isset($file)) {
+                // 更新前の画像ファイルを削除
+                if (Storage::disk('public')->exists($instructor->profile_image)) {
+                    Storage::disk('public')->delete($instructor->profile_image);
+                }
+
+                // 画像ファイル保存処理
+                $extension = $file->getClientOriginalExtension();
+                $filename = Str::uuid()->toString() . '.' . $extension;
+                $imagePath = Storage::disk('public')->putFileAs('instructor', $file, $filename);
+            }
+
+            $instructor->update([
+                'nick_name' => $request->nick_name,
+                'last_name' => $request->last_name,
+                'first_name' => $request->first_name,
+                'email' => $request->email,
+                'profile_image' => $imagePath,
+            ]);
+            return response()->json([
+                'result' => true,
+                'data' => new InstructorPatchResource($instructor)
+            ]);
+        } catch (RuntimeException $e) {
+            Log::error($e);
+            return response()->json([
+                "result" => false,
+            ], 500);
+        }
+    }
+    /**
+     * 講師情報編集API
+     *
+     * @return InstructorEditResource
+     */
+    public function edit()
+    {
+        return response()->json([]);
+        //$instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
+        //return new InstructorEditResource($instructor);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -179,6 +179,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('attendance')->group(function () {
                     Route::post('/', 'Api\Manager\AttendanceController@store');
                 });
+                // マネージャー-講師
+                Route::prefix('instructor')->group(function () {
+                    Route::get('{instructor_id}', 'Api\Manager\InstructorController@edit');
+                });
             });
         });
     });


### PR DESCRIPTION
## 概要
- 新権限マネージャー設立による配下のinstructorの講師情報取得(編集)API作成の
子課題
空の配列を返すルータとコントローラの作成

## 動作確認
- GETリクエストで
/api/v1/manager/instructor/{instructor_id}/を実行
instructor_idを変えても
が返ってきた。

## 考慮して欲しいこと
- 特にありません。

## 確認して欲しいこと
- 特にありません。