### PR TITLE
マネージャーによるinstructorの作成した受講情報を削除するAPI作成（空の配列を返すルーターとコントローラの作成）（ひろせ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -90,3 +90,4 @@ class AttendanceController extends Controller
     public function delete() {
         return response() ->json ([]);
     }
+}

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -87,7 +87,8 @@ class AttendanceController extends Controller
     }
 
     // 配下のinstructorの講座に紐づく受講情報を削除
-    public function delete() {
-        return response() ->json ([]);
+    public function delete()
+    {
+        return response() ->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -85,4 +85,8 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
-}
+
+    // 配下のinstructorの講座に紐づく受講情報を削除
+    public function delete() {
+        return response() ->json ([]);
+    }

--- a/routes/api.php
+++ b/routes/api.php
@@ -178,6 +178,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-受講
                 Route::prefix('attendance')->group(function () {
                     Route::post('/', 'Api\Manager\AttendanceController@store');
+                    Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
                 });
 
                 // マネージャー-お知らせ


### PR DESCRIPTION
## issue
新権限マネージャー設立による配下のinstructorの作成した講座の受講情報を削除するAPI作成
https://gut-familie.atlassian.net/browse/JKA-709
子課題  
空の配列を返すルーターとコントローラーの作成

## 概要
- 新権限マネージャー設立による配下のinstructorの作成した講座の受講情報を削除するAPI作成
空の配列を返すようルーターとコントローラー実装しました。

## 動作確認手順
- postmanを使ってlocalhost:8080/api/v1/manager/attendance/1
にアクセス。
空の配列が返ってくることを確認しました。

## 考慮してほしいこと
- 特にありません

## 確認してほしいこと
- 特にありません