### PR TITLE
JKA-797 空の配列を返すルーターとコントローラーの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -74,7 +74,9 @@ class NotificationController extends Controller
         return new NotificationShowResource($notification);
     }
 
-    //* お知らせ登録
+    /**
+     * お知らせ登録API
+     */
     public function store()
     {
         return response()->json([]);

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -74,6 +74,13 @@ class NotificationController extends Controller
         return new NotificationShowResource($notification);
     }
 
+    //* お知らせ登録
+    public function store()
+
+    {
+        return response()->json([]);
+    }
+
     /**
      * お知らせ更新API
      *

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -76,7 +76,6 @@ class NotificationController extends Controller
 
     //* お知らせ登録
     public function store()
-
     {
         return response()->json([]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -174,6 +174,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 });
                             });
                         });
+                        Route::prefix('notification')->group(function () {
+                            Route::post('/', 'Api\Manager\NotificationController@store');
+                        });
                     });
                 });
 


### PR DESCRIPTION
## issue
JKA-797

## 概要
空の配列を返すルーターとコントローラーの作成
（JKA-744の子課題1）

## 動作確認手順
postmanにて、POSTメソッドで、<http://localhost:8080/api/v1/manager/course>に接続し、
レスポンスが[]になることを確認しました

## 考慮してほしいこと
なし

## 確認してほしいこと
なし