### PR TITLE
feature/ohtomo/create_logic_for_notification_registration_jka744_2

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -92,10 +92,10 @@ class NotificationController extends Controller
 
          // managerと配下のinstructorのIDを取得
          $instructorIds = $manager->managings->pluck('id')->toArray();
-         array_push($instructorIds, $instructorId);
+         $instructorIds[] = $manager->id;
 
          // 対象のコースを取得し、権限の確認を行う
-         $course = Course::FindOrFail($request->course_id);
+         $course = Course::findOrFail($request->course_id);
          if (!in_array($course->instructor_id, $instructorIds, true)) {
          return response()->json([
              'result' => false,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -69,7 +69,7 @@ class NotificationController extends Controller
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
             'result' => false,
-            'message' => 'Forbidden, not allowed to access this notification.',
+            'message' => 'Forbidden.',
             ], 403);
         }
 
@@ -78,28 +78,23 @@ class NotificationController extends Controller
 
     /**
      * お知らせ登録API
-     *
-     * @param NotificationStoreRequest $request
-     * @return JsonResponse
      */
-
     public function store(Request $request)
     {
-
-        // ユーザー認証を確認
         $instructorId = Auth::guard('instructor')->user()->id;
-        $manager = Instructor::with('managings')->find($instructorId);
 
-        // managerと配下のinstructorのIDを取得
+        // 配下のインストラクター情報を取得
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        // 対象のコースを取得し、権限の確認を行う
+        /** @var Course $course */
         $course = Course::findOrFail($request->course_id);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
             return response()->json([
             'result' => false,
-            'message' => 'Forbidden, not allowed to Registration this course.',
+            'message' => 'Forbidden.',
             ], 403);
         }
 
@@ -143,7 +138,7 @@ class NotificationController extends Controller
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
                 'result' => false,
-                'message' => 'Forbidden, not allowed to update this notification.',
+                'message' => 'Forbidden.',
             ], 403);
         }
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -83,40 +83,40 @@ class NotificationController extends Controller
      * @return JsonResponse
      */
 
-     public function store(Request $request)
-     {
+    public function store(Request $request)
+    {
 
-         // ユーザー認証を確認
-         $instructorId = Auth::guard('instructor')->user()->id;
-         $manager = Instructor::with('managings')->find($instructorId);
+        // ユーザー認証を確認
+        $instructorId = Auth::guard('instructor')->user()->id;
+        $manager = Instructor::with('managings')->find($instructorId);
 
-         // managerと配下のinstructorのIDを取得
-         $instructorIds = $manager->managings->pluck('id')->toArray();
-         $instructorIds[] = $manager->id;
+        // managerと配下のinstructorのIDを取得
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
 
-         // 対象のコースを取得し、権限の確認を行う
-         $course = Course::findOrFail($request->course_id);
-         if (!in_array($course->instructor_id, $instructorIds, true)) {
-         return response()->json([
-             'result' => false,
-             'message' => 'Forbidden, not allowed to Registration this course.',
-         ], 403);
-         }
+        // 対象のコースを取得し、権限の確認を行う
+        $course = Course::findOrFail($request->course_id);
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
+            return response()->json([
+            'result' => false,
+            'message' => 'Forbidden, not allowed to Registration this course.',
+            ], 403);
+        }
 
-         Notification::create([
-            'course_id'     => $request->course_id,
-            'instructor_id' => Auth::guard('instructor')->user()->id,
-            'title'         => $request->title,
-            'type'          => $request->type,
-            'start_date'    => $request->start_date,
-            'end_date'      => $request->end_date,
-            'content'       => $request->content,
-         ]);
+        Notification::create([
+           'course_id'     => $request->course_id,
+           'instructor_id' => Auth::guard('instructor')->user()->id,
+           'title'         => $request->title,
+           'type'          => $request->type,
+           'start_date'    => $request->start_date,
+           'end_date'      => $request->end_date,
+           'content'       => $request->content,
+        ]);
 
-         return response()->json([
-             'result' => true,
-         ]);
-     }
+        return response()->json([
+            'result' => true,
+        ]);
+    }
 
     /**
      * お知らせ更新API


### PR DESCRIPTION
## issue
JKA-804

## 概要
お知らせ登録API作成 ロジックの作成
（JKA-744の子課題）


## 動作確認手順
・postmanにて、
メソッド: POST、URL: http://localhost:8080/api/v1/manager/course/1/notification
に接続し、レスポンスがtrueになることを確認しました。

・DataBaseのnotificationにデータが格納されることを確認しました。


## 考慮してほしいこと
なし

## 確認してほしいこと
なし