### PR TITLE
ロジックの作成-紐づくレッスン名更新API作成(かずふみ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -279,10 +279,10 @@ class LessonController extends Controller
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
-        
+
         // 指定されたレッスンを取得
         $lesson = Lesson::with('chapter.course')->findOrFail($lesson_id);
-        
+
         // 自分、または配下の講師の講座のレッスンでなければエラー応答
         if (!in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
             return response()->json([
@@ -304,7 +304,7 @@ class LessonController extends Controller
                 'message' => 'Invalid chapter_id.',
             ], 403);
         }
-        
+
         $lesson->update([
             'title' => $request->title
         ]);

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -282,10 +282,9 @@ class LessonController extends Controller
         
         // 指定されたレッスンを取得
         $lesson = Lesson::with('chapter.course')->findOrFail($lesson_id);
-        $course = Course::FindOrFail($request->course_id);
         
         // 自分、または配下の講師の講座のレッスンでなければエラー応答
-        if (!in_array($course->instructor_id, $instructorIds, true)) {
+        if (!in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
             return response()->json([
                 'result' => false,
                 'message' => 'Unauthorized access to update lesson title.'

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -281,7 +281,6 @@ class LessonController extends Controller
         $instructorIds[] = $instructorId;
         
         // 指定されたレッスンを取得
-        $user = Auth::guard('instructor')->user();
         $lesson = Lesson::with('chapter.course')->findOrFail($lesson_id);
         $course = Course::FindOrFail($request->course_id);
         
@@ -290,13 +289,6 @@ class LessonController extends Controller
             return response()->json([
                 'result' => false,
                 'message' => 'Unauthorized access to update lesson title.'
-            ], 403);
-        }
-
-        if ((int) $instructorIds !== $user->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id',
             ], 403);
         }
 


### PR DESCRIPTION
##  概要
- 新権限マネージャー設立による配下のinstructorが作成したレッスン"名"更新API作成
子課題
ロジックの作成
## 動作確認手順
- Postmanでinstructor1でログインした後で
PATCHの
/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/title
course_id
chapter_id
lesson_idをそれぞれ入力して
指定のlesson titleが変更されているか確認
- もう一人のmanager  instructor4でログイン
更新できない事を確認
- instructor2でログイン
更新できない事を確認
## 考慮して欲しいこと
- 特にありません
## 確認して欲しいこと
- 特にありません
