### PR TITLE
受講生一覧取得API（マネージャー側に受講生名・日時検索を追加する）

### DIFF
--- a/app/Http/Requests/Manager/StudentIndexRequest.php
+++ b/app/Http/Requests/Manager/StudentIndexRequest.php
@@ -35,8 +35,11 @@ class StudentIndexRequest extends FormRequest
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
-            'sortBy' => ['string', new IndexSortByRule()],
+            'sort_by' => ['string', new IndexSortByRule()],
             'order' => ['string', 'in:asc,desc'],
+            'input_text' => ['string'],
+            'start_date' => ['date_format:Y-m-d H:i:s'],
+            'end_date' => ['date_format:Y-m-d H:i:s'],
         ];
     }
 }

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -46,7 +46,7 @@ class StudentIndexResource extends JsonResource
                 'profile_image' => $result->profile_image,
                 'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
-                'attendanced_at' => $result->created_at,
+                'attendanced_at' => $result->attendanced_at,
             ];
         });
     }


### PR DESCRIPTION
## Issue
子課題　JKA-722

受講生一覧取得API（講師側・マネージャー側の２つ）に受講生名・日時検索を追加する
https://gut-familie.atlassian.net/browse/JKA-716

## 概要
受講生一覧取得API（マネージャー側に受講生名・日時検索を追加する）

## 動作確認手順
instructor(id=1)でログインし、講座の受講生一覧を取得。条件で絞り込めているか確認。
GET:  {{APP_URL}}/api/v1/manager/course/1/student/index?sort_by=last_login_at

- 受講生名検索
param(key)：  input_text
param(value)：
　※以下の項目について１件づつ部分一致で検索
　※空白は除去される
　　last_name(+ first_name)： 生徒　テスト
　　nick_name： 生徒ニックネーム1 
　　email： test_student_1@example.com

- 日時検索
param(key)：  start_date /end_date
param(value)： 指定した開始日～終了日

## 考慮して欲しいこと
- Instractor側と同様にソート機能も修正しました。