### PR TITLE
空の配列を返すルーターとコントローラの作成（鈴木）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ManagerController.php
+++ b/app/Http/Controllers/Api/Manager/ManagerController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ManagerController extends Controller
+{
+    public function update()
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -137,6 +137,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
+                Route::prefix('instructor')->group(function () {
+                    Route::post('{id}', 'Api\Manager\ManagerController@update');});
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,7 +138,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
                 Route::prefix('instructor')->group(function () {
-                    Route::post('{id}', 'Api\Manager\ManagerController@update');});
+                    Route::post('{id}', 'Api\Manager\ManagerController@update');
+                });
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,7 +138,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
                 Route::prefix('instructor')->group(function () {
-                    Route::post('{instructor_id}', 'Api\Manager\ManagerController@update');});
+                    Route::post('{instructor_id}', 'Api\Manager\ManagerController@update');
+                });
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,7 +138,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
                 Route::prefix('instructor')->group(function () {
-                    Route::post('{id}', 'Api\Manager\ManagerController@update');});
+                    Route::post('{instructor_id}', 'Api\Manager\ManagerController@update');});
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-724

## 概要
- 空の配列を返すルーターとコントローラーの作成

## 動作確認手順
- POSTメソッドでhttp://localhost:8080/api/v1/manager/instructor/{instructor_id}にリクエストを送り、空の配列が返ってくることを確認

## 考慮してほしいこと
特になし

## 確認してほしいこと
特になし
