### PR TITLE
#527 JKA-806講師側ダッシュボード今月のレッスン・チャプタ完了数取得APIー空の配列を返す（西田修）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -204,4 +204,10 @@ class AttendanceController extends Controller
         $percent = ($number / $total) * 100;
         return floor($percent);
     }
+
+    public function thisMonth()
+    {
+        $emptyArray = [];
+        return $emptyArray;
+    }
 }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -205,7 +205,7 @@ class AttendanceController extends Controller
         return floor($percent);
     }
 
-    public function thisMonth()
+    public function showStatusThisMonth()
     {
         $emptyArray = [];
         return $emptyArray;

--- a/routes/api.php
+++ b/routes/api.php
@@ -108,6 +108,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('attendance')->group(function () {
                         Route::get('status', 'Api\Instructor\AttendanceController@show');
                         Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
+                        Route::get('status/this-month', 'Api\Instructor\AttendanceController@thisMonth');
                     });
                 });
             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -108,7 +108,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('attendance')->group(function () {
                         Route::get('status', 'Api\Instructor\AttendanceController@show');
                         Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
-                        Route::get('status/this-month', 'Api\Instructor\AttendanceController@showStatusthisMonth');
+                        Route::get('status/this-month', 'Api\Instructor\AttendanceController@showStatusThisMonth');
                     });
                 });
             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -108,7 +108,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('attendance')->group(function () {
                         Route::get('status', 'Api\Instructor\AttendanceController@show');
                         Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
-                        Route::get('status/this-month', 'Api\Instructor\AttendanceController@thisMonth');
+                        Route::get('status/this-month', 'Api\Instructor\AttendanceController@showStatusthisMonth');
                     });
                 });
             });


### PR DESCRIPTION
## 概要
- 講師側ダッシュボード今月のレッスン・チャプタ完了数取得APIー空の配列を返す

## 動作確認手順
- 以下はPostmanでの操作
- Headersにアクセス元のURLを設定
   Referer → `http://localhost:3000`
   Origin → `http://localhost:3000`
- http://localhost:8080/api/v1/instructor/course/1/attendance/status/this-month にGET送信する
- 空の配列が返ってきているかを確認

## 考慮してほしいこと
- 特になし