### PR TITLE
InstructorのログインユーザIDの取得方法の書き換え(かずふみ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -35,7 +35,7 @@ class CourseController extends Controller
      */
     public function index(Request $request)
     {
-        $instructorId = $request->user()->id;
+        $instructorId = Auth::guard('instructor')->user()->id;
         $courses = Course::where('instructor_id', $instructorId)->get();
 
         return new CourseIndexResource($courses);
@@ -62,7 +62,7 @@ class CourseController extends Controller
      */
     public function store(CourseStoreRequest $request)
     {
-        $instructorId = $request->user()->id;
+        $instructorId = Auth::guard('instructor')->user()->id;
         $file = $request->file('image');
         $extension = $file->getClientOriginalExtension();
         $filename = Str::uuid()->toString() . '.' . $extension;
@@ -158,7 +158,7 @@ class CourseController extends Controller
     public function delete(CourseDeleteRequest $request)
     {
         try {
-            $user = Instructor::find($request->user()->id);
+            $user = Instructor::find(Auth::guard('instructor')->user()->id);
             $course = Course::findOrFail($request->course_id);
 
             if ($user->id !== $course->instructor_id) {


### PR DESCRIPTION
##  概要
- InstructorのログインユーザIDの取得方法の書き換え

## 動作確認手順
- コードを
```$request->user()->id;```
から
```Auth::guard('instructor')->id()```
に変更
ポストマンで
getメソッド　http://localhost:8080/api/v1/instructor/course/1
postメソッド http://localhost:8080/api/v1/instructor/course
deleteメソッド http://localhost:8080/api/v1/instructor/course/10
コードの変更前と変更後を比較して
リクエスト・レスポンスが同じになることを確認

- 又、インストラクターidを変えての確認も行いました。
## 考慮して欲しいこと
- 特にあません
## 確認して欲しいこと
- 特にありません
