### PR TITLE
講師側 ダッシュボード 今月のレッスン・チャプター完了数 取得APIフォームリクエスト作成　西田修

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Collection;
 use App\Http\Requests\Instructor\LoginRateRequest;
 use App\Http\Requests\Instructor\AttendanceShowRequest;
+use App\Http\Requests\Instructor\AttendanceShowThisMonthRequest;
 use App\Http\Requests\Instructor\AttendanceStoreRequest;
 use App\Http\Requests\Instructor\AttendanceStatusRequest;
 use App\Http\Requests\Instructor\AttendanceDeleteRequest;
@@ -258,10 +259,10 @@ class AttendanceController extends Controller
     /**
      * 講座受講状況-今月
      *
-     * @param AttendanceShowRequest $request
+     * @param AttendanceShowThisMonthRequest $request
      * @return JsonResponse
      */
-    public function showStatusThisMonth(AttendanceShowRequest $request): JsonResponse
+    public function showStatusThisMonth(AttendanceShowThisMonthRequest $request): JsonResponse
     {
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -16,7 +16,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Collection;
 use App\Http\Requests\Instructor\LoginRateRequest;
-use App\Http\Requests\Instructor\AttendanceShowRequest;
+use App\Http\Requests\Instructor\AttendanceShowTodayRequest;
 use App\Http\Requests\Instructor\AttendanceShowThisMonthRequest;
 use App\Http\Requests\Instructor\AttendanceStoreRequest;
 use App\Http\Requests\Instructor\AttendanceStatusRequest;
@@ -214,7 +214,7 @@ class AttendanceController extends Controller
      * @param AttendanceShowRequest $request
      * @return JsonResponse
      */
-    public function showStatusToday(AttendanceShowRequest $request): JsonResponse
+    public function showStatusToday(AttendanceShowTodayRequest $request): JsonResponse
     {
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Collection;
 use App\Http\Requests\Instructor\LoginRateRequest;
+use App\Http\Requests\Instructor\AttendanceShowRequest;
 use App\Http\Requests\Instructor\AttendanceShowTodayRequest;
 use App\Http\Requests\Instructor\AttendanceShowThisMonthRequest;
 use App\Http\Requests\Instructor\AttendanceStoreRequest;

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -212,7 +212,7 @@ class AttendanceController extends Controller
     /**
      * 講座受講状況-当日
      *
-     * @param AttendanceShowRequest $request
+     * @param AttendanceShowTodayRequest $request
      * @return JsonResponse
      */
     public function showStatusToday(AttendanceShowTodayRequest $request): JsonResponse
@@ -270,7 +270,7 @@ class AttendanceController extends Controller
         // 今月完了したレッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
             $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
-                return $lessonAttendance->status === 'STATUS_COMPLETED_ATTENDANCE' && $lessonAttendance->updated_at->isCurrentMonth();
+                return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $lessonAttendance->updated_at->isCurrentMonth();
             });
             return $compleatedLessonAttendances;
         })->count();

--- a/app/Http/Requests/Instructor/AttendanceShowRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceShowRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required','integer', 'exists:courses,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/AttendanceShowThisMonthRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceShowThisMonthRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceShowThisMonthRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required','integer', 'exists:courses,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/AttendanceShowTodayRequest.php
+++ b/app/Http/Requests/Instructor/AttendanceShowTodayRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttendanceShowRequest extends FormRequest
+class AttendanceShowTodayRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
## 概要
- 講師側ダッシュボード今月のレッスン・チャプタ完了数取得APIーフォームリクエスト作成

## 動作確認
- 以下はPostmanでの操作
- Headersにアクセス元のURLを設定
- Referer → http://localhost:3000/
- Origin → http://localhost:3000/
- http://localhost:8080/api/v1/instructor/course/1/attendance/status/this-monthにGET送信
- 今月のレッスン完了数（completed_lessons_count）及びチャプター完了数（completed_chapters_count）が、返ってきているかを確認
- 〜/course/1/attendance/〜の”1”を”8”などに変えてGET送信
- エラーメッセージが返ってくるかを確認