### PR TITLE
空の配列を返すルーターとコントローラの作成(川端）

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -9,6 +9,7 @@ use App\Model\Course;
 use App\Model\LessonAttendance;
 use App\Http\Requests\Manager\LessonUpdateRequest;
 use App\Http\Requests\Manager\LessonSortRequest;
+use App\Http\Requests\Manager\LessonPatchStatusRequest;
 use App\Http\Requests\Manager\LessonDeleteRequest;
 use App\Http\Requests\Manager\LessonStoreRequest;
 use App\Http\Resources\Manager\LessonStoreResource;
@@ -119,6 +120,18 @@ class LessonController extends Controller
             'result' => true,
         ]);
     }
+
+    /**
+     * レッスンステータス更新API
+     *
+     * @param LessonPatchStatusRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function updateStatus()
+    {
+        return response()->json([]);
+    }
+
 
 
     /**

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -9,7 +9,6 @@ use App\Model\Course;
 use App\Model\LessonAttendance;
 use App\Http\Requests\Manager\LessonUpdateRequest;
 use App\Http\Requests\Manager\LessonSortRequest;
-use App\Http\Requests\Manager\LessonPatchStatusRequest;
 use App\Http\Requests\Manager\LessonDeleteRequest;
 use App\Http\Requests\Manager\LessonStoreRequest;
 use App\Http\Resources\Manager\LessonStoreResource;
@@ -131,8 +130,6 @@ class LessonController extends Controller
     {
         return response()->json([]);
     }
-
-
 
     /**
      * レッスン削除API

--- a/routes/api.php
+++ b/routes/api.php
@@ -168,6 +168,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');
+                                        Route::patch('status', 'Api\Manager\LessonController@updateStatus');
                                     });
                                 });
                             });


### PR DESCRIPTION
## 新権限マネージャー設立による配下のinstructorに紐づくレッスン"ステータス"更新API作成
子課題①空の配列を返すルーターとコントローラの作成
## 動作確認

postman　（http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/status) send

実行結果>　[]    
空の配列で返ってきました。

## 確認してほしい所
特になし
## 考慮して欲しい所
ご指摘お願いいたします！！