### PR TITLE
Managerのリクエストファイルのrule関数に存在しないidを参照しないような記述をする（林）

### DIFF
--- a/app/Http/Requests/Manager/CourseDeleteRequest.php
+++ b/app/Http/Requests/Manager/CourseDeleteRequest.php
@@ -31,7 +31,7 @@ class CourseDeleteRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id'],
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
         ];
     }
 }

--- a/app/Http/Requests/Manager/CourseUpdateRequest.php
+++ b/app/Http/Requests/Manager/CourseUpdateRequest.php
@@ -32,7 +32,7 @@ class CourseUpdateRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required','integer', 'exists:courses,id'],
+            'course_id' => ['required','integer', 'exists:courses,id,deleted_at,NULL'],
             'title' => ['required','string'],
             'image' => ['mimes:jpg,png'],
             'status' => ['required', 'string', new CourseStatusRule()],


### PR DESCRIPTION
## issue、概要
Managerのリクエストファイルのrule関数に存在しないidを参照しないような記述をする

## 動作確認手順
ポストマンで変更したリクエストファイルに関わるコントローラーのurlで動作確認しました。
POST　http://localhost:8080/api/v1/manager/course/10
DELETE　http://localhost:8080/api/v1/manager/course/10

## 考慮して欲しいこと
なし