### PR TITLE
jka841 マネージャー側 お知らせ 一括（選択）表示ステータス変更API 空の配列を返す（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -117,7 +117,7 @@ class NotificationController extends Controller
         ]);
     }
 
-    public function updateStatus()
+    public function updateType()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -65,8 +65,8 @@ class NotificationController extends Controller
         // アクセス権限のチェック
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
-            'result' => false,
-            'message' => 'Forbidden, not allowed to access this notification.',
+                'result' => false,
+                'message' => 'Forbidden, not allowed to access this notification.',
             ], 403);
         }
 
@@ -110,10 +110,15 @@ class NotificationController extends Controller
             'title' => $request->title,
             'content' => $request->content,
         ])
-        ->save();
+            ->save();
 
         return response()->json([
             'result' => true,
         ]);
+    }
+
+    public function updateStatus()
+    {
+        return response()->json([]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,6 +203,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
+                    Route::put('status/{status}', 'Api\Manager\NotificationController@updateStatus');
                 });
             });
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,7 +203,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
-                    Route::put('status/{status}', 'Api\Manager\NotificationController@updateStatus');
+                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
                 });
             });
         });


### PR DESCRIPTION
## task
-Closes JKA-841

## 概要
- 空の配列を返す

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/notification/status/all をPUTで送信し、[] が返ってくることを確認

## 考慮して欲しいこと
- 特にありません
## 確認してほしいこと
- putとpatchどちらがいいのでしょうか？