### PR TITLE
新権限マネージャー設立による配下のinstructorの講師情報更新API作成(はいしま)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -16,7 +16,19 @@ use App\Http\Resources\Instructor\InstructorPatchResource;
 class InstructorController extends Controller
 {
     /**
-     * インストラクター情報更新API
+     * 講師情報取得API
+     *
+     * @return InstructorEditResource
+     */
+    public function edit()
+    {
+        /** @var Instructor $instructor */
+        $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
+        return new InstructorEditResource($instructor);
+    }
+
+    /**
+     * 講師情報更新API
      *
      * @param InstructorPatchRequest $request
      * @return \Illuminate\Http\JsonResponse
@@ -59,15 +71,5 @@ class InstructorController extends Controller
                 "result" => false,
             ], 500);
         }
-    }
-    /**
-     * 講師情報編集API
-     *
-     * @return InstructorEditResource
-     */
-    public function edit()
-    {
-        $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
-        return new InstructorEditResource($instructor);
     }
 }

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\InstructorEditRequest;
 use App\Http\Resources\Manager\InstructorEditResource;
+use App\Http\Requests\Manager\InstructorPatchRequest;
+use App\Http\Resources\Manager\InstructorPatchResource;
 
 class InstructorController extends Controller
 {
@@ -37,5 +39,74 @@ class InstructorController extends Controller
 
         $instructor = Instructor::findOrFail($requestInstructorId);
         return new InstructorEditResource($instructor);
+    }
+
+    /**
+     * インストラクター情報更新API
+     *
+     * @param InstructorPatchRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(InstructorPatchRequest $request)
+    {
+        //対象の講師ID
+        $requestInstructorId = $request->instructor_id;
+
+        // マネージャーと配下の講師情報を取得
+        $instructorId = $request->user()->id;
+        $manager = Instructor::with('managings')->findOrFail($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        try {
+            $instructor = Instructor::FindOrFail($requestInstructorId);
+
+            //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+            if (!in_array((int)$requestInstructorId, $instructorIds, true)) {
+                return response()->json([
+                    'result'  => false,
+                    'message' => "Forbidden, not allowed to edit this instructor.",
+                ], 403);
+            }
+
+            // 更新前の画像情報を取得
+            $imagePath = $instructor->profile_image;
+            $file = $request->file('profile_image');
+
+            if (isset($file)) {
+                // 更新前の画像ファイルを削除
+                if (Storage::disk('public')->exists($instructor->profile_image)) {
+                    Storage::disk('public')->delete($instructor->profile_image);
+                }
+
+                // 画像ファイルを保存
+                $extension = $file->getClientOriginalExtension();
+                $filename = Str::uuid()->toString() . '.' . $extension;
+                $imagePath = Storage::disk('public')->putFileAs('instructor', $file, $filename);
+            }
+
+            $instructor->update([
+                'nick_name' => $request->nick_name,
+                'last_name' => $request->last_name,
+                'first_name' => $request->first_name,
+                'email' => $request->email,
+                'profile_image' => $imagePath,
+            ]);
+            return response()->json([
+                'result' => true,
+                'data' => new InstructorPatchResource($instructor)
+            ]);
+
+        } catch (ModelNotFoundException $exception) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Not Found course.'
+            ], 404);
+        } catch (RuntimeException $e) {
+            Log::error($e);
+            return response()->json([
+                "result" => false,
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -96,7 +96,6 @@ class InstructorController extends Controller
                 'result' => true,
                 'data' => new InstructorPatchResource($instructor)
             ]);
-
         } catch (ModelNotFoundException $exception) {
             return response()->json([
                 'result' => false,

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Api\Manager;
 use App\Model\Instructor;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use App\Http\Requests\Manager\InstructorEditRequest;
 use App\Http\Resources\Manager\InstructorEditResource;
 use App\Http\Requests\Manager\InstructorPatchRequest;

--- a/app/Http/Controllers/Api/Manager/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/InstructorController.php
@@ -91,6 +91,7 @@ class InstructorController extends Controller
                 'first_name' => $request->first_name,
                 'email' => $request->email,
                 'profile_image' => $imagePath,
+                'type' => $request->type,
             ]);
             return response()->json([
                 'result' => true,

--- a/app/Http/Requests/Manager/InstructorEditRequest.php
+++ b/app/Http/Requests/Manager/InstructorEditRequest.php
@@ -12,6 +12,7 @@ class InstructorEditRequest extends FormRequest
             'instructor_id' => $this->route('instructor_id'),
         ]);
     }
+
     /**
      * Determine if the user is authorized to make this request.
      *

--- a/app/Http/Requests/Manager/InstructorPatchRequest.php
+++ b/app/Http/Requests/Manager/InstructorPatchRequest.php
@@ -3,8 +3,8 @@
 namespace App\Http\Requests\Manager;
 
 use App\Rules\InstructorUniqueEmailRule;
+use App\Rules\InstructorTypeRule;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Auth;
 
 class InstructorPatchRequest extends FormRequest
 {
@@ -39,6 +39,7 @@ class InstructorPatchRequest extends FormRequest
             'email' => ['required', 'email', new InstructorUniqueEmailRule($this->email),'max:255'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
             'profile_image' => ['mimes:jpg,png', 'max:2048'],
+            'type' =>  ['required', 'string', new InstructorTypeRule()],
         ];
     }
 }

--- a/app/Http/Requests/Manager/InstructorPatchRequest.php
+++ b/app/Http/Requests/Manager/InstructorPatchRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use App\Rules\InstructorUniqueEmailRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+
+class InstructorPatchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'instructor_id' => $this->route('instructor_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'nick_name' => ['required', 'string','max:50'],
+            'last_name' => ['required', 'string','max:50'],
+            'first_name' => ['required', 'string','max:50'],
+            'email' => ['required', 'email', new InstructorUniqueEmailRule($this->email),'max:255'],
+            'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
+            'profile_image' => ['mimes:jpg,png', 'max:2048'],
+        ];
+    }
+}

--- a/app/Http/Requests/Manager/InstructorPatchRequest.php
+++ b/app/Http/Requests/Manager/InstructorPatchRequest.php
@@ -39,7 +39,6 @@ class InstructorPatchRequest extends FormRequest
             'email' => ['required', 'email', new InstructorUniqueEmailRule($this->email),'max:255'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
             'profile_image' => ['mimes:jpg,png', 'max:2048'],
-            'type' =>  ['required', 'string', new InstructorTypeRule()],
         ];
     }
 }

--- a/app/Http/Resources/Instructor/InstructorEditResource.php
+++ b/app/Http/Resources/Instructor/InstructorEditResource.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class InstructorEditResource extends JsonResource
 {
+    /** @var \App\Model\Instructor */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *

