### PR TITLE
jka-805 講師側 ダッシュボード 本日のレッスン・チャプター完了数 取得APIの実装 developブランチへのマージ（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -212,6 +212,26 @@ class AttendanceController extends Controller
      */
     public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {
-        return response()->json([]);
+        $completedLessonattendancesId = LessonAttendance::with(['attendance' => function ($query) use ($request) {
+            $query->where('course_id', $request->course_id);
+        }])->where('status', 'completed_attendance')->whereDate('updated_at', Carbon::today())->pluck('id');
+
+        $completedLessonsCount = count($completedLessonattendancesId);
+
+        $lessons = Lesson::whereIn('id', $completedLessonattendancesId)->with(['chapter' => function ($query) {
+            $query->withCount('lessons')->get();
+        }])->get();
+        $completedChaptersCount = 0;
+        $lessons->each(function ($lesson) use (&$completedChaptersCount) {
+            $totalLessons = $lesson->chapter->lessons_count;
+            // $completedLesssons = 
+        });
+
+        return response()->json([
+            'completedLessonattendancesId' => $completedLessonattendancesId,
+            'completed_lessons_count' => $completedLessonsCount,
+            'lessons' => $lessons,
+            'completed_chapters_count' =>  $completedChaptersCount
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -212,9 +212,9 @@ class AttendanceController extends Controller
      */
     public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {
-        $completedLessonsCount = LessonAttendance::with(['attendance' => function ($query) use ($request) {
+        $completedLessonsCount = LessonAttendance::whereHas('attendance', function ($query) use ($request) {
             $query->where('course_id', $request->course_id);
-        }])->where('status', 'completed_attendance')->whereDate('updated_at', Carbon::today())->count();
+        })->where('status', 'completed_attendance')->whereDate('updated_at', Carbon::today())->count();
 
         // withCountとcount()どちらを使う方がいいでしょうか？
         function chapterTotalLessonCount($chapter_id)

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -258,7 +258,7 @@ class AttendanceController extends Controller
                 'chapter_id' => $lessonAttendance->lesson->chapter_id,
                 'attendance_id' => $lessonAttendance->attendance_id,
             ];
-        })->unique();
+        })->unique()->count();
 
         return response()->json([
             'completed_lessons_count' => $completedLessonsCount,

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -204,4 +204,14 @@ class AttendanceController extends Controller
         $percent = ($number / $total) * 100;
         return floor($percent);
     }
+
+    /**
+     * 講座受講状況-当日
+     *
+     * @param AttendanceShowRequest $request
+     */
+    public function showAttendanceStatus(AttendanceShowRequest $request): JsonResponse
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -210,7 +210,7 @@ class AttendanceController extends Controller
      *
      * @param AttendanceShowRequest $request
      */
-    public function showAttendanceStatus(AttendanceShowRequest $request): JsonResponse
+    public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -192,14 +192,4 @@ class CourseController extends Controller
             'result' => 'true'
         ]);
     }
-
-    /**
-     * 講座受講状況-当日
-     *
-     * @param CourseShowRequest $request
-     */
-    public function showAttendanceStatus(CourseShowRequest $request): JsonResponse
-    {
-        return response()->json([]);
-    }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -200,6 +200,6 @@ class CourseController extends Controller
      */
     public function showAttendanceStatus(CourseShowRequest $request): JsonResponse
     {
-        return response()->json([]);
+        return response()->json(["kara"]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -200,6 +200,6 @@ class CourseController extends Controller
      */
     public function showAttendanceStatus(CourseShowRequest $request): JsonResponse
     {
-        return response()->json(["kara"]);
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -192,4 +192,14 @@ class CourseController extends Controller
             'result' => 'true'
         ]);
     }
+
+    /**
+     * 講座受講状況-当日
+     *
+     * @param CourseShowRequest $request
+     */
+    public function showAttendanceStatus(CourseShowRequest $request): JsonResponse
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Model/LessonAttendance.php
+++ b/app/Model/LessonAttendance.php
@@ -4,14 +4,15 @@ namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
  * @property int $lesson_id
  * @property int $attendance_id
  * @property 'before_attendance'|'in_attendance'|'completed_attendance' $status
- * @property string $created_at
- * @property string $updated_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property string|null $deleted_at
  * @property Lesson $lesson
  * @property Attendance $attendance
@@ -31,6 +32,12 @@ class LessonAttendance extends Model
         'lesson_id',
         'attendance_id',
         'status'
+    ];
+
+    protected $dates = [
+        'created_at',
+        'updated_at',
+        'deleted_at'
     ];
 
     // ステータス定数

--- a/routes/api.php
+++ b/routes/api.php
@@ -69,7 +69,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('/', 'Api\Instructor\CourseController@show');
                     Route::post('/', 'Api\Instructor\CourseController@update');
                     Route::delete('/', 'Api\Instructor\CourseController@delete');
-                    Route::get('attendance/status/today', 'Api\Instructor\CourseController@showAttendanceStatus');
                     // 講師-講座-チャプター
                     Route::prefix('chapter')->group(function () {
                         Route::post('/', 'Api\Instructor\ChapterController@store');
@@ -108,6 +107,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('attendance')->group(function () {
                         Route::get('status', 'Api\Instructor\AttendanceController@show');
                         Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
+                        Route::get('status/today', 'Api\Instructor\AttendanceController@showAttendanceStatus');
                     });
                 });
             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -69,7 +69,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('/', 'Api\Instructor\CourseController@show');
                     Route::post('/', 'Api\Instructor\CourseController@update');
                     Route::delete('/', 'Api\Instructor\CourseController@delete');
-                    Route::get('attendance/status/today', 'Api\Instructor\CourseController@showAttendanceStatus');
                     // 講師-講座-チャプター
                     Route::prefix('chapter')->group(function () {
                         Route::post('/', 'Api\Instructor\ChapterController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -69,6 +69,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('/', 'Api\Instructor\CourseController@show');
                     Route::post('/', 'Api\Instructor\CourseController@update');
                     Route::delete('/', 'Api\Instructor\CourseController@delete');
+                    Route::get('attendance/status/today', 'Api\Instructor\CourseController@showAttendanceStatus');
                     // 講師-講座-チャプター
                     Route::prefix('chapter')->group(function () {
                         Route::post('/', 'Api\Instructor\ChapterController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -107,7 +107,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('attendance')->group(function () {
                         Route::get('status', 'Api\Instructor\AttendanceController@show');
                         Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
-                        Route::get('status/today', 'Api\Instructor\AttendanceController@showAttendanceStatus');
+                        Route::get('status/today', 'Api\Instructor\AttendanceController@showStatusToday');
                     });
                 });
             });


### PR DESCRIPTION
## issue
-Closes jka-805

## 概要
- 講師側 ダッシュボード 本日のレッスン・チャプター完了数 取得APIの実装

## 動作確認手順
- Postmanで講師 id：1 でログイン後GET http://localhost:8080/api/v1/instructor/course/1/attendance/status/today　をする

## 考慮して欲しいこと
- 特にありません

## 確認してほしいこと
- 特にありません