### PR TITLE
Instructor/Managerでチャプター更新処理が分散してしまう問題の解消（林）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -275,7 +275,7 @@ class ChapterController extends Controller
      */
     public function putStatus(ChapterPutStatusRequest $request)
     {
-        Chapter::chapterupdate($request);
+        Chapter::chapterUpdateAll($request);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -275,6 +275,7 @@ class ChapterController extends Controller
      */
     public function putStatus(ChapterPutStatusRequest $request)
     {
+        /** @var Course $course */
         $course = Course::findOrFail($request->course_id);
 
         if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -275,6 +275,14 @@ class ChapterController extends Controller
      */
     public function putStatus(ChapterPutStatusRequest $request)
     {
+        $course = Course::findOrFail($request->course_id);
+
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+            return response()->json([
+                'result' => false,
+                "message" => "Not authorized."
+            ], 403);
+        }
         Chapter::chapterUpdateAll($request);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -284,7 +284,7 @@ class ChapterController extends Controller
             ], 403);
         }
 
-        Chapter::chapterUpdateAll($request, $request->course_id, $request->status);
+        Chapter::chapterUpdateAll($request->course_id, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -276,5 +276,9 @@ class ChapterController extends Controller
     public function putStatus(ChapterPutStatusRequest $request)
     {
         Chapter::chapterupdate($request);
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -283,7 +283,8 @@ class ChapterController extends Controller
                 "message" => "Not authorized."
             ], 403);
         }
-        Chapter::chapterUpdateAll($request);
+
+        Chapter::chapterUpdateAll($request, $request->course_id, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -275,21 +275,6 @@ class ChapterController extends Controller
      */
     public function putStatus(ChapterPutStatusRequest $request)
     {
-        $course = Course::findOrFail($request->course_id);
-
-        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
-            return response()->json([
-                'result' => 'false',
-                "message" => "Not authorized."
-            ], 403);
-        }
-        Chapter::where('course_id', $request->course_id)
-            ->update([
-                'status' => $request->status
-            ]);
-
-        return response()->json([
-            'result' => 'true'
-        ]);
+        Chapter::chapterupdate($request);
     }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -322,7 +322,7 @@ class ChapterController extends Controller
                 "message" => "Not authorized."
             ], 403);
         }
-        Chapter::chapterUpdateAll($request, $request->course_id, $request->status);
+        Chapter::chapterUpdateAll($request->course_id, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -298,7 +298,7 @@ class ChapterController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        Chapter::chapterupdate($request);
+        Chapter::chapterUpdateAll($request);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -322,7 +322,7 @@ class ChapterController extends Controller
                 "message" => "Not authorized."
             ], 403);
         }
-        Chapter::chapterUpdateAll($request ,$request->course_id, $request->status);
+        Chapter::chapterUpdateAll($request, $request->course_id, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -294,34 +294,10 @@ class ChapterController extends Controller
     public function putStatus(ChapterPutStatusRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
 
-        // インストラクターが管理しているコースのIDを取得
-        $managedCourseIds = Instructor::with('managings')->find($instructorId)
-            ->managings->pluck('id')->toArray();
-
-        // 自身が担当しているコースのIDを追加
-        $managedCourseIds[] = $instructorId;
-
-        // リクエストで指定されたコースのIDを取得
-        $courseId = $request->course_id;
-
-        // インストラクターが管理しているコースでない場合、権限エラーを返す
-        if (!in_array($courseId, $managedCourseIds)) {
-            return response()->json([
-                'result' => false,
-                "message" => "Not authorized."
-            ], 403);
-        }
-
-        // コースのステータスを更新
-        Chapter::where('course_id', $courseId)
-            ->update([
-                'status' => $request->status
-            ]);
-
-        // 成功レスポンスを返す
-        return response()->json([
-            'result' => true,
-        ]);
+        Chapter::chapterupdate($request);
     }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -298,6 +298,14 @@ class ChapterController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
+        $course = Course::findOrFail($request->course_id);
+
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+            return response()->json([
+                'result' => false,
+                "message" => "Not authorized."
+            ], 403);
+        }
         Chapter::chapterUpdateAll($request);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -300,21 +300,6 @@ class ChapterController extends Controller
 
         $course = Course::findOrFail($request->course_id);
 
