### PR TITLE
空の配列を返すルーターとコントローラーの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -74,6 +74,11 @@ class NotificationController extends Controller
         return new NotificationShowResource($notification);
     }
 
+    public function store()
+    {
+        return response()->json([]);
+    }
+
     /**
      * お知らせ更新API
      *

--- a/routes/api.php
+++ b/routes/api.php
@@ -173,6 +173,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 });
                             });
                         });
+                        Route::prefix('notification')->group(function () {
+                            Route::post('/', 'Api\Manager\NotificationController@store');
+                        });
                     });
                 });
 


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-744

## 概要
- 空の配列を返すルーターとコントローラーの実装

## 動作確認
- POSTメソッドで[http://localhost:8080/api/v1/manager/instructor/{instructor_id}にリクエストを送り、空の配列が返ってくることを確認]
## 考慮してほしいこと

## 確認してほしいこと