### PR TITLE
講師側 お知らせ 一括（選択）表示ステータス変更API作成 ロジックの作成(近藤佑哉)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -16,7 +16,8 @@ use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use Exception;
-// use 
+
+// use
 
 class NotificationController extends Controller
 {

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -99,7 +99,7 @@ class Notification extends Model
         return $this->belongsTo(Course::class, 'course_id');
     }
 
-    public static function typeUpdateAll(int $notifications,string $type): void
+    public static function typeUpdateAll(int $notifications, string $type): void
     {
         Notification::where('notificationId', $notifications)
             ->update([


### PR DESCRIPTION
## 概要
- Closes JKA-840
## 概要
- 講師側 お知らせ 一括（選択）表示ステータス変更API作成 ロジックの作成
## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/notification/type/always の Body に
```
{
    "type" : "once",
    "notifications" : [1,4]
}
```
を記載
## 確認して欲しいこと
動作確認をしたところ以下の画像のエラーが返ってきました。
typeがrequiredとなっていますが、Bodyに含めた為なぜこのエラーが返ってくるのかわかりません。
解像度が低くて申し訳ございませんが、ご教授お願い致します。

![スクリーンショット 2024-05-12 13 47 59](https://github.com/yukihiroLaravel/juko_laravel/assets/150170336/82c7cb20-7e61-4847-8477-1657c432367a)
![スクリーンショット 2024-05-12 13 48 23](https://github.com/yukihiroLaravel/juko_laravel/assets/150170336/9c75efdd-189e-4453-be5f-a9ec2d2e4d60)
