### PR TITLE
空の配列-紐づくレッスン名更新API作成(かずふみ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -263,4 +263,14 @@ class LessonController extends Controller
             ]);
         }
     }
+    /**
+     * レッスン名を更新するAPI
+     *
+     * @param
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function updateTitle()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -168,6 +168,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');
+                                        Route::patch('title', 'Api\Manager\LessonController@updateTitle');
                                     });
                                 });
                             });


### PR DESCRIPTION
##  概要
- 新権限マネージャー設立による配下のinstructorに紐づくレッスン"名"更新API作成
   子課題  
   空の配列を返すルーターとコントローラの作成
## 動作確認手順
- Postmanでhttp://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/title
   urlを作り、空が返ってくるか確認
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません