### PR TITLE
新権限マネージャー設立による配下のinstructorの作成した講座の受講情報を削除するAPI作成（ロジックの作成）（ひろせ）

### DIFF
--- a/app/Http/Requests/Manager/AttendanceDeleteRequest.php
+++ b/app/Http/Requests/Manager/AttendanceDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'attendance_id' => ['required', 'integer', 'exists:attendances,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'attendance_id' => $this->route('attendance_id'),
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- 新権限マネージャー設立による配下のinstructorの作成した講座の受講情報を削除するAPI作成、ロジックの作成
## 動作確認手順
- ポストマンで、localhost:8080/api/v1/manager/attendance/1
を入力すると以下のレスポンスあり
{
    "result": true
}
/2は同じ反応、/3だとidがないのでエラーで帰ってくることを確認。
アドマイナーでnullに更新して再度、ポストマンでの処理をしても同様な反応となった。
## 考慮してほしいこと
- 特にありません
## 確認してほしいこと
- 空の配列を返すルーターとコントローラの作成
- ロジックの作成
- フォームリクエストの作成 or 変更（必要あれば）
- レスポンス整形のリソースファイル作成 or 変更（必要あればだが、今回は不要）
- topicブランチからdevelopへのプルリク
この状態だと、どこまで進んだのでしょうか。