### PR TITLE
空の配列を返すルーターとコントローラーの作成（林）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -283,4 +283,15 @@ class ChapterController extends Controller
           'result' => true,
         ]);
     }
+
+    /**
+     * チャプター一括更新API(公開・非公開切り替え)
+     *
+     * @param ChapterPutStatusRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function putStatus()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -156,6 +156,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('chapter')->group(function () {
                             Route::post('sort', 'Api\Manager\ChapterController@sort');
                             Route::post('/', 'Api\Manager\ChapterController@store');
+                            Route::put('status', 'Api\Manager\ChapterController@putStatus');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');


### PR DESCRIPTION
## issue
新権限マネージャー設立による配下のinstructorの作成したチャプター公開状態一括更新API作成
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-746
子課題
空の配列を返すルーターとコントローラーの作成

## 概要
空の配列を返すルーターとコントローラーの作成

## 動作確認手順
ポストマンでhttp://localhost:8080/api/v1/manager/course/1/chapter/statusと打ち、
空の配列が返ってくることを確認

## 考慮して欲しいこと
なし