-         // 講師が管理している講座のIDを取得
-         $managedCourseIds = Instructor::with('managings')->find($instructorId)
-         ->managings->pluck('id')->toArray();
-
-         // リクエストで指定された講座のIDを取得
-         $courseId = $request->course_id;
-
-        // 講師が管理している講座でない場合、権限エラーを返す
-        if (!in_array($courseId, $managedCourseIds)) {
-            return response()->json([
-                'result' => false,
-                "message" => "Not authorized."
-            ], 403);
-        }
-
         // 認証者と講座の講師が一致しているか確認
         if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
             return response()->json([

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -300,18 +300,14 @@ class ChapterController extends Controller
 
         $course = Course::findOrFail($request->course_id);
 
-        // インストラクターが管理している講座のIDを取得
-        $managedCourseIds = Instructor::with('managings')->find($instructorId)
-        ->managings->pluck('id')->toArray();
-
-        // 自身が担当している講座のIDを追加
-        $managedCourseIds[] = $instructorId;
+        // 認証されたマネージャーとマネージャーが管理する講師の講座IDのリストを取得
+        $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
 
         // リクエストで指定されたコースのIDを取得
         $courseId = $request->course_id;
 
         // 講師が管理している講座でない場合、権限エラーを返す
-        if (!in_array($courseId, $managedCourseIds)) {
+        if (!in_array($courseId, $courseIds)) {
             return response()->json([
                 'result' => false,
                 "message" => "Not authorized."

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -299,5 +299,9 @@ class ChapterController extends Controller
         $instructorIds[] = $manager->id;
 
         Chapter::chapterupdate($request);
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -301,7 +301,7 @@ class ChapterController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // 認証されたマネージャーとマネージャーが管理する講師の講座IDのリストを取得
-        $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
+        $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id')->toArray();
 
         // リクエストで指定されたコースのIDを取得
         $courseId = $request->course_id;

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -294,26 +294,24 @@ class ChapterController extends Controller
     public function putStatus(ChapterPutStatusRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
+
+        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        $course = Course::findOrFail($request->course_id);
-
         // 認証されたマネージャーとマネージャーが管理する講師の講座IDのリストを取得
         $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id')->toArray();
 
-        // リクエストで指定されたコースのIDを取得
-        $courseId = $request->course_id;
-
         // 講師が管理している講座でない場合、権限エラーを返す
-        if (!in_array($courseId, $courseIds)) {
+        if (!in_array($request->course_id, $courseIds)) {
             return response()->json([
                 'result' => false,
                 "message" => "Not authorized."
             ], 403);
         }
 
+        $course = Course::findOrFail($request->course_id);
         // 認証者と講座の講師が一致しているか確認
         if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
             return response()->json([

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -5,7 +5,6 @@ namespace App\Model;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Facades\Auth;
 
 /**
  * @property int $id
@@ -98,6 +97,11 @@ class Chapter extends Model
 
     public static function chapterUpdateAll($request)
     {
+         // $requestがnullである場合、またはcourse_idとstatusがnullである場合は処理を行わない
+        if (is_null($request) || is_null($request->course_id) || is_null($request->status)) {
+            return; // 何も処理しない
+        }
+
         Chapter::where('course_id', $request->course_id)
             ->update([
                 'status' => $request->status

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -110,10 +110,6 @@ class Chapter extends Model
             ->update([
                 'status' => $request->status
             ]);
-
-        return response()->json([
-            'result' => true,
-        ]);
     }
 
 }

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -95,11 +95,11 @@ class Chapter extends Model
         });
     }
 
-    public static function chapterUpdateAll($request, $course_id, $status)
+    public static function chapterUpdateAll($course_id, $status)
     {
-        Chapter::where('course_id', $request->course_id)
+        Chapter::where('course_id', $course_id)
             ->update([
-                'status' => $request->status
+                'status' => $status
             ]);
     }
 }

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -95,7 +95,14 @@ class Chapter extends Model
         });
     }
 
-    public static function chapterUpdateAll($courseId, $status)
+    /**
+     * チャプターのステータスを一括更新
+     *
+     * @param int $courseId
+     * @param 'public'|'private' $status
+     * @return void
+     */
+    public static function chapterUpdateAll(int $courseId, string $status): void
     {
         Chapter::where('course_id', $courseId)
             ->update([

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -96,16 +96,8 @@ class Chapter extends Model
         });
     }
 
-    public static function chapterupdate($request)
+    public static function chapterUpdateAll($request)
     {
-        $course = Course::findOrFail($request->course_id);
-
-        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
-            return response()->json([
-                'result' => false,
-                "message" => "Not authorized."
-            ], 403);
-        }
         Chapter::where('course_id', $request->course_id)
             ->update([
                 'status' => $request->status

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -115,5 +115,4 @@ class Chapter extends Model
             'result' => true,
         ]);
     }
-
 }

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -95,9 +95,9 @@ class Chapter extends Model
         });
     }
 
-    public static function chapterUpdateAll($course_id, $status)
+    public static function chapterUpdateAll($courseId, $status)
     {
-        Chapter::where('course_id', $course_id)
+        Chapter::where('course_id', $courseId)
             ->update([
                 'status' => $status
             ]);

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -95,13 +95,8 @@ class Chapter extends Model
         });
     }
 
-    public static function chapterUpdateAll($request)
+    public static function chapterUpdateAll($request, $course_id, $status)
     {
-         // $requestがnullである場合、またはcourse_idとstatusがnullである場合は処理を行わない
-        if (is_null($request) || is_null($request->course_id) || is_null($request->status)) {
-            return; // 何も処理しない
-        }
-
         Chapter::where('course_id', $request->course_id)
             ->update([
                 'status' => $request->status

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -5,6 +5,7 @@ namespace App\Model;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @property int $id
@@ -94,4 +95,25 @@ class Chapter extends Model
             return $chapter->status === Chapter::STATUS_PUBLIC;
         });
     }
+
+    public static function chapterupdate($request)
+    {
+        $course = Course::findOrFail($request->course_id);
+
+        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+            return response()->json([
+                'result' => false,
+                "message" => "Not authorized."
+            ], 403);
+        }
+        Chapter::where('course_id', $request->course_id)
+            ->update([
+                'status' => $request->status
+            ]);
+
+        return response()->json([
+            'result' => true,
+        ]);
+    }
+
 }


### PR DESCRIPTION
## issue
Instructor/Managerでチャプター更新処理が分散してしまう問題の解消
https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-758

## 概要
Instructor/Managerでチャプター更新処理が分散してしまう問題の解消

## 動作確認手順
ポストマンで[http://localhost:8080/api/v1/manager/course/1/chapter/statusと打ち、
return true と返ってくることを確認

instructor側ではなくmanager側で重複を減らし、一貫性を高め、保守性を向上させたコードに変更しました。

## 考慮して欲しいこと
なし