### PR TITLE
JKA-838 講師側お知らせ削除API 空の配列を返すルーターとコントローラの作成（小林）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -100,8 +100,9 @@ class NotificationController extends Controller
             'result' => true,
         ]);
     }
+
     /**
-    * お知らせ全削除、空の配列を返す
+    * お知らせ選択削除、空の配列を返す
     *
     * @param Request $request
     * @return JsonResponse

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Model\Notification;
+use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
@@ -98,5 +99,15 @@ class NotificationController extends Controller
         return response()->json([
             'result' => true,
         ]);
+    }
+    /**
+    * お知らせ全削除、空の配列を返す
+    *
+    * @param Request $request
+    * @return JsonResponse
+    */
+    public function delete(Request $request): JsonResponse
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -107,7 +107,7 @@ class NotificationController extends Controller
     * @param Request $request
     * @return JsonResponse
     */
-    public function delete(Request $request): JsonResponse
+    public function bulkDelete(Request $request): JsonResponse
     {
         return response()->json([]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -134,7 +134,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', 'Api\Instructor\NotificationController@index');
-                Route::delete('/', 'Api\Instructor\NotificationController@delete');
+                Route::delete('/', 'Api\Instructor\NotificationController@bulkDelete');
             });
         });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -134,6 +134,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', 'Api\Instructor\NotificationController@index');
+                Route::delete('/', 'Api\Instructor\NotificationController@delete');
             });
         });
 


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-838
## 概要
- 講師側 お知らせ 一括（選択）削除API作成　子課題
  空の配列を返すルータとコントローラの作成
## 動作確認手順
- DELETEリクエストで　http://localhost:8080/api/v1/instructor/notification
  を実行すると空の配列が返ってきた
## 考慮してほしいこと
- 今回は特にありません。
## 確認してほしいこと
- 今回は特にありません。