--- a/app/Http/Resources/Manager/InstructorEditResource.php
+++ b/app/Http/Resources/Manager/InstructorEditResource.php
@@ -6,6 +6,9 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class InstructorEditResource extends JsonResource
 {
+    /** @var \App\Model\Instructor */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *

--- a/app/Http/Resources/Manager/InstructorPatchResource.php
+++ b/app/Http/Resources/Manager/InstructorPatchResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InstructorPatchResource extends JsonResource
+{
+    /** @var \App\Model\Instructor */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'nick_name' => $this->resource->nick_name,
+            'last_name' => $this->resource->last_name,
+            'first_name' => $this->resource->first_name,
+            'email' => $this->resource->email,
+            'profile_image' => $this->resource->profile_image,
+            'type' => $this->resource->type,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -137,6 +137,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
+                Route::prefix('instructor')->group(function () {
+                    Route::post('{instructor_id}', 'Api\Manager\InstructorController@update');
+                });
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-720

## 概要
新権限マネージャー設立による配下のinstructorの講師情報更新API作成

## 動作確認手順
Postmanでレスポンスを確認。
{{APP_URL}}/api/v1/manager/instructor/2

```
{
    "nick_name": "ニックネーム",
    "last_name": "名字",
    "first_name": "名前",
    "email": "test2@example.com",
    "profile_image": "instructor/default.png",
    "type": "instructor"
}
```
## 考慮して欲しいこと
タスクを分割せずに作業しましたが、こちらで問題ないでしょうか。