### PR TITLE
受講生一覧取得APIにおいて、受講状況が論理削除されているものは含めないようにする（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -55,13 +55,14 @@ class StudentController extends Controller
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
             ->where('attendances.course_id', $request->course_id)
+            ->whereNull('attendances.deleted_at')
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
             ->when($inputText, function ($query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
                 $query->where(function ($query) use ($inputText) {
                     $query->orWhere('students.nick_name', 'LIKE', "%{$inputText}%")
-                    ->orWhere('students.email', 'LIKE', "%{$inputText}%")
-                    ->orWhere(DB::raw("CONCAT(students.last_name, students.first_name)"), 'LIKE', "%{$inputText}%");
+                        ->orWhere('students.email', 'LIKE', "%{$inputText}%")
+                        ->orWhere(DB::raw("CONCAT(students.last_name, students.first_name)"), 'LIKE', "%{$inputText}%");
                 });
             })
             // 日付検索


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-777

## 概要
- 受講生一覧取得APIにおいて、受講状況が論理削除されているものは含めないようにする

## 動作確認手順
- データベースのattendancesテーブルのデータcourseカラムが1のデータを一つ論理削除し、Postmanでhttp://localhost:8080/api/v1/instructor/course/1/student/index にGETリクエストを送信して削除された生徒以外の情報が返ってくることを確認

## 考慮して欲しいこと
- 特にありません

## 確認してほしいこと
- 特にありません