### PR TITLE
jka-832 マネージャー側 講師-講座一覧APIの作成（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -15,7 +15,7 @@ class CourseController extends Controller
      * 講師-講座情報一覧取得API
      *
      * @param InstructorCourseIndexRequest $request
-     * @return InstructorCourseIndexResource|\Illuminate\Http\JsonResponse 
+     * @return InstructorCourseIndexResource|\Illuminate\Http\JsonResponse
      */
     public function index(InstructorCourseIndexRequest $request)
     {

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -25,17 +25,16 @@ class CourseController extends Controller
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->findOrFail($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $managerId;
+        $instructorIds[] = $manager->id;
 
-        //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+        // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
         if (!in_array((int)$request->instructor_id, $instructorIds, true)) {
             return response()->json([
                 'result'  => false,
-                'message' => "Forbidden, not allowed to this instructor.",
+                'message' => "Forbidden.",
             ], 403);
         }
 
-        /** @var Instructor $instructor */
         $courses = Course::where('instructor_id', $request->instructor_id)
             ->paginate(5);
 

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -3,15 +3,42 @@
 namespace App\Http\Controllers\Api\Manager\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\InstructorCourseIndexRequest;
+use App\Http\Resources\Manager\InstructorCourseIndexResource;
+use App\Model\Course;
+use App\Model\Instructor;
+use Illuminate\Support\Facades\Auth;
 
 class CourseController extends Controller
 {
     /**
-     * 講師講座情報一覧取得API
+     * 講師-講座情報一覧取得API
      *
+     * @param InstructorCourseIndexRequest $request
+     * @return InstructorCourseIndexResource|\Illuminate\Http\JsonResponse 
      */
-    public function index()
+    public function index(InstructorCourseIndexRequest $request)
     {
-        return response()->json([]);
+        $managerId = Auth::guard('instructor')->user()->id;
+
+        // 配下の講師情報を取得
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->findOrFail($managerId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $managerId;
+
+        //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+        if (!in_array((int)$request->instructor_id, $instructorIds, true)) {
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to this instructor.",
+            ], 403);
+        }
+
+        /** @var Instructor $instructor */
+        $courses = Course::where('instructor_id', $request->instructor_id)
+            ->paginate(5);
+
+        return new InstructorCourseIndexResource($courses);
     }
 }

--- a/app/Http/Requests/Manager/InstructorCourseIndexRequest.php
+++ b/app/Http/Requests/Manager/InstructorCourseIndexRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class InstructorCourseIndexRequest extends FormRequest
+{
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'instructor_id' => $this->route('instructor_id'),
+        ]);
+    }
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
+        ];
+    }
+}

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -31,10 +31,10 @@ class InstructorCourseIndexResource extends JsonResource
     }
 
     /**
-     * @param Collection<\App\Model\Course> $notifications
+     * @param Collection<\App\Model\Course> $courses
      * @return array
      */
-    private function mapCourses($courses)
+    private function mapCourses(Collection $courses)
     {
         return $courses->map(function (Course $course) {
             return [
@@ -42,6 +42,7 @@ class InstructorCourseIndexResource extends JsonResource
                 "title" => $course->title,
                 "status" => $course->status
             ];
-        });
+        })
+        ->toArray();
     }
 }

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Manager;
 
+use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -21,7 +22,7 @@ class InstructorCourseIndexResource extends JsonResource
     {
         $courses = $this->resource;
         return [
-            "courses" => $this->mapCourses($courses),
+            "courses" => $this->mapCourses($courses->getCollection()),
             "pagination" => [
                 "page" => $courses->currentPage(),
                 "total" => $courses->total()
@@ -30,16 +31,16 @@ class InstructorCourseIndexResource extends JsonResource
     }
 
     /**
-     * @param Collection<\App\Model\Notification> $notifications
+     * @param Collection<\App\Model\Course> $notifications
      * @return array
      */
     private function mapCourses($courses)
     {
-        return $courses->map(function ($course) {
+        return $courses->map(function (Course $course) {
             return [
                 "course_id" => $course->id,
-                "course_title" => $course->title,
-                "couese_status" => $course->status
+                "title" => $course->title,
+                "status" => $course->status
             ];
         });
     }

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -38,8 +38,8 @@ class InstructorCourseIndexResource extends JsonResource
         return $courses->map(function ($course) {
             return [
                 "course_id" => $course->id,
-                "title" => $course->title,
-                "status" => $course->status
+                "course_title" => $course->title,
+                "couese_status" => $course->status
             ];
         });
     }

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class InstructorCourseIndexResource extends JsonResource
+{
+    /** @var LengthAwarePaginator */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        $courses = $this->resource;
+        return [
+            "courses" => $this->mapCourses($courses),
+            "pagination" => [
+                "page" => $courses->currentPage(),
+                "total" => $courses->total()
+            ]
+        ];
+    }
+
+    /**
+     * @param Collection<\App\Model\Notification> $notifications
+     * @return array
+     */
+    private function mapCourses($courses)
+    {
+        return $courses->map(function ($course) {
+            return [
+                "course_id" => $course->id,
+                "title" => $course->title,
+                "status" => $course->status
+            ];
+        });
+    }
+}


### PR DESCRIPTION
## task
-Closes JKA-832

## 概要
- マネージャー側 講師-講座一覧APIの作成

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/instructor/2/course/index をGETで送信して
```
{
    "data": {
        "courses": [
            {
                "course_id": 2,
                "course_title": "Laravel入門講座",
                "couese_status": "public"
            },
            {
                "course_id": 6,
                "course_title": "Vue入門講座",
                "couese_status": "public"
            }
        ],
        "pagination": {
            "page": 1,
            "total": 2
        }
    }
}
```
が返ってくることを確認

## 考慮して欲しいこと
- 特にありません
## 確認してほしいこと
- 特にありません