### PR TITLE
新権限マネージャー設立による配下のinstructorの作成した講座の受講情報を削除するAPI作成（ロジック作成）

### DIFF
--- a/app/Http/Requests/Manager/AttendanceDeleteRequest.php
+++ b/app/Http/Requests/Manager/AttendanceDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'attendance_id' => ['required', 'integer', 'exists:attendances,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'attendance_id' => $this->route('attendance_id'),
+        ]);
+    }
+}

--- a/database/seeds/AttendanceSeeder.php
+++ b/database/seeds/AttendanceSeeder.php
@@ -29,6 +29,13 @@ class AttendanceSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'course_id' => 2,
+                'student_id' => 1,
+                'progress' => 10,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## issue
- 新権限マネージャー設立による配下のinstructorの作成した講座の受講情報を削除するAPI作成、ロジックの作成
## 動作確認手順
- ポストマンで、localhost:8080/api/v1/manager/attendance/1
を入力すると以下のレスポンスあり
{
    "result": true
}
/2、/3でも同じ反応。
アドマイナーでnullに更新して再度、ポストマンでの処理をしても同様な反応となった。
## 考慮してほしいこと
- pushに手間取り、ブランチを作成し直しpushし、プルリクしました。
　以前、２回目以降はプルリクは不要とのお話もあったかと思いますが、gitにlogic5をうまく反映できず、今回の手順を踏ました。
## 確認してほしいこと
- 特にありません