### PR TITLE
講師の生徒一覧APIに受講idがレスポンスに含まれていないので、受講情報を返すように修正

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -51,7 +51,7 @@ class StudentController extends Controller
                 'students.email',
                 'students.profile_image',
                 'students.last_login_at',
-                'attendances.id as attendanced_id',
+                'attendances.id as attendance_id',
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -51,6 +51,7 @@ class StudentController extends Controller
                 'students.email',
                 'students.profile_image',
                 'students.last_login_at',
+                'attendances.id as attendanced_id',
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -65,7 +65,7 @@ class StudentController extends Controller
                 'students.email',
                 'students.profile_image',
                 'students.last_login_at',
-                'attendances.course_id as attendanced_id',
+                'attendances.id as attendanced_id',
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -65,7 +65,7 @@ class StudentController extends Controller
                 'students.email',
                 'students.profile_image',
                 'students.last_login_at',
-                'attendances.id as attendanced_id',
+                'attendances.id as attendance_id',
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -65,6 +65,7 @@ class StudentController extends Controller
                 'students.email',
                 'students.profile_image',
                 'students.last_login_at',
+                'attendances.course_id as attendanced_id',
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
@@ -92,7 +93,7 @@ class StudentController extends Controller
         $course = Course::find($request->course_id);
         return new StudentIndexResource([
             'course' => $course,
-            'data' => $results
+            'data' => $results,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -93,7 +93,7 @@ class StudentController extends Controller
         $course = Course::find($request->course_id);
         return new StudentIndexResource([
             'course' => $course,
-            'data' => $results,
+            'data' => $results
         ]);
     }
 

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -43,10 +43,12 @@ class StudentIndexResource extends JsonResource
                 'student_id' => $result->student_id,
                 'nick_name' => $result->nick_name,
                 'email' => $result->email,
-                'profile_image' => $result->profile_image,
                 'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
-                'attendanced_at' => $result->attendanced_at,
+                'attendance' => [
+                    'attendanced_id' => $course->course_id,
+                    'attendanced_at' => $result->attendanced_at,
+                ],
             ];
         });
     }

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -46,7 +46,7 @@ class StudentIndexResource extends JsonResource
                 'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
-                    'attendanced_id' => $result->attendanced_id,
+                    'attendance_id' => $result->attendance_id,
                     'attendanced_at' => $result->attendanced_at,
                 ],
             ];

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -46,7 +46,7 @@ class StudentIndexResource extends JsonResource
                 'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
-                    'attendanced_id' => $course->course_id,
+                    'attendanced_id' => $result->attendanced_id,
                     'attendanced_at' => $result->attendanced_at,
                 ],
             ];

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -46,7 +46,10 @@ class StudentIndexResource extends JsonResource
                 'profile_image' => $result->profile_image,
                 'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
-                'attendanced_at' => $result->attendanced_at,
+                'attendance' => [
+                    'attendanced_id' => $result->attendanced_id,
+                    'attendanced_at' => $result->attendanced_at,
+                ],
             ];
         });
     }

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -47,7 +47,7 @@ class StudentIndexResource extends JsonResource
                 'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
-                    'attendanced_id' => $result->attendanced_id,
+                    'attendance_id' => $result->attendance_id,
                     'attendanced_at' => $result->attendanced_at,
                 ],
             ];


### PR DESCRIPTION
## issue
 - https://gut-familie.atlassian.net/browse/JKA-774
## 概要
 - 講師の生徒一覧APIに受講idがレスポンスに含まれていないので、受講情報を返すように修正
## 動作確認手順
 - https://yukihirolaravel.github.io/laravel_next_docker/api/swagger-sample/index.html#/Instructor-Course/getInstructorCourseStudentIndex
## 考慮してほしいこと
 - エラーになっていない状態のレスポンスが返ってきます。現状はattenadance_id:nullになっております。
## 確認してほしいこと
 - StudentController.php68行目、StudentIndexResource.php48~51行目の追加をしたがエラーになる