### PR TITLE
チャプターを非公開にしたときのみ、チャプターに紐づくレッスンもすべて非公開にするよう変更（はいしま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -160,7 +160,7 @@ class ChapterController extends Controller
         ]);
 
         // チャプターを非公開にする場合は、レッスンのステータスも更新する
-        if ($request->status === Chapter::STATUS_PRIVATE ) {
+        if ($request->status === Chapter::STATUS_PRIVATE) {
             Lesson::where('chapter_id', $request->chapter_id)
             ->update([
                 'status' => $request->status

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\Instructor;
 use Exception;
 use App\Model\Course;
 use App\Model\Chapter;
-use App\Model\Lesson;
 use App\Model\Instructor;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use Exception;
 use App\Model\Course;
 use App\Model\Chapter;
+use App\Model\Lesson;
 use App\Model\Instructor;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -157,6 +158,14 @@ class ChapterController extends Controller
         $chapter->update([
             'status' => $request->status
         ]);
+
+        // チャプターを非公開にする場合は、レッスンのステータスも更新する
+        if ($request->status === Chapter::STATUS_PRIVATE ) {
+            Lesson::where('chapter_id', $request->chapter_id)
+            ->update([
+                'status' => $request->status
+            ]);
+        }
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -159,14 +159,6 @@ class ChapterController extends Controller
             'status' => $request->status
         ]);
 
-        // チャプターを非公開にする場合は、レッスンのステータスも更新する
-        if ($request->status === Chapter::STATUS_PRIVATE) {
-            Lesson::where('chapter_id', $request->chapter_id)
-            ->update([
-                'status' => $request->status
-            ]);
-        }
-
         return response()->json([
             'result' => true,
         ]);

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -60,6 +60,15 @@ class Chapter extends Model
                 $child->delete();
             }
         });
+
+        // チャプター更新時に紐づくレッスンも更新（ステータスが非公開の場合）
+        static::updating(function ($chapter) {
+            if ($chapter->status === Chapter::STATUS_PRIVATE) {
+                foreach ($chapter->lessons()->get() as $child) {
+                    $child->update(['status' => Lesson::STATUS_PRIVATE]);
+                }
+            }
+        });
     }
 
     /**

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -55,18 +55,14 @@ class Chapter extends Model
         parent::boot();
 
         // チャプター削除時に紐づくレッスンも削除
-        static::deleting(function ($chapter) {
-            foreach ($chapter->lessons()->get() as $child) {
-                $child->delete();
-            }
+        static::deleting(function (Chapter $chapter) {
+            $chapter->lessons()->delete();
         });
 
         // チャプター更新時に紐づくレッスンも更新（ステータスが非公開の場合）
-        static::updating(function ($chapter) {
+        static::updating(function (Chapter $chapter) {
             if ($chapter->status === Chapter::STATUS_PRIVATE) {
-                foreach ($chapter->lessons()->get() as $child) {
-                    $child->update(['status' => Lesson::STATUS_PRIVATE]);
-                }
+                $chapter->lessons()->update(['status' => Lesson::STATUS_PRIVATE]);
             }
         });
     }


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-700
子課題　JKA-770 ロジック修正

>親課題
改修タスク：チャプターを非公開にしたときのみ、チャプターに紐づくレッスンもすべて非公開にするよう変更
https://gut-familie.atlassian.net/browse/JKA-769

## 概要
Instructor側：チャプターを非公開にしたとき、紐づくレッスンもすべて非公開にするよう変更

## 動作確認手順
Instructorでログインし、配下の指定した講座のチャプターのステータスを更新する
PATCH
http://localhost:8080/api/v1/instructor/course/1/chapter/2/status
Body>Raw (JSON)
```
{
    "status" : "private"
}
```
ステータスがprivateのとき、配下のレッスンも全て更新に成功すること
```
{
    "result": true
}
```
## 考慮して欲しいこと
Postmanで動作確認する場合、上記の動作はどのように確認できるのでしょうか。
エラーが出なければ、レッスンのステータスも正しく更新されていると考えて問題ないでしょうか。