### PR TITLE
jka-799ロジックの作成～受講生側お知らせ詳細API作成(オオハシ)

### DIFF
--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -53,9 +53,25 @@ class NotificationController extends Controller
         });
     }
 
-    public function show()
+    public function show(Request $request)
     {
-        return Notification::find(1);
-        return response()->json([]);
+        $student =  \Auth::user();
+        $notification = Notification::where('student_id', $student->id)->first();
+        if($notification){
+            $data = [
+                'course_id' => $notification->course_id,
+                'title' => $notification->title,
+                'content' => $notification->content,
+            ];
+
+            return response()->json($data, 200);
+
+        }else{
+
+            return response()->json([
+                "result" => false,
+                "message" => "Notification not found."
+            ], 404);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -75,12 +75,6 @@ class NotificationController extends Controller
             
             return response()->json($data, 200);
 
-        }else{
-
-            return response()->json([
-                "result" => false,
-                "message" => "Notification not found."
-            ], 404);
         }
     }
 }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -64,9 +64,7 @@ class NotificationController extends Controller
         //DBにあるcourseIdから受講生が受講しているcourse_id(1)が一致した場合そのお知らせ通知を取り出す。
         $notification = Notification::whereIn('course_id', $courseIds)->firstOrFail();
 
-        //お知らせがあった場合、詳細に必要な情報のcourse_id,title,contentのデータのみ取り出して$dataに入れる
-        if($notification){
-            
+        　//お知らせがあった場合、詳細に必要な情報のcourse_id,title,contentのデータを$dataに入れて代入する
             $data = [
                 'course_id' => $notification->course_id,
                 'title' => $notification->title,
@@ -74,7 +72,5 @@ class NotificationController extends Controller
             ];
             
             return response()->json($data, 200);
-
-        }
     }
 }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -54,9 +54,17 @@ class NotificationController extends Controller
     }
 
     public function show(Request $request)
-    {
+    {   
+        //ログイン中の受講生の情報を取得
         $student =  \Auth::user();
-        $notification = Notification::where('student_id', $student->id)->first();
+
+        //受講生が受講しているコース情報の取得。plickでcourse_idのみ取得
+        $courseIds = Attendance::where('student_id', $student->id)->pluck('course_id')->toArray();
+
+        //DBにあるcourse_idから受講生が受講しているcourse_idの通知を取り出す
+        $notification = Notification::whereIn('course_id', $courseIds)->first();
+
+        //お知らせがあった場合、詳細に必要な情報のcourse_id,title,contentのデータのみ取り出して$dataに入れる
         if($notification){
             $data = [
                 'course_id' => $notification->course_id,

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -57,11 +57,10 @@ class NotificationController extends Controller
     {   
         $student = Student::findOrFail($request->user()->id);
         $courseIds = Attendance::where('student_id', $student->id)->pluck('course_id')->toArray();
-        $notification = Notification::whereIn('course_id', $courseIds)
-                        ->where('id', $notification_id)
-                        ->with('course') 
-                        ->firstOrFail();
+        $notification = Notification::with(['course'])
+            ->findOrFail($notification_id);
             
+        if (in_array($notification->course_id, $courseIds)) {
             $data = [
                 'notification_id' => $notification_id,
                 'title' => $notification->title,
@@ -73,9 +72,13 @@ class NotificationController extends Controller
                     'title' => $notification->course->title,
                 ],
                 
-                
             ];
-
-            return response()->json($data, 200);
+             return response()->json($data, 200);
+        }else{
+            return response()->json([
+                'result' => false,
+                'message' => 'Forbidden, not allowed to access this notification.',
+            ], 403);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -52,25 +52,30 @@ class NotificationController extends Controller
             return true;
         });
     }
-
-    public function show(Request $request)
+   
+    public function show(Request $request, $notification_id)
     {   
-        //受講生の情報を取得
         $student = Student::findOrFail($request->user()->id);
-
-        //受講生が受講しているコース情報の取得。pluckで受講しているcourse_idのみ取得。今のDBではcourse_idは1のみ
         $courseIds = Attendance::where('student_id', $student->id)->pluck('course_id')->toArray();
-
-        //DBにあるcourseIdから受講生が受講しているcourse_id(1)が一致した場合そのお知らせ通知を取り出す。
-        $notification = Notification::whereIn('course_id', $courseIds)->firstOrFail();
-
-        　//お知らせがあった場合、詳細に必要な情報のcourse_id,title,contentのデータを$dataに入れて代入する
+        $notification = Notification::whereIn('course_id', $courseIds)
+                        ->where('id', $notification_id)
+                        ->with('course') 
+                        ->firstOrFail();
+            
             $data = [
-                'course_id' => $notification->course_id,
+                'notification_id' => $notification_id,
                 'title' => $notification->title,
                 'content' => $notification->content,
+                "start_date" => $notification->start_date,
+                "end_date" => $notification->end_date,
+                'course' => [ 
+                    'course_id' => $notification->course->id, 
+                    'title' => $notification->course->title,
+                ],
+                
+                
             ];
-            
+
             return response()->json($data, 200);
     }
 }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -55,23 +55,24 @@ class NotificationController extends Controller
 
     public function show(Request $request)
     {   
-        //ログイン中の受講生の情報を取得
-        $student =  \Auth::user();
+        //受講生の情報を取得
+        $student = Student::findOrFail($request->user()->id);
 
-        //受講生が受講しているコース情報の取得。plickでcourse_idのみ取得
+        //受講生が受講しているコース情報の取得。pluckで受講しているcourse_idのみ取得。今のDBではcourse_idは1のみ
         $courseIds = Attendance::where('student_id', $student->id)->pluck('course_id')->toArray();
 
-        //DBにあるcourse_idから受講生が受講しているcourse_idの通知を取り出す
-        $notification = Notification::whereIn('course_id', $courseIds)->first();
+        //DBにあるcourseIdから受講生が受講しているcourse_id(1)が一致した場合そのお知らせ通知を取り出す。
+        $notification = Notification::whereIn('course_id', $courseIds)->firstOrFail();
 
         //お知らせがあった場合、詳細に必要な情報のcourse_id,title,contentのデータのみ取り出して$dataに入れる
         if($notification){
+            
             $data = [
                 'course_id' => $notification->course_id,
                 'title' => $notification->title,
                 'content' => $notification->content,
             ];
-
+            
             return response()->json($data, 200);
 
         }else{

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -60,7 +60,13 @@ class NotificationController extends Controller
         $notification = Notification::with(['course'])
             ->findOrFail($notification_id);
             
-        if (in_array($notification->course_id, $courseIds)) {
+        if (!in_array($notification->course_id, $courseIds)) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Forbidden, not allowed to access this notification.',
+            ], 403);
+        }
+
             $data = [
                 'notification_id' => $notification_id,
                 'title' => $notification->title,
@@ -70,15 +76,10 @@ class NotificationController extends Controller
                 'course' => [ 
                     'course_id' => $notification->course->id, 
                     'title' => $notification->course->title,
-                ],
-                
+                ], 
             ];
-             return response()->json($data, 200);
-        }else{
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to access this notification.',
-            ], 403);
-        }
+             
+            return response()->json($data, 200);
     }
 }
+

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -60,7 +60,7 @@ class NotificationController extends Controller
         $notification = Notification::with(['course'])
             ->findOrFail($notification_id);
             
-        if (!in_array($notification->course_id, $courseIds)) {
+        if (!in_array($notification->course_id, $courseIds, true)) {
             return response()->json([
                 'result' => false,
                 'message' => 'Forbidden, not allowed to access this notification.',

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -52,14 +52,14 @@ class NotificationController extends Controller
             return true;
         });
     }
-   
+
     public function show(Request $request, $notification_id)
-    {   
+    {
         $student = Student::findOrFail($request->user()->id);
         $courseIds = Attendance::where('student_id', $student->id)->pluck('course_id')->toArray();
         $notification = Notification::with(['course'])
             ->findOrFail($notification_id);
-            
+
         if (!in_array($notification->course_id, $courseIds, true)) {
             return response()->json([
                 'result' => false,
@@ -73,13 +73,12 @@ class NotificationController extends Controller
                 'content' => $notification->content,
                 "start_date" => $notification->start_date,
                 "end_date" => $notification->end_date,
-                'course' => [ 
-                    'course_id' => $notification->course->id, 
+                'course' => [
+                    'course_id' => $notification->course->id,
                     'title' => $notification->course->title,
-                ], 
+                ],
             ];
-             
+
             return response()->json($data, 200);
     }
 }
-


### PR DESCRIPTION
## 概要
- 受講生側お知らせ詳細API作成の子課題　ロジックの作成
## 動作確認手順
- http://localhost:8080/login
- http://localhost:8080/api/v1/notification/1 
## 確認していただきたいこと
-アクセスしたら確認してほしいことアクセスしたら、下記のようにcourse_id,title,contentの情報を取得できるか
{
    "course_id": 1,
    "title": "レッスン「変数とは？」閲覧について",
    "content": "10月1日〜10日の間、レッスン「変数とは？」がメンテナンスにつき閲覧できなくなります。"
}
## ご教授いただきたいこと
- 他のidで検索しても、DBに存在しないidで検索しても同じcourse_id1の情報が返ってきてしまいます。検索して色々やってみましたが、原因がわからない状況です。
本日の夜勤のための準備をしないといけない時間になってしまったため、プルリクエストさせていただきました。解決のために何かアドバイスを頂きたいです。よろしくお願いいたしいます。