### PR TITLE
空の配列を返すルーターとコントローラーの作成（林）

### DIFF
--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -109,4 +109,16 @@ class StudentController extends Controller
 
         return new StudentShowResource($student);
     }
+
+     /**
+     * 受講生登録API
+     *
+     * @param StudentStoreRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store()
+    {
+        return response()->json([]);
+    }
+
 }

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -120,5 +120,4 @@ class StudentController extends Controller
     {
         return response()->json([]);
     }
-
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -182,6 +182,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-生徒
                 Route::prefix('student')->group(function () {
                     Route::get('{student_id}', 'Api\Manager\StudentController@show');
+                    Route::post('/', 'Api\Manager\StudentController@store');
                 });
 
                 // マネージャー-お知らせ


### PR DESCRIPTION
## issue
新権限マネージャー設立による配下のinstructorの作成した講座に紐づく受講生を登録するAPI作成
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-738
子課題
空の配列を返すルーターとコントローラーの作成

## 概要
空の配列を返すルーターとコントローラーの作成

## 動作確認手順
ポストマンでhttp://localhost:8080/api/v1/manager/student
と打ち、空の配列が返ってくることを確認。

## 確認して欲しいこと
登録なのでstoreメソッドを作りました。

## 考慮して欲しいこと
なし