### PR TITLE
#828 お知らせ登録API作成 フォームリクエストの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Resources\Manager\NotificationShowResource;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
 use App\Http\Resources\Manager\NotificationUpdateResource;
+use App\Http\Requests\Manager\NotificationStoreRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 
@@ -79,7 +80,7 @@ class NotificationController extends Controller
     /**
      * お知らせ登録API
      */
-    public function store(Request $request)
+    public function store(NotificationStoreRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 

--- a/app/Http/Requests/Manager/NotificationStoreRequest.php
+++ b/app/Http/Requests/Manager/NotificationStoreRequest.php
@@ -25,7 +25,7 @@ class NotificationStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id'     => ['required', 'exists:courses,id', 'integer'],
+            'course_id'     => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'title'         => ['required', 'string', 'max:50'],
             'type'          => ['required', new NotificationStoreStatusRule()],
             'start_date'    => ['required', 'date_format:Y-m-d H:i:s'],

--- a/app/Http/Requests/Manager/NotificationStoreRequest.php
+++ b/app/Http/Requests/Manager/NotificationStoreRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\NotificationStoreStatusRule;
+
+class NotificationStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id'     => ['required', 'exists:courses,id', 'integer'],
+            'title'         => ['required', 'string', 'max:50'],
+            'type'          => ['required', new NotificationStoreStatusRule()],
+            'start_date'    => ['required', 'date_format:Y-m-d H:i:s'],
+            'end_date'      => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
+            'content'       => ['required', 'string', 'max:500'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
JKA-828

## 概要
お知らせ登録API作成 フォームリクエストの作成
（JKA-744の子課題）


## 動作確認手順
・postmanにて、
メソッド: POST、URL: http://localhost:8080/api/v1/manager/course/1/notification
に接続し、レスポンスが下記になることを確認しました。
{
    "result": true
}


・DataBaseのnotificationにデータが格納されることを確認しました。
