### PR TITLE
JKA-779 講師側受講状況API フォームリクエストの作成（小林）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -246,7 +246,7 @@ class AttendanceController extends Controller
             'title' => $chapter->title,
             'status' => $chapter->status,
             'progress' => $chapterProgress,
-            'lessons' => $this->getChapterLessonsData($chapter, $attendance),
+            'lessons' => $this->getChapterLessonsForChapter($chapter, $attendance),
             ];
         })->toArray();
     }
@@ -276,7 +276,7 @@ class AttendanceController extends Controller
  * @param Attendance $attendance
  * @return array
  */
-    private function getChapterLessonsData(Chapter $chapter, Attendance $attendance): array
+    private function getChapterLessonsForChapter(Chapter $chapter, Attendance $attendance): array
     {
         return $chapter->lessons->map(function ($lesson) use ($attendance) {
             $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -111,7 +111,7 @@ class AttendanceController extends Controller
     public function delete(AttendanceDeleteRequest $request): JsonResponse
     {
         DB::beginTransaction();
-        
+
         try {
             $attendanceId = $request->route('attendance_id');
             $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -211,10 +211,10 @@ class AttendanceController extends Controller
             'data' => [
                 'attendance_id' => $attendance->id,
                 'course' => [
-                    'course_id' => $attendance->course_id,
+                    'course_id' => $attendance->course->id,
                     'title' => $attendance->course->title,
                     'progress' => $attendance->progress,
-                    'chapter' => $attendance->course->chapters->map(function ($chapter) {
+                    'chapter' => $attendance->course->chapters->map(function (Chapter $chapter) {
                         return [
                             'chapter_id' => $chapter->id,
                             'title' => $chapter->title,

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -259,10 +259,10 @@ class AttendanceController extends Controller
     */
     private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
     {
-        return $chapter->lessons->flatMap(function ($lesson) use ($attendance) {
-            $lessonAttendance = $lesson->lessonAttendances->firstWhere('attendance_id', $attendance->id);
-            return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-        })->count();
+    return $chapter->lessons->filter(function ($lesson) use ($attendance) {
+        $lessonAttendance = $lesson->lessonAttendances->firstWhere('attendance_id', $attendance->id);
+        return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+    })->count();
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -263,13 +263,20 @@ class AttendanceController extends Controller
  */
     private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
     {
-        return $chapter->lessons->flatMap(function ($lesson) use ($attendance) {
-            $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
+        // チャプター内のレッスンIDを配列として取得
+        $lessonIds = $chapter->lessons->pluck('id')->toArray();
+    
+        // レッスンIDが含まれる LessonAttendance を一括で取得
+        $lessonAttendances = LessonAttendance::whereIn('lesson_id', $lessonIds)
             ->where('attendance_id', $attendance->id)
-            ->first();
+            ->get();
 
-            return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+        // 完了済みのレッスン数をカウント
+        $completedCount = $lessonAttendances->filter(function ($lessonAttendance) {
+            return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
         })->count();
+
+        return $completedCount;
     }
 
 /**

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -197,7 +197,7 @@ class AttendanceController extends Controller
      */
     public function status(AttendanceStatusRequest $request): JsonResponse
     {
-        $attendanceId = $request->attendanceId();
+        $attendanceId = $request->attendance_id;
 
         /** @var Attendance */
         $attendance = Attendance::with('course.chapters')->findOrFail($attendanceId);
@@ -236,8 +236,6 @@ class AttendanceController extends Controller
  */
     private function calculateChapterProgress(Attendance $attendance): array
     {
-
-        $chapters = $attendance->course->chapters()->with(['lessons', 'lessons.lessonAttendances'])->get();
 
         return $attendance->course->chapters->map(function ($chapter) use ($attendance) {
             $completedCount = $this->calculateCompletedLessonCount($chapter, $attendance);

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -30,48 +30,48 @@ class AttendanceController extends Controller
      * @param AttendanceStoreRequest $request
      * @return JsonResponse
      */
-public function store(AttendanceStoreRequest $request): JsonResponse
-{
-    $attendance = Attendance::where('course_id', $request->course_id)
-        ->where('student_id', $request->student_id)
-        ->first();
+    public function store(AttendanceStoreRequest $request): JsonResponse
+    {
+        $attendance = Attendance::where('course_id', $request->course_id)
+            ->where('student_id', $request->student_id)
+            ->first();
 
-    if ($attendance) {
-        return response()->json([
-            'result' => false,
-            'message' => 'Attendance record already exists.'
-        ], 409);
-    }
-
-    DB::beginTransaction();
-    try {
-        $attendance = Attendance::create([
-            'course_id'  => $request->course_id,
-            'student_id' => $request->student_id,
-            'progress'   => Attendance::PROGRESS_DEFAULT_VALUE
-        ]);
-        $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
-            $query->where('course_id', $request->course_id);
-        })->get();
-        foreach ($lessons as $lesson) {
-            LessonAttendance::create([
-                'attendance_id' => $attendance->id,
-                'lesson_id'     => $lesson->id,
-                'status'        => LessonAttendance::STATUS_BEFORE_ATTENDANCE
-            ]);
+        if ($attendance) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Attendance record already exists.'
+            ], 409);
         }
-        DB::commit();
-        return response()->json([
-            'result' => true,
-        ]);
-    } catch (Exception $e) {
-        DB::rollBack();
-        Log::error($e);
-        return response()->json([
-            'result' => false,
-        ], 500);
+
+        DB::beginTransaction();
+        try {
+            $attendance = Attendance::create([
+                'course_id'  => $request->course_id,
+                'student_id' => $request->student_id,
+                'progress'   => Attendance::PROGRESS_DEFAULT_VALUE
+            ]);
+            $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
+                $query->where('course_id', $request->course_id);
+            })->get();
+            foreach ($lessons as $lesson) {
+                LessonAttendance::create([
+                    'attendance_id' => $attendance->id,
+                    'lesson_id'     => $lesson->id,
+                    'status'        => LessonAttendance::STATUS_BEFORE_ATTENDANCE
+                ]);
+            }
+            DB::commit();
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+            ], 500);
+        }
     }
-}
 
     /**
      * 受講状況取得API
@@ -79,28 +79,28 @@ public function store(AttendanceStoreRequest $request): JsonResponse
      * @param AttendanceShowRequest $request
      * @return AttendanceShowResource
      */
-public function show(AttendanceShowRequest $request): AttendanceShowResource
-{
-    $courseId = $request->course_id;
+    public function show(AttendanceShowRequest $request): AttendanceShowResource
+    {
+        $courseId = $request->course_id;
 
-    /** @var Collection<Chapter> */
-    $chapters = Chapter::with('lessons.lessonAttendances')->where('course_id', $courseId)->get();
+        /** @var Collection<Chapter> */
+        $chapters = Chapter::with('lessons.lessonAttendances')->where('course_id', $courseId)->get();
 
-    /** @var int */
-    $studentsCount = Attendance::where('course_id', $courseId)->count();
+        /** @var int */
+        $studentsCount = Attendance::where('course_id', $courseId)->count();
 
-    $chapters->each(function (Chapter $chapter) {
-        $completedCount = $chapter->lessons->flatMap(function (Lesson $lesson) {
-            return $lesson->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
-        })->count();
-        $chapter->completed_count = $completedCount;
-    });
+        $chapters->each(function (Chapter $chapter) {
+            $completedCount = $chapter->lessons->flatMap(function (Lesson $lesson) {
+                return $lesson->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
+            })->count();
+            $chapter->completed_count = $completedCount;
+        });
 
-    return new AttendanceShowResource([
-        'chapters' => $chapters,
-        'studentsCount' => $studentsCount,
-    ]);
-}
+        return new AttendanceShowResource([
+            'chapters' => $chapters,
+            'studentsCount' => $studentsCount,
+        ]);
+    }
 
     /**
      * 受講状況削除API
@@ -108,36 +108,36 @@ public function show(AttendanceShowRequest $request): AttendanceShowResource
      * @param AttendanceDeleteRequest $request
      * @return JsonResponse
      */
-public function delete(AttendanceDeleteRequest $request): JsonResponse
-{
-    DB::beginTransaction();
+    public function delete(AttendanceDeleteRequest $request): JsonResponse
+    {
+        DB::beginTransaction();
 
-    try {
-        $attendanceId = $request->route('attendance_id');
-        $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);
+        try {
+            $attendanceId = $request->route('attendance_id');
+            $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);
 
-        if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
+            if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
+                return response()->json([
+                    "result" => false,
+                    "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
+                ], 403);
+            }
+
+            $attendance->delete();
+
+            DB::commit();
+
+            return response()->json([
+                "result" => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
             return response()->json([
                 "result" => false,
-                "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
-            ], 403);
+            ], 500);
         }
-
-        $attendance->delete();
-
-        DB::commit();
-
-        return response()->json([
-            "result" => true,
-        ]);
-    } catch (Exception $e) {
-        DB::rollBack();
-        Log::error($e);
-        return response()->json([
-            "result" => false,
-        ], 500);
     }
-}
 
     /**
      * 受講生ログイン率取得API
@@ -145,49 +145,49 @@ public function delete(AttendanceDeleteRequest $request): JsonResponse
      * @param LoginRateRequest $request
      * @return JsonResponse
      */
-public function loginRate(LoginRateRequest $request): JsonResponse
-{
-    $instructorId = Course::findOrFail($request->course_id)->instructor_id;
-    $loginId = Auth::guard('instructor')->user()->id;
+    public function loginRate(LoginRateRequest $request): JsonResponse
+    {
+        $instructorId = Course::findOrFail($request->course_id)->instructor_id;
+        $loginId = Auth::guard('instructor')->user()->id;
 
-    if ($instructorId !== $loginId) {
-        return response()->json([
-            'result' => 'false',
-            'message' => 'You could not get login rate'
-        ], 403);
-    }
-
-    $endDate = new Carbon();
-
-    if ($request->period === Attendance::PERIOD_WEEK) {
-        $periodAgo = $endDate->subWeek();
-    } elseif ($request->period === Attendance::PERIOD_MONTH) {
-        $periodAgo = $endDate->subMonth();
-    } elseif ($request->period === Attendance::PERIOD_YEAR) {
-        $periodAgo = $endDate->subYear();
-    } else {
-        return response()->json([
-            'result' => 'false',
-            'message' => 'You could not get login rate'
-        ], 400);
-    }
-
-    $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
-    $studentsCount = $attendances->count();
-
-    // 期間内にログインした受講生数
-    $loginCount = 0;
-
-    foreach ($attendances as $attendance) {
-        $lastLoginDate = $attendance->student->last_login_at;
-        if ($lastLoginDate->gte($periodAgo)) {
-            $loginCount++;
+        if ($instructorId !== $loginId) {
+            return response()->json([
+                'result' => 'false',
+                'message' => 'You could not get login rate'
+            ], 403);
         }
-    }
 
-    $loginRate = $this->calcLoginRate($loginCount, $studentsCount);
-    return response()->json(['login_rate' => $loginRate], 200);
-}
+        $endDate = new Carbon();
+
+        if ($request->period === Attendance::PERIOD_WEEK) {
+            $periodAgo = $endDate->subWeek();
+        } elseif ($request->period === Attendance::PERIOD_MONTH) {
+            $periodAgo = $endDate->subMonth();
+        } elseif ($request->period === Attendance::PERIOD_YEAR) {
+            $periodAgo = $endDate->subYear();
+        } else {
+            return response()->json([
+                'result' => 'false',
+                'message' => 'You could not get login rate'
+            ], 400);
+        }
+
+        $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
+        $studentsCount = $attendances->count();
+
+        // 期間内にログインした受講生数
+        $loginCount = 0;
+
+        foreach ($attendances as $attendance) {
+            $lastLoginDate = $attendance->student->last_login_at;
+            if ($lastLoginDate->gte($periodAgo)) {
+                $loginCount++;
+            }
+        }
+
+        $loginRate = $this->calcLoginRate($loginCount, $studentsCount);
+        return response()->json(['login_rate' => $loginRate], 200);
+    }
 
 /**
  * 講師側受講状況API
@@ -258,19 +258,19 @@ if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id
     }
 
 		/**
-		* 受講生ログイン率計算
-		*
-		* @param int $number
-		* @param int $total
-		* @return float
-		*/
-		public function calcLoginRate(int $number, int $total): float
-		{
+     * 受講生ログイン率計算
+     *
+     * @param int $number
+     * @param int $total
+     * @return float
+     */
+    public function calcLoginRate(int $number, int $total): float
+    {
         if ($total === 0) {
             return 0;
         }
 
         $percent = ($number / $total) * 100;
         return floor($percent);
-		}
-		}
+    }
+}

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -236,7 +236,7 @@ class AttendanceController extends Controller
     */
     private function calculateChapterProgress(Attendance $attendance): array
     {
-    
+
         $attendance->course->load('chapters.lessons');
 
         return $attendance->course->chapters->map(function ($chapter) use ($attendance) {
@@ -280,20 +280,20 @@ class AttendanceController extends Controller
     * @param Attendance $attendance
     * @return array
     */
-        private function getChapterLessonsForChapter(Chapter $chapter, Attendance $attendance): array
-        {
+    private function getChapterLessonsForChapter(Chapter $chapter, Attendance $attendance): array
+    {
 
-            $chapter->load(['lessons.lessonAttendances']);
+        $chapter->load(['lessons.lessonAttendances']);
 
-            return $chapter->lessons->map(function ($lesson) use ($attendance) {
-                $lessonAttendance = $lesson->lessonAttendances->firstWhere('attendance_id', $attendance->id);
+        return $chapter->lessons->map(function ($lesson) use ($attendance) {
+            $lessonAttendance = $lesson->lessonAttendances->firstWhere('attendance_id', $attendance->id);
 
-                return [
-                    'lesson_id' => $lesson->id,
-                    'status' => $lessonAttendance ? $lessonAttendance->status : null,
-                ];
-            })->toArray();
-        }
+            return [
+                'lesson_id' => $lesson->id,
+                'status' => $lessonAttendance ? $lessonAttendance->status : null,
+            ];
+        })->toArray();
+    }
 
     /**
      * 受講生ログイン率計算

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -257,7 +257,7 @@ class AttendanceController extends Controller
         return response()->json($response, 200);
     }
 
-	/**
+    /**
      * 受講生ログイン率計算
      *
      * @param int $number

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -196,8 +196,10 @@ class AttendanceController extends Controller
      * @param AttendanceStatusRequest $request
      * @return JsonResponse
      */
-    public function status(int $attendance_id, AttendanceStatusRequest $request): JsonResponse
+    public function status(AttendanceStatusRequest $request): JsonResponse
     {
+        $attendance_id = $request->input('attendance_id');
+        
         /** @var Attendance */
         $attendance = Attendance::with('course.chapters')->findOrFail($attendance_id);
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -195,47 +195,47 @@ class AttendanceController extends Controller
  * @param AttendanceStatusRequest $request
  * @return JsonResponse
  */
-public function status(AttendanceStatusRequest $request): JsonResponse
-{
-    $attendanceId = $request->attendanceId();
+    public function status(AttendanceStatusRequest $request): JsonResponse
+    {
+        $attendanceId = $request->attendanceId();
 
-    /** @var Attendance */
-    $attendance = Attendance::with('course.chapters')->findOrFail($attendanceId);
+        /** @var Attendance */
+        $attendance = Attendance::with('course.chapters')->findOrFail($attendanceId);
 
-    if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
-        return response()->json([
+        if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
+            return response()->json([
             "result" => false,
             "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
-        ], 403);
-    }
+            ], 403);
+        }
 
-    $chapterData = $attendance->course->chapters->map(function ($chapter) use ($attendance) {
-        $lessons = $chapter->lessons->map(function ($lesson) use ($attendance) {
-            $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
+        $chapterData = $attendance->course->chapters->map(function ($chapter) use ($attendance) {
+            $lessons = $chapter->lessons->map(function ($lesson) use ($attendance) {
+                $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
                 ->where('attendance_id', $attendance->id)
                 ->first();
 
-            $progress = 0;
-            if ($lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
-                $progress = "100%";
-            }
+                $progress = 0;
+                if ($lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
+                    $progress = "100%";
+                }
 
-            return [
+                return [
                 'lesson_id' => $lesson->id,
                 'status' => $lessonAttendance ? $lessonAttendance->status : null,
                 'progress' => $progress = "0%",
-            ];
-        });
+                ];
+            });
 
-        return [
+            return [
             'chapter_id' => $chapter->id,
             'title' => $chapter->title,
             'status' => $chapter->status,
             'lessons' => $lessons,
-        ];
-    });
+            ];
+        });
 
-    $response = [
+        $response = [
         'data' => [
             'attendance_id' => $attendance->id,
             'progress' => $attendance->progress,
@@ -247,10 +247,10 @@ public function status(AttendanceStatusRequest $request): JsonResponse
                 'chapter' => $chapterData,
             ],
         ],
-    ];
+        ];
 
-    return response()->json($response, 200);
-}
+        return response()->json($response, 200);
+    }
 
     /**
      * 受講生ログイン率計算

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -192,7 +192,6 @@ class AttendanceController extends Controller
     /**
      * 講師側受講状況API
      *
-     * @param int $attendance_id
      * @param AttendanceStatusRequest $request
      * @return JsonResponse
      */

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -225,7 +225,6 @@ class AttendanceController extends Controller
             return [
                 'lesson_id' => $lesson->id,
                 'status' => $lessonAttendance ? $lessonAttendance->status : null,
-                'progress' => $isCompleted ? 100 : 0,
             ];
         });
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -211,7 +211,7 @@ class AttendanceController extends Controller
 
         $chapterCollect = $this->calculateChapterProgress($attendance);
 
-    $response = [
+        $response = [
         'data' => [
             'attendance_id' => $attendance->id,
             'progress' => $attendance->progress,
@@ -223,7 +223,7 @@ class AttendanceController extends Controller
                 'chapter' => $chapterCollect,
             ],
         ],
-    ];
+        ];
 
         return response()->json($response, 200);
     }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -263,7 +263,7 @@ class AttendanceController extends Controller
     {
         // チャプター内のレッスンIDを配列として取得
         $lessonIds = $chapter->lessons->pluck('id')->toArray();
-    
+
         // レッスンIDが含まれる LessonAttendance を一括で取得
         $lessonAttendances = LessonAttendance::whereIn('lesson_id', $lessonIds)
             ->where('attendance_id', $attendance->id)

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -229,7 +229,7 @@ class AttendanceController extends Controller
 }
 
 /**
- * 
+ * チャプターの進捗計算
  *
  * @param Attendance $attendance
  * @return array
@@ -252,7 +252,7 @@ private function calculateChapterProgress(Attendance $attendance): array
 }
 
 /**
- * 
+ * チャプター内完了済みレッスン数計算
  *
  * @param Chapter $chapter
  * @param Attendance $attendance
@@ -270,7 +270,7 @@ private function calculateCompletedLessonCount(Chapter $chapter, Attendance $att
 }
 
 /**
- * 
+ * チャプターレッスンデータ取得
  *
  * @param Chapter $chapter
  * @param Attendance $attendance

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -189,7 +189,7 @@ class AttendanceController extends Controller
         return response()->json(['login_rate' => $loginRate], 200);
     }
 
-    　　/**
+    /**
      * 講師側受講状況API
      *
      * @param int $attendance_id

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -261,21 +261,18 @@ class AttendanceController extends Controller
  */
     private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
     {
-        // チャプター内のレッスンIDを配列として取得
-        $lessonIds = $chapter->lessons->pluck('id')->toArray();
-    
-        // レッスンIDが含まれる LessonAttendance を一括で取得
+
+        $lessonIds = $chapter->lessons->pluck('id');
+
         $lessonAttendances = LessonAttendance::whereIn('lesson_id', $lessonIds)
             ->where('attendance_id', $attendance->id)
-            ->get();
+            ->get(['lesson_id', 'status']);
 
-        // 完了済みのレッスン数をカウント
-        $completedCount = $lessonAttendances->filter(function ($lessonAttendance) {
-            return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-        })->count();
+        $completedCount = $lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)->count();
 
         return $completedCount;
     }
+
 
 /**
  * チャプターレッスンデータ取得

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -30,48 +30,48 @@ class AttendanceController extends Controller
      * @param AttendanceStoreRequest $request
      * @return JsonResponse
      */
-public function store(AttendanceStoreRequest $request): JsonResponse
-{
-    $attendance = Attendance::where('course_id', $request->course_id)
+    public function store(AttendanceStoreRequest $request): JsonResponse
+    {
+        $attendance = Attendance::where('course_id', $request->course_id)
         ->where('student_id', $request->student_id)
         ->first();
 
-    if ($attendance) {
-        return response()->json([
+        if ($attendance) {
+            return response()->json([
             'result' => false,
             'message' => 'Attendance record already exists.'
-        ], 409);
-    }
+            ], 409);
+        }
 
-    DB::beginTransaction();
-    try {
-        $attendance = Attendance::create([
+        DB::beginTransaction();
+        try {
+            $attendance = Attendance::create([
             'course_id'  => $request->course_id,
             'student_id' => $request->student_id,
             'progress'   => Attendance::PROGRESS_DEFAULT_VALUE
-        ]);
-        $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
-            $query->where('course_id', $request->course_id);
-        })->get();
-        foreach ($lessons as $lesson) {
-            LessonAttendance::create([
-                'attendance_id' => $attendance->id,
-                'lesson_id'     => $lesson->id,
-                'status'        => LessonAttendance::STATUS_BEFORE_ATTENDANCE
             ]);
-        }
-        DB::commit();
-        return response()->json([
+            $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
+                $query->where('course_id', $request->course_id);
+            })->get();
+            foreach ($lessons as $lesson) {
+                LessonAttendance::create([
+                    'attendance_id' => $attendance->id,
+                    'lesson_id'     => $lesson->id,
+                    'status'        => LessonAttendance::STATUS_BEFORE_ATTENDANCE
+                ]);
+            }
+            DB::commit();
+            return response()->json([
             'result' => true,
-        ]);
-    } catch (Exception $e) {
-        DB::rollBack();
-        Log::error($e);
-        return response()->json([
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
             'result' => false,
-        ], 500);
+            ], 500);
+        }
     }
-}
 
     /**
      * 受講状況取得API
@@ -79,28 +79,28 @@ public function store(AttendanceStoreRequest $request): JsonResponse
      * @param AttendanceShowRequest $request
      * @return AttendanceShowResource
      */
-public function show(AttendanceShowRequest $request): AttendanceShowResource
-{
-    $courseId = $request->course_id;
+    public function show(AttendanceShowRequest $request): AttendanceShowResource
+    {
+        $courseId = $request->course_id;
 
-    /** @var Collection<Chapter> */
-    $chapters = Chapter::with('lessons.lessonAttendances')->where('course_id', $courseId)->get();
+        /** @var Collection<Chapter> */
+        $chapters = Chapter::with('lessons.lessonAttendances')->where('course_id', $courseId)->get();
 
-    /** @var int */
-    $studentsCount = Attendance::where('course_id', $courseId)->count();
+        /** @var int */
+        $studentsCount = Attendance::where('course_id', $courseId)->count();
 
-    $chapters->each(function (Chapter $chapter) {
-        $completedCount = $chapter->lessons->flatMap(function (Lesson $lesson) {
-            return $lesson->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
-        })->count();
-        $chapter->completed_count = $completedCount;
-    });
+        $chapters->each(function (Chapter $chapter) {
+            $completedCount = $chapter->lessons->flatMap(function (Lesson $lesson) {
+                return $lesson->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
+            })->count();
+            $chapter->completed_count = $completedCount;
+        });
 
-    return new AttendanceShowResource([
+        return new AttendanceShowResource([
         'chapters' => $chapters,
         'studentsCount' => $studentsCount,
-    ]);
-}
+        ]);
+    }
 
     /**
      * 受講状況削除API
@@ -108,36 +108,36 @@ public function show(AttendanceShowRequest $request): AttendanceShowResource
      * @param AttendanceDeleteRequest $request
      * @return JsonResponse
      */
-public function delete(AttendanceDeleteRequest $request): JsonResponse
-{
-    DB::beginTransaction();
+    public function delete(AttendanceDeleteRequest $request): JsonResponse
+    {
+        DB::beginTransaction();
 
-    try {
-        $attendanceId = $request->route('attendance_id');
-        $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);
+        try {
+            $attendanceId = $request->route('attendance_id');
+            $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);
 
-        if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
-            return response()->json([
+            if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
+                return response()->json([
                 "result" => false,
                 "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
-            ], 403);
-        }
+                ], 403);
+            }
 
-        $attendance->delete();
+            $attendance->delete();
 
-        DB::commit();
+            DB::commit();
 
-        return response()->json([
+            return response()->json([
             "result" => true,
-        ]);
-    } catch (Exception $e) {
-        DB::rollBack();
-        Log::error($e);
-        return response()->json([
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
             "result" => false,
-        ], 500);
+            ], 500);
+        }
     }
-}
 
     /**
      * 受講生ログイン率取得API
@@ -145,49 +145,49 @@ public function delete(AttendanceDeleteRequest $request): JsonResponse
      * @param LoginRateRequest $request
      * @return JsonResponse
      */
-public function loginRate(LoginRateRequest $request): JsonResponse
-{
-    $instructorId = Course::findOrFail($request->course_id)->instructor_id;
-    $loginId = Auth::guard('instructor')->user()->id;
+    public function loginRate(LoginRateRequest $request): JsonResponse
+    {
+        $instructorId = Course::findOrFail($request->course_id)->instructor_id;
+        $loginId = Auth::guard('instructor')->user()->id;
 
-    if ($instructorId !== $loginId) {
-        return response()->json([
+        if ($instructorId !== $loginId) {
+            return response()->json([
             'result' => 'false',
             'message' => 'You could not get login rate'
-        ], 403);
-    }
-
-    $endDate = new Carbon();
-
-    if ($request->period === Attendance::PERIOD_WEEK) {
-        $periodAgo = $endDate->subWeek();
-    } elseif ($request->period === Attendance::PERIOD_MONTH) {
-        $periodAgo = $endDate->subMonth();
-    } elseif ($request->period === Attendance::PERIOD_YEAR) {
-        $periodAgo = $endDate->subYear();
-    } else {
-        return response()->json([
-            'result' => 'false',
-            'message' => 'You could not get login rate'
-        ], 400);
-    }
-
-    $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
-    $studentsCount = $attendances->count();
-
-    // 期間内にログインした受講生数
-    $loginCount = 0;
-
-    foreach ($attendances as $attendance) {
-        $lastLoginDate = $attendance->student->last_login_at;
-        if ($lastLoginDate->gte($periodAgo)) {
-            $loginCount++;
+            ], 403);
         }
-    }
 
-    $loginRate = $this->calcLoginRate($loginCount, $studentsCount);
-    return response()->json(['login_rate' => $loginRate], 200);
-}
+        $endDate = new Carbon();
+
+        if ($request->period === Attendance::PERIOD_WEEK) {
+            $periodAgo = $endDate->subWeek();
+        } elseif ($request->period === Attendance::PERIOD_MONTH) {
+            $periodAgo = $endDate->subMonth();
+        } elseif ($request->period === Attendance::PERIOD_YEAR) {
+            $periodAgo = $endDate->subYear();
+        } else {
+            return response()->json([
+            'result' => 'false',
+            'message' => 'You could not get login rate'
+            ], 400);
+        }
+
+        $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
+        $studentsCount = $attendances->count();
+
+        // 期間内にログインした受講生数
+        $loginCount = 0;
+
+        foreach ($attendances as $attendance) {
+            $lastLoginDate = $attendance->student->last_login_at;
+            if ($lastLoginDate->gte($periodAgo)) {
+                $loginCount++;
+            }
+        }
+
+        $loginRate = $this->calcLoginRate($loginCount, $studentsCount);
+        return response()->json(['login_rate' => $loginRate], 200);
+    }
 
 /**
  * 講師側受講状況API
@@ -195,43 +195,43 @@ public function loginRate(LoginRateRequest $request): JsonResponse
  * @param AttendanceStatusRequest $request
  * @return JsonResponse
  */
-public function status(AttendanceStatusRequest $request): JsonResponse
+    public function status(AttendanceStatusRequest $request): JsonResponse
     {
         $attendanceId = $request->attendanceId();
 
         /** @var Attendance */
         $attendance = Attendance::with('course.chapters')->findOrFail($attendanceId);
 
-if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
-    return response()->json([
-    "result" => false,
-    "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
-    ], 403);
-}
+        if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
+            return response()->json([
+            "result" => false,
+            "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
+            ], 403);
+        }
 
-    $chapterData = $attendance->course->chapters->map(function ($chapter) use ($attendance) {
-        $completedCount = 0;
-        $lessons = $chapter->lessons->map(function ($lesson) use ($attendance, &$completedCount) {
-            $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
+        $chapterData = $attendance->course->chapters->map(function ($chapter) use ($attendance) {
+            $completedCount = 0;
+            $lessons = $chapter->lessons->map(function ($lesson) use ($attendance, &$completedCount) {
+                $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
                 ->where('attendance_id', $attendance->id)
                 ->first();
 
-            $isCompleted = $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+                $isCompleted = $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
 
-            if ($isCompleted) {
-                $completedCount++;
-            }
+                if ($isCompleted) {
+                    $completedCount++;
+                }
 
-            return [
+                return [
                 'lesson_id' => $lesson->id,
                 'status' => $lessonAttendance ? $lessonAttendance->status : null,
-            ];
-        });
+                ];
+            });
 
-        $totalLessonsCount = $lessons->count();
-        $chapterProgress = $totalLessonsCount > 0 ? ($completedCount / $totalLessonsCount) * 100 : 0;
+            $totalLessonsCount = $lessons->count();
+            $chapterProgress = $totalLessonsCount > 0 ? ($completedCount / $totalLessonsCount) * 100 : 0;
 
-        return [
+            return [
             'chapter_id' => $chapter->id,
             'title' => $chapter->title,
             'status' => $chapter->status,
@@ -239,7 +239,7 @@ if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id
             'lessons' => $lessons,
             ];
         });
-    
+
         $response = [
         'data' => [
             'attendance_id' => $attendance->id,
@@ -253,24 +253,24 @@ if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id
             ],
         ],
         ];
-    
+
         return response()->json($response, 200);
     }
 
-		/**
-		* 受講生ログイン率計算
-		*
-		* @param int $number
-		* @param int $total
-		* @return float
-		*/
-		public function calcLoginRate(int $number, int $total): float
-		{
+        /**
+        * 受講生ログイン率計算
+        *
+        * @param int $number
+        * @param int $total
+        * @return float
+        */
+    public function calcLoginRate(int $number, int $total): float
+    {
         if ($total === 0) {
             return 0;
         }
 
         $percent = ($number / $total) * 100;
         return floor($percent);
-		}
-		}
+    }
+}

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -263,15 +263,15 @@ class AttendanceController extends Controller
     */
     private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
     {
-    $lessonIds = $chapter->lessons->pluck('id')->toArray();
+        $lessonIds = $chapter->lessons->pluck('id')->toArray();
 
-    $lessonAttendances = LessonAttendance::whereIn('lesson_id', $lessonIds)
+        $lessonAttendances = LessonAttendance::whereIn('lesson_id', $lessonIds)
         ->where('attendance_id', $attendance->id)
         ->get(['lesson_id', 'status']);
 
-    $completedCount = $lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)->count();
+        $completedCount = $lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)->count();
 
-    return $completedCount;
+        return $completedCount;
     }
 
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -286,7 +286,7 @@ class AttendanceController extends Controller
 
         return $chapter->lessons->map(function ($lesson) use ($attendance) {
             $lessonAttendance = $lesson->lessonAttendances->firstWhere('attendance_id', $attendance->id);
-            
+
             return [
                 'lesson_id' => $lesson->id,
                 'status' => $lessonAttendance ? $lessonAttendance->status : null,

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -257,7 +257,7 @@ class AttendanceController extends Controller
         return response()->json($response, 200);
     }
 
-		/**
+        /**
      * 受講生ログイン率計算
      *
      * @param int $number

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -111,7 +111,7 @@ class AttendanceController extends Controller
     public function delete(AttendanceDeleteRequest $request): JsonResponse
     {
         DB::beginTransaction();
-
+        
         try {
             $attendanceId = $request->route('attendance_id');
             $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);
@@ -238,17 +238,10 @@ class AttendanceController extends Controller
             'status' => $chapter->status,
             'progress' => $chapterProgress,
             'lessons' => $lessons,
-<<<<<<< HEAD
-        ];
-    });
-    
-    $response = [
-=======
             ];
         });
-
+    
         $response = [
->>>>>>> b0711df2ac0e146a84b2acbd0c1dd1427075feff
         'data' => [
             'attendance_id' => $attendance->id,
             'progress' => $attendance->progress,
@@ -260,17 +253,10 @@ class AttendanceController extends Controller
                 'chapter' => $chapterData,
             ],
         ],
-<<<<<<< HEAD
-    ];
-    
-    return response()->json($response, 200);
-}
-=======
         ];
-
+    
         return response()->json($response, 200);
     }
->>>>>>> b0711df2ac0e146a84b2acbd0c1dd1427075feff
 
     /**
      * 受講生ログイン率計算

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -198,6 +198,7 @@ class AttendanceController extends Controller
      */
     public function status(int $attendance_id, AttendanceStatusRequest $request): JsonResponse
     {
+        /** @var Attendance */
         $attendance = Attendance::with('course.chapters')->findOrFail($attendance_id);
 
         if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -199,7 +199,7 @@ class AttendanceController extends Controller
     public function status(AttendanceStatusRequest $request): JsonResponse
     {
         $attendance_id = $request->input('attendance_id');
-        
+
         /** @var Attendance */
         $attendance = Attendance::with('course.chapters')->findOrFail($attendance_id);
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -189,7 +189,7 @@ class AttendanceController extends Controller
         return response()->json(['login_rate' => $loginRate], 200);
     }
 
-     /**
+    /**
      * 講師側受講状況API
      *
      * @param int $attendance_id

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -212,15 +212,17 @@ class AttendanceController extends Controller
         $response = [
             'data' => [
                 'attendance_id' => $attendance->id,
+                'progress' => $attendance->progress,
                 'course' => [
                     'course_id' => $attendance->course->id,
                     'title' => $attendance->course->title,
-                    'progress' => $attendance->progress,
+                    'status' => $attendance->course->status,
+                    'image' => $attendance->course->image,
                     'chapter' => $attendance->course->chapters->map(function (Chapter $chapter) {
                         return [
                             'chapter_id' => $chapter->id,
                             'title' => $chapter->title,
-                            'progress' => $chapter->progress,
+                            'status' => $chapter->status,
                         ];
                     }),
                 ],

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -189,7 +189,7 @@ class AttendanceController extends Controller
         return response()->json(['login_rate' => $loginRate], 200);
     }
 
-    /**
+　　/**
      * 講師側受講状況API
      *
      * @param int $attendance_id

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -189,12 +189,12 @@ class AttendanceController extends Controller
         return response()->json(['login_rate' => $loginRate], 200);
     }
 
-/**
- * 講師側受講状況API
- *
- * @param AttendanceStatusRequest $request
- * @return JsonResponse
- */
+    /**
+     * 講師側受講状況API
+     *
+     * @param AttendanceStatusRequest $request
+     * @return JsonResponse
+     */
     public function status(AttendanceStatusRequest $request): JsonResponse
     {
         $attendanceId = $request->attendanceId();
@@ -204,8 +204,8 @@ class AttendanceController extends Controller
 
         if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
             return response()->json([
-            "result" => false,
-            "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
+                "result" => false,
+                "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
             ], 403);
         }
 
@@ -257,7 +257,7 @@ class AttendanceController extends Controller
         return response()->json($response, 200);
     }
 
-		/**
+	/**
      * 受講生ログイン率計算
      *
      * @param int $number

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -259,10 +259,10 @@ class AttendanceController extends Controller
     */
     private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
     {
-    return $chapter->lessons->filter(function ($lesson) use ($attendance) {
-        $lessonAttendance = $lesson->lessonAttendances->firstWhere('attendance_id', $attendance->id);
-        return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-    })->count();
+        return $chapter->lessons->filter(function ($lesson) use ($attendance) {
+            $lessonAttendance = $lesson->lessonAttendances->firstWhere('attendance_id', $attendance->id);
+            return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+        })->count();
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -214,19 +214,19 @@ public function status(AttendanceStatusRequest $request): JsonResponse
             $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
                 ->where('attendance_id', $attendance->id)
                 ->first();
-
+    
             $progress = 0;
-            if ($lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
-                $progress = "100%";
+            if ($lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
+                $progress = 100;
             }
-
+    
             return [
                 'lesson_id' => $lesson->id,
                 'status' => $lessonAttendance ? $lessonAttendance->status : null,
-                'progress' => $progress = "0%",
+                'progress' => $progress,
             ];
         });
-
+    
         return [
             'chapter_id' => $chapter->id,
             'title' => $chapter->title,
@@ -234,7 +234,7 @@ public function status(AttendanceStatusRequest $request): JsonResponse
             'lessons' => $lessons,
         ];
     });
-
+    
     $response = [
         'data' => [
             'attendance_id' => $attendance->id,
@@ -248,7 +248,7 @@ public function status(AttendanceStatusRequest $request): JsonResponse
             ],
         ],
     ];
-
+    
     return response()->json($response, 200);
 }
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -263,13 +263,15 @@ class AttendanceController extends Controller
     */
     private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
     {
-        return $chapter->lessons->flatMap(function ($lesson) use ($attendance) {
-            $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
-                ->where('attendance_id', $attendance->id)
-                ->first();
+    $lessonIds = $chapter->lessons->pluck('id')->toArray();
 
-            return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-        })->count();
+    $lessonAttendances = LessonAttendance::whereIn('lesson_id', $lessonIds)
+        ->where('attendance_id', $attendance->id)
+        ->get(['lesson_id', 'status']);
+
+    $completedCount = $lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)->count();
+
+    return $completedCount;
     }
 
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -189,7 +189,7 @@ class AttendanceController extends Controller
         return response()->json(['login_rate' => $loginRate], 200);
     }
 
-　　/**
+    　　/**
      * 講師側受講状況API
      *
      * @param int $attendance_id

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -211,7 +211,7 @@ class AttendanceController extends Controller
 
         $chapterData = $this->calculateChapterProgress($attendance);
 
-    $response = [
+        $response = [
         'data' => [
             'attendance_id' => $attendance->id,
             'progress' => $attendance->progress,
@@ -223,72 +223,72 @@ class AttendanceController extends Controller
                 'chapter' => $chapterData,
             ],
         ],
-    ];
+        ];
 
-    return response()->json($response, 200);
-}
+        return response()->json($response, 200);
+    }
 
 /**
- * 
+ *
  *
  * @param Attendance $attendance
  * @return array
  */
-private function calculateChapterProgress(Attendance $attendance): array
-{
-    return $attendance->course->chapters->map(function ($chapter) use ($attendance) {
-        $completedCount = $this->calculateCompletedLessonCount($chapter, $attendance);
-        $totalLessonsCount = $chapter->lessons->count();
-        $chapterProgress = $totalLessonsCount > 0 ? ($completedCount / $totalLessonsCount) * 100 : 0;
+    private function calculateChapterProgress(Attendance $attendance): array
+    {
+        return $attendance->course->chapters->map(function ($chapter) use ($attendance) {
+            $completedCount = $this->calculateCompletedLessonCount($chapter, $attendance);
+            $totalLessonsCount = $chapter->lessons->count();
+            $chapterProgress = $totalLessonsCount > 0 ? ($completedCount / $totalLessonsCount) * 100 : 0;
 
-        return [
+            return [
             'chapter_id' => $chapter->id,
             'title' => $chapter->title,
             'status' => $chapter->status,
             'progress' => $chapterProgress,
             'lessons' => $this->getChapterLessonsData($chapter, $attendance),
-        ];
-    })->toArray();
-}
+            ];
+        })->toArray();
+    }
 
 /**
- * 
+ *
  *
  * @param Chapter $chapter
  * @param Attendance $attendance
  * @return int
  */
-private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
-{
-    return $chapter->lessons->flatMap(function ($lesson) use ($attendance) {
-        $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
+    private function calculateCompletedLessonCount(Chapter $chapter, Attendance $attendance): int
+    {
+        return $chapter->lessons->flatMap(function ($lesson) use ($attendance) {
+            $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
             ->where('attendance_id', $attendance->id)
             ->first();
 
-        return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-    })->count();
-}
+            return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+        })->count();
+    }
 
 /**
- * 
+ *
  *
  * @param Chapter $chapter
  * @param Attendance $attendance
  * @return array
  */
-private function getChapterLessonsData(Chapter $chapter, Attendance $attendance): array
-{
-    return $chapter->lessons->map(function ($lesson) use ($attendance) {
-        $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
+    private function getChapterLessonsData(Chapter $chapter, Attendance $attendance): array
+    {
+        return $chapter->lessons->map(function ($lesson) use ($attendance) {
+            $lessonAttendance = LessonAttendance::where('lesson_id', $lesson->id)
             ->where('attendance_id', $attendance->id)
             ->first();
 
-        return [
+            return [
             'lesson_id' => $lesson->id,
             'status' => $lessonAttendance ? $lessonAttendance->status : null,
-        ];
-    })->toArray();
-}
+            ];
+        })->toArray();
+    }
 
     /**
      * 受講生ログイン率計算

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -209,7 +209,7 @@ class AttendanceController extends Controller
             ], 403);
         }
 
-        $chapterData = $this->calculateChapterProgress($attendance);
+        $chapterCollect = $this->calculateChapterProgress($attendance);
 
         $response = [
         'data' => [
@@ -220,7 +220,7 @@ class AttendanceController extends Controller
                 'title' => $attendance->course->title,
                 'status' => $attendance->course->status,
                 'image' => $attendance->course->image,
-                'chapter' => $chapterData,
+                'chapter' => $chapterCollect,
             ],
         ],
         ];

--- a/app/Http/Requests/Instructor/AttendanceStatusRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceStatusRequest.php
@@ -28,6 +28,11 @@ class AttendanceStatusRequest extends FormRequest
         ];
     }
 
+    public function attendanceId()
+    {
+        return $this->route('attendance_id');
+    }
+
     protected function prepareForValidation()
     {
         $this->merge([

--- a/app/Http/Requests/Instructor/AttendanceStatusRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceStatusRequest.php
@@ -28,11 +28,16 @@ class AttendanceStatusRequest extends FormRequest
         ];
     }
 
+    /**
+     * Get the attendance ID from the request.
+     *
+     * @return int
+     */
     public function attendanceId()
     {
         return $this->route('attendance_id');
     }
-
+    
     protected function prepareForValidation()
     {
         $this->merge([

--- a/app/Http/Requests/Instructor/AttendanceStatusRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceStatusRequest.php
@@ -34,5 +34,4 @@ class AttendanceStatusRequest extends FormRequest
             'attendance_id' => $this->route('attendance_id'),
         ]);
     }
-    
 }

--- a/app/Http/Requests/Instructor/AttendanceStatusRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceStatusRequest.php
@@ -24,24 +24,7 @@ class AttendanceStatusRequest extends FormRequest
     public function rules()
     {
         return [
-            'attendance_id' => ['required','integer', 'exists:attendances,id,deleted_at,NULL'],
+            'attendance_id' => ['required', 'integer', 'exists:attendances,id,deleted_at,NULL'],
         ];
-    }
-
-    /**
-     * Get the attendance ID from the request.
-     *
-     * @return int
-     */
-    public function attendanceId()
-    {
-        return $this->route('attendance_id');
-    }
-    
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'attendance_id' => $this->route('attendance_id'),
-        ]);
     }
 }

--- a/app/Http/Requests/Instructor/AttendanceStatusRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceStatusRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'attendance_id' => ['required','integer', 'exists:attendances,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'attendance_id' => $this->route('attendance_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/AttendanceStatusRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceStatusRequest.php
@@ -37,7 +37,7 @@ class AttendanceStatusRequest extends FormRequest
     {
         return $this->route('attendance_id');
     }
-    
+
     protected function prepareForValidation()
     {
         $this->merge([


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-779
## 概要
- 講師側 受講生詳細画面の学習状況を取得するAPIを作成　子課題
  フォームリクエストの作成
## 動作確認手順
- http://localhost:8080/api/v1/instructor/attendance/2/status
  にアクセスすると直下のように値をとれるが、

```
{
    "data": {
        "attendance_id": 2,
        "progress": 10,
        "course": {
            "course_id": 1,
            "title": "猫ミーム",
            "status": "public",
            "image": "course/4be8edf5-7f3e-4ade-9bff-2e24a63490cd.jpeg",
            "chapter": [
                {
                    "chapter_id": 2,
                    "title": "PHPの基礎を学ぼう",
                    "status": "public",
                    "progress": 25
                },
                {
                    "chapter_id": 3,
                    "title": "PHPの応用にチャレンジしよう",
                    "status": "public",
                    "progress": 0
                }
            ]
        }
    }
}
```

## 考慮してほしいこと
- 今回は特にありません。
## 確認してほしいこと
- 今回は特にありません。