### PR TITLE
空の配列を返すルーティングとコントローラーの作成(近藤佑哉)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -100,7 +100,8 @@ class NotificationController extends Controller
         ]);
     }
 
-    public function updateStatus() {
+    public function updateStatus()
+    {
         return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -13,6 +13,8 @@ use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 
+use function PHPSTORM_META\type;
+
 class NotificationController extends Controller
 {
     /**
@@ -100,7 +102,7 @@ class NotificationController extends Controller
         ]);
     }
 
-    public function updateStatus()
+    public function updateType()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -99,4 +99,8 @@ class NotificationController extends Controller
             'result' => true,
         ]);
     }
+
+    public function updateStatus() {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -13,8 +13,6 @@ use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 
-use function PHPSTORM_META\type;
-
 class NotificationController extends Controller
 {
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -220,7 +220,7 @@ Route::prefix('v1')->group(function () {
 Route::prefix('v1')->group(function () {
     Route::prefix('instructor')->group(function () {
         Route::prefix('notification')->group(function () {
-            Route::put('status/{status}', 'Api\Instructor\NotificationController@updateStatus');
+            Route::put('type/{type}', 'Api\Instructor\NotificationController@updateStatus');
             Route::prefix('{notification_id}')->group(function () {
                 Route::get('/', 'Api\Instructor\NotificationController@show');
                 Route::patch('/', 'Api\Instructor\NotificationController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -220,7 +220,7 @@ Route::prefix('v1')->group(function () {
 Route::prefix('v1')->group(function () {
     Route::prefix('instructor')->group(function () {
         Route::prefix('notification')->group(function () {
-            Route::put('type/{type}', 'Api\Instructor\NotificationController@updateStatus');
+            Route::put('type/{type}', 'Api\Instructor\NotificationController@updateType');
             Route::prefix('{notification_id}')->group(function () {
                 Route::get('/', 'Api\Instructor\NotificationController@show');
                 Route::patch('/', 'Api\Instructor\NotificationController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -220,6 +220,7 @@ Route::prefix('v1')->group(function () {
 Route::prefix('v1')->group(function () {
     Route::prefix('instructor')->group(function () {
         Route::prefix('notification')->group(function () {
+            Route::put('status/{status}', 'Api\Instructor\NotificationController@updateStatus');
             Route::prefix('{notification_id}')->group(function () {
                 Route::get('/', 'Api\Instructor\NotificationController@show');
                 Route::patch('/', 'Api\Instructor\NotificationController@update');


### PR DESCRIPTION
## task
 - JKA-840
## 概要
 - 空の配列を返すルーティングとコントローラーの作成
## 動作確認手順
 - /login/instructor
 - /api/v1/instructor/notification/status/always
 - /api/v1/instructor/notification/status/once
以上の2つで空の配列が返ってくることを確認
## 確認してほしいこと
 - 一括変更ということでSwaggerを参考にPUTでよろしいでしょうか？
 - 最後のalways, onceの部分ですが、今回はルーティングと空の配列が返ってくることを確認することが大切だと考えております。しかし、現状のコードですとalways, once以外の文字列が入っても空の配列が返ってきます。その点は修正した方がよろしいでしょうか？