### PR TITLE
topicからdevelopへ新権限マネージャー設立による配下のinstructorの講師情報取得(編集)API作成(かずふみ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -34,7 +34,7 @@ class InstructorController extends Controller
         if (!in_array((int)$requestInstructor, $instructorIds, true)) {
             return response()->json([
                 'result'  => false,
-                'message' => "Forbidden, not allowed to edit this course.",
+                'message' => "Forbidden, not allowed to edit this instructor.",
             ], 403);
         }
         

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -2,64 +2,10 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
-use RuntimeException;
-use App\Model\Manager;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Storage;
-//use App\Http\Requests\Manager\InstructorPatchRequest;
-//use App\Http\Resources\Manager\InstructorEditResource;
-//use App\Http\Resources\Manager\InstructorPatchResource;
 
 class InstructorController extends Controller
 {
-    /**
-     * インストラクター情報更新API
-     *
-     * @param InstructorPatchRequest $request
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function update(InstructorPatchRequest $request)
-    {
-        try {
-            $instructor = Auth::user();
-
-            // 更新前の画像パスを使用
-            $imagePath = $instructor->profile_image;
-            $file = $request->file('profile_image');
-
-            if (isset($file)) {
-                // 更新前の画像ファイルを削除
-                if (Storage::disk('public')->exists($instructor->profile_image)) {
-                    Storage::disk('public')->delete($instructor->profile_image);
-                }
-
-                // 画像ファイル保存処理
-                $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString() . '.' . $extension;
-                $imagePath = Storage::disk('public')->putFileAs('instructor', $file, $filename);
-            }
-
-            $instructor->update([
-                'nick_name' => $request->nick_name,
-                'last_name' => $request->last_name,
-                'first_name' => $request->first_name,
-                'email' => $request->email,
-                'profile_image' => $imagePath,
-            ]);
-            return response()->json([
-                'result' => true,
-                'data' => new InstructorPatchResource($instructor)
-            ]);
-        } catch (RuntimeException $e) {
-            Log::error($e);
-            return response()->json([
-                "result" => false,
-            ], 500);
-        }
-    }
     /**
      * 講師情報編集API
      *
@@ -68,7 +14,5 @@ class InstructorController extends Controller
     public function edit()
     {
         return response()->json([]);
-        //$instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
-        //return new InstructorEditResource($instructor);
     }
 }

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -20,7 +20,7 @@ class InstructorController extends Controller
     {
         //フォームリクエストから講師情報の取得
         $requestInstructorId = $request->instructor_id;
-        
+
         // 現在のユーザーを取得（講師の場合）
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -36,9 +36,8 @@ class InstructorController extends Controller
                 'message' => "Forbidden, not allowed to edit this instructor.",
             ], 403);
         }
-        
+
         $instructor = Instructor::findOrFail($requestInstructorId);
         return new InstructorEditResource($instructor);
     }
-
 }

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -3,16 +3,36 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use App\Model\Instructor;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Resources\Manager\InstructorEditResource;
 
 class InstructorController extends Controller
 {
     /**
      * 講師情報編集API
      *
-     * @return InstructorEditResource
+     * @param InstructorEditRequest $request
+     * @return InstructorEditResource|\Illuminate\Http\JsonResponse
      */
-    public function edit()
+    public function edit($instructor_id)
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+        // 配下の講師情報を取得
+        $manager = Instructor::with('managings')->findOrFail($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+        if (!in_array((int)$instructor_id, $instructorIds, true)) {
+            // 自分、または配下の講師でなければエラー応答
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to edit this course.",
+            ], 403);
+        }
+
+        $instructor = Instructor::findOrFail($instructor_id);
+        return new InstructorEditResource($instructor);
     }
 }

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\Manager\InstructorEditResource;
 use App\Http\Requests\Manager\InstructorEditRequest;
 use App\Model\Instructor;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class InstructorController extends Controller
@@ -20,7 +19,7 @@ class InstructorController extends Controller
     public function edit(InstructorEditRequest $request)
     {
         //フォームリクエストから講師情報の取得
-        $requestInstructor = $request->instructor_id;
+        $requestInstructorId = $request->instructor_id;
         
         // 現在のユーザーを取得（講師の場合）
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -31,14 +30,14 @@ class InstructorController extends Controller
         $instructorIds[] = $instructorId;
 
         //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
-        if (!in_array((int)$requestInstructor, $instructorIds, true)) {
+        if (!in_array((int)$requestInstructorId, $instructorIds, true)) {
             return response()->json([
                 'result'  => false,
                 'message' => "Forbidden, not allowed to edit this instructor.",
             ], 403);
         }
         
-        $instructor = Instructor::findOrFail($requestInstructor);
+        $instructor = Instructor::findOrFail($requestInstructorId);
         return new InstructorEditResource($instructor);
     }
 

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use RuntimeException;
+use App\Model\Manager;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+//use App\Http\Requests\Manager\InstructorPatchRequest;
+//use App\Http\Resources\Manager\InstructorEditResource;
+//use App\Http\Resources\Manager\InstructorPatchResource;
+
+class InstructorController extends Controller
+{
+    /**
+     * インストラクター情報更新API
+     *
+     * @param InstructorPatchRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(InstructorPatchRequest $request)
+    {
+        try {
+            $instructor = Auth::user();
+
+            // 更新前の画像パスを使用
+            $imagePath = $instructor->profile_image;
+            $file = $request->file('profile_image');
+
+            if (isset($file)) {
+                // 更新前の画像ファイルを削除
+                if (Storage::disk('public')->exists($instructor->profile_image)) {
+                    Storage::disk('public')->delete($instructor->profile_image);
+                }
+
+                // 画像ファイル保存処理
+                $extension = $file->getClientOriginalExtension();
+                $filename = Str::uuid()->toString() . '.' . $extension;
+                $imagePath = Storage::disk('public')->putFileAs('instructor', $file, $filename);
+            }
+
+            $instructor->update([
+                'nick_name' => $request->nick_name,
+                'last_name' => $request->last_name,
+                'first_name' => $request->first_name,
+                'email' => $request->email,
+                'profile_image' => $imagePath,
+            ]);
+            return response()->json([
+                'result' => true,
+                'data' => new InstructorPatchResource($instructor)
+            ]);
+        } catch (RuntimeException $e) {
+            Log::error($e);
+            return response()->json([
+                "result" => false,
+            ], 500);
+        }
+    }
+    /**
+     * 講師情報編集API
+     *
+     * @return InstructorEditResource
+     */
+    public function edit()
+    {
+        return response()->json([]);
+        //$instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
+        //return new InstructorEditResource($instructor);
+    }
+}

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
-use App\Http\Controllers\Controller;
-use App\Http\Resources\Manager\InstructorEditResource;
-use App\Http\Requests\Manager\InstructorEditRequest;
 use App\Model\Instructor;
+use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\Manager\InstructorEditRequest;
+use App\Http\Resources\Manager\InstructorEditResource;
 
 class InstructorController extends Controller
 {
@@ -18,10 +18,8 @@ class InstructorController extends Controller
      */
     public function edit(InstructorEditRequest $request)
     {
-        //フォームリクエストから講師情報の取得
         $requestInstructorId = $request->instructor_id;
 
-        // 現在のユーザーを取得（講師の場合）
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -13,7 +13,7 @@ class InstructorController extends Controller
 {
     /**
      * 講師情報編集API
-     * 
+     *
      * @param InstructorEditRequest $request
      * @return InstructorEditResource|\Illuminate\Http\JsonResponse
      */

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -3,36 +3,43 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use App\Model\Instructor;
-use Illuminate\Support\Facades\Auth;
 use App\Http\Resources\Manager\InstructorEditResource;
+use App\Http\Requests\Manager\InstructorEditRequest;
+use App\Model\Instructor;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class InstructorController extends Controller
 {
     /**
      * 講師情報編集API
-     *
+     * Auth::guard('instructor')
      * @param InstructorEditRequest $request
      * @return InstructorEditResource|\Illuminate\Http\JsonResponse
      */
-    public function edit($instructor_id)
+    public function edit(InstructorEditRequest $request)
     {
+        //フォームリクエストから講師情報の取得
+        $requestInstructor = $request->instructor_id;
+        
+        // 現在のユーザーを取得（講師の場合）
         $instructorId = Auth::guard('instructor')->user()->id;
+
         // 配下の講師情報を取得
         $manager = Instructor::with('managings')->findOrFail($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
         //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
-        if (!in_array((int)$instructor_id, $instructorIds, true)) {
-            // 自分、または配下の講師でなければエラー応答
+        if (!in_array((int)$requestInstructor, $instructorIds, true)) {
             return response()->json([
                 'result'  => false,
                 'message' => "Forbidden, not allowed to edit this course.",
             ], 403);
         }
-
-        $instructor = Instructor::findOrFail($instructor_id);
+        
+        $instructor = Instructor::findOrFail($requestInstructor);
         return new InstructorEditResource($instructor);
     }
+
 }

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -13,7 +13,7 @@ class InstructorController extends Controller
 {
     /**
      * 講師情報編集API
-     * Auth::guard('instructor')
+     * 
      * @param InstructorEditRequest $request
      * @return InstructorEditResource|\Illuminate\Http\JsonResponse
      */

--- a/app/Http/Requests/Manager/InstructorEditRequest.php
+++ b/app/Http/Requests/Manager/InstructorEditRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class InstructorEditRequest extends FormRequest
+{
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'instructor_id' => $this->route('instructor_id'),
+        ]);
+    }
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'instructor_id' => ['required', 'integer'],
+        ];
+    }
+}

--- a/app/Http/Requests/Manager/InstructorEditRequest.php
+++ b/app/Http/Requests/Manager/InstructorEditRequest.php
@@ -30,7 +30,7 @@ class InstructorEditRequest extends FormRequest
     public function rules()
     {
         return [
-            'instructor_id' => ['required', 'integer'],
+            'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
         ];
     }
 }

--- a/app/Http/Resources/Manager/InstructorEditResource.php
+++ b/app/Http/Resources/Manager/InstructorEditResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InstructorEditResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'instructor_id' => $this->resource->id,
+            'nick_name' => $this->resource->nick_name,
+            'last_name' => $this->resource->last_name,
+            'first_name' => $this->resource->first_name,
+            'email' => $this->resource->email,
+            'profile_image' => $this->resource->profile_image,
+            'type' => $this->resource->type,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -179,6 +179,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('attendance')->group(function () {
                     Route::post('/', 'Api\Manager\AttendanceController@store');
                 });
+                // マネージャー-講師
+                Route::prefix('instructor')->group(function () {
+                    Route::get('{instructor_id}', 'Api\Manager\InstructorController@edit');
+                });
             });
         });
     });


### PR DESCRIPTION
##  概要
- 新権限マネージャー設立による配下のinstructorの講師情報取得(編集)API作成  
   topicからdevelopへ
## 動作確認手順
- Postmanで[http://localhost:8080/api/v1/manager/instructor/{instructor_id}](http://localhost:8080/api/v1/manager/instructor/%7Binstructor_id%7D)  
   instructor_idの数字を変えて、レスポンスが返ってくるか確認
- 自分と配下の講師の情報は取れるけど、違うマネージャーの情報を  
   取得出来ないことを確認
- 存在しないIDでの確認をしました。
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません