### PR TITLE
JKA-723自分と配下の講師の講師情報取得(編集)ロジック作成(かずふみ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -3,16 +3,36 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use App\Model\Instructor;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Resources\Manager\InstructorEditResource;
 
 class InstructorController extends Controller
 {
     /**
      * 講師情報編集API
      *
-     * @return InstructorEditResource
+     * @param InstructorEditRequest $request
+     * @return InstructorEditResource|\Illuminate\Http\JsonResponse
      */
-    public function edit()
+    public function edit($instructor_id)
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+        // 配下の講師情報を取得
+        $manager = Instructor::with('managings')->findOrFail($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+        if (!in_array((int)$instructor_id, $instructorIds, true)) {
+            // 自分、または配下の講師でなければエラー応答
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to edit this course.",
+            ], 403);
+        }
+
+        $instructor = Instructor::findOrFail($instructor_id);
+        return new InstructorEditResource($instructor);
     }
 }

--- a/app/Http/Resources/Manager/InstructorEditResource.php
+++ b/app/Http/Resources/Manager/InstructorEditResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InstructorEditResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'instructor_id' => $this->resource->id,
+            'nick_name' => $this->resource->nick_name,
+            'last_name' => $this->resource->last_name,
+            'first_name' => $this->resource->first_name,
+            'email' => $this->resource->email,
+            'profile_image' => $this->resource->profile_image,
+            'type' => $this->resource->type,
+        ];
+    }
+}


### PR DESCRIPTION
## 概要
- 新権限マネージャー設立による配下のinstructorの講師情報取得(編集)API作成
子課題
ロジック作成
## 動作確認手順
- Postmanでhttp://localhost:8080/api/v1/manager/instructor/{instructor_id}
instructor_idの数字を変えて、レスポンスが返ってくるか確認
- 自分と配下の講師の情報は取れるけど、違うマネージャーの情報を
取得出来ないことを確認
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません
