### PR TITLE
JKA-806（講師側 ダッシュボード 今月のレッスン・チャプター完了数 取得API）ロジック実装（西田　修）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -256,6 +256,54 @@ class AttendanceController extends Controller
     }
 
     /**
+     * 講座受講状況-今月
+     *
+     * @param AttendanceShowRequest $request
+     * @return JsonResponse
+     */
+    public function showStatusThisMonth(AttendanceShowRequest $request): JsonResponse
+    {
+        $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+
+        // 今月完了したレッスンの個数を取得
+        $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
+            $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
+                return $lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isCurrentMonth();
+            });
+            return $compleatedLessonAttendances;
+        })->count();
+
+        // 今月完了したチャプターの個数を取得
+        $completedChaptersCount = $attendances->flatMap(function (Attendance $attendance) {
+            return $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
+        })
+        ->filter(function (LessonAttendance $lessonAttendance) {
+            // チャプターに含まれているレッスンが全て完了されているかつ、最新のレッスンの完了済みステータスへの更新日時が今月の日時という条件で絞り込む
+            $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
+            $totalLessonsCount = $allLessonsId->count();
+            $compleatedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
+                ->whereIn('lesson_id', $allLessonsId)
+                ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
+                ->count();
+            return $lessonAttendance->updated_at->isCurrentMonth() && $totalLessonsCount === $compleatedLessonsCount;
+        })
+        ->map(function (LessonAttendance $lessonAttendance) {
+            // chapter_idとattendance_idをキーにもつ新しい配列を作成
+            return [
+                'chapter_id' => $lessonAttendance->lesson->chapter_id,
+                'attendance_id' => $lessonAttendance->attendance_id
+            ];
+        })
+        ->unique()
+        ->count();
+
+        return response()->json([
+            'completed_lessons_count' => $completedLessonsCount,
+            'completed_chapters_count' =>  $completedChaptersCount
+        ]);
+    }
+
+    /**
      * 講師側受講状況API
      *
      * @param AttendanceStatusRequest $request

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -268,7 +268,7 @@ class AttendanceController extends Controller
         // 今月完了したレッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
             $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
-                return $lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isCurrentMonth();
+                return $lessonAttendance->status === 'STATUS_COMPLETED_ATTENDANCE' && $lessonAttendance->updated_at->isCurrentMonth();
             });
             return $compleatedLessonAttendances;
         })->count();

--- a/routes/api.php
+++ b/routes/api.php
@@ -111,6 +111,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('status', 'Api\Instructor\AttendanceController@show');
                         Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
                         Route::get('status/today', 'Api\Instructor\AttendanceController@showStatusToday');
+                        Route::get('status/this-month', 'Api\Instructor\AttendanceController@showStatusThisMonth');
                     });
                 });
             });


### PR DESCRIPTION
## 概要
 講師側ダッシュボード今月のレッスン・チャプタ完了数取得APIーロジック実装

## 動作確認方法
以下はPostmanでの操作
- Headersにアクセス元のURLを設定  
   Referer → http://localhost:3000/  
   Origin → http://localhost:3000/
- http://localhost:8080/api/v1/instructor/course/1/attendance/status/this-month　にGET送信
- 今月のレッスン完了数（completed_lessons_count）及びチャプター完了数（completed_chapters_count）が、返ってきているかを確認

## 考慮してほしいこと
- 特になし