### PR TITLE
マネージャー側 お知らせ 一括（選択）表示ステータス変更API　developへマージ（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -151,6 +151,7 @@ class NotificationController extends Controller
             ], 403);
         }
 
+        DB::beginTransaction();
         try {
             $notifications->each(function ($notification) use ($request) {
                 // 指定されたお知らせIDでお知らせを取得
@@ -159,6 +160,7 @@ class NotificationController extends Controller
                         'type' => $request->type,
                     ])->save();
             });
+            DB::commit();
             return response()->json([
                 'result' => true,
             ]);

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -117,7 +117,7 @@ class NotificationController extends Controller
         ]);
     }
 
-    public function updateStatus()
+    public function updateType()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -13,6 +13,8 @@ use App\Http\Resources\Manager\NotificationShowResource;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
 use Exception;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class NotificationController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -127,9 +127,6 @@ class NotificationController extends Controller
      */
     public function updateType(NotificationPutTypeRequest $request)
     {
-        // 選択されたお知らせを取得
-        $notifications = Notification::whereIn('id', $request->notifications);
-
         // ユーザーID取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -139,6 +136,8 @@ class NotificationController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
+        // 選択されたお知らせを取得
+        $notifications = Notification::whereIn('id', $request->notifications)->get();
         // お知らせの所有者のidを配列で取得
         $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
@@ -162,9 +161,10 @@ class NotificationController extends Controller
                 'result' => true,
             ]);
         } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
             return response()->json([
                 'result' => false,
-                'message' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -65,8 +65,8 @@ class NotificationController extends Controller
         // アクセス権限のチェック
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
-            'result' => false,
-            'message' => 'Forbidden, not allowed to access this notification.',
+                'result' => false,
+                'message' => 'Forbidden, not allowed to access this notification.',
             ], 403);
         }
 
@@ -110,10 +110,15 @@ class NotificationController extends Controller
             'title' => $request->title,
             'content' => $request->content,
         ])
-        ->save();
+            ->save();
 
         return response()->json([
             'result' => true,
         ]);
+    }
+
+    public function updateStatus()
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -142,15 +142,21 @@ class NotificationController extends Controller
         $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
         // アクセス権限のチェック
-        if (empty(array_diff($notificationsInstructorIds, $instructorIds))) {
+        if (!empty(array_diff($notificationsInstructorIds, $instructorIds))) {
             return response()->json([
                 'result' => false,
                 'message' => 'Forbidden, not allowed to update this notification.',
             ], 403);
         }
 
+        if ($request->type === Notification::TYPE_ALWAYS) {
+            $type = Notification::TYPE_ALWAYS_INT;
+        } elseif ($request->type === Notification::TYPE_ONCE) {
+            $type = Notification::TYPE_ONCE_INT;
+        }
+
         try {
-            $notifications->update(['type' => $request->type]);
+            $notifications->update(['type' => $type]);
         } catch (\Exception $e) {
             return response()->json([
                 'result' => false,

--- a/app/Http/Requests/Manager/NotificationPutTypeRequest.php
+++ b/app/Http/Requests/Manager/NotificationPutTypeRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Manager;
 
-use App\Model\Notification;
 use App\Rules\NotificationUpdateStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -20,9 +19,6 @@ class NotificationPutTypeRequest extends FormRequest
 
     protected function prepareForValidation()
     {
-        if (Notification::whereIn('id', $this->notifications)->exists()) {
-            # code...
-        }
         $this->merge([
             'type' => $this->route('notification_type'),
         ]);
@@ -37,7 +33,6 @@ class NotificationPutTypeRequest extends FormRequest
     {
         return [
             'type' => ['required',  new NotificationUpdateStatusRule()],
-            'notifications' => ['required', 'array'],
             'notifications.*' => ['integer', 'exists:notifications,id,deleted_at,NULL'],
         ];
     }

--- a/app/Http/Requests/Manager/NotificationPutTypeRequest.php
+++ b/app/Http/Requests/Manager/NotificationPutTypeRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Manager;
 
+use App\Model\Notification;
 use App\Rules\NotificationUpdateStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -19,6 +20,9 @@ class NotificationPutTypeRequest extends FormRequest
 
     protected function prepareForValidation()
     {
+        if (Notification::whereIn('id', $this->notifications)->exists()) {
+            # code...
+        }
         $this->merge([
             'type' => $this->route('notification_type'),
         ]);
@@ -34,7 +38,7 @@ class NotificationPutTypeRequest extends FormRequest
         return [
             'type' => ['required',  new NotificationUpdateStatusRule()],
             'notifications' => ['required', 'array'],
-            'notifications.*' => ['int'],
+            'notifications.*' => ['integer', 'exists:notifications,id,deleted_at,NULL'],
         ];
     }
 }

--- a/app/Http/Requests/Manager/NotificationPutTypeRequest.php
+++ b/app/Http/Requests/Manager/NotificationPutTypeRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use App\Rules\NotificationUpdateStatusRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationPutTypeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'type' => $this->route('type'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'type' => ['required', 'string', new NotificationUpdateStatusRule()],
+            'notifications' => ['required|array'],
+            'notifications.*' => ['int'],
+        ];
+    }
+}

--- a/app/Http/Requests/Manager/NotificationPutTypeRequest.php
+++ b/app/Http/Requests/Manager/NotificationPutTypeRequest.php
@@ -20,7 +20,7 @@ class NotificationPutTypeRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
-            'type' => $this->route('notification_type'),
+            'type' => $this->route('type'),
         ]);
     }
 

--- a/app/Http/Requests/Manager/NotificationPutTypeRequest.php
+++ b/app/Http/Requests/Manager/NotificationPutTypeRequest.php
@@ -20,7 +20,7 @@ class NotificationPutTypeRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
-            'type' => $this->route('type'),
+            'type' => $this->route('notification_type'),
         ]);
     }
 
@@ -32,8 +32,8 @@ class NotificationPutTypeRequest extends FormRequest
     public function rules()
     {
         return [
-            'type' => ['required', 'string', new NotificationUpdateStatusRule()],
-            'notifications' => ['required|array'],
+            'type' => ['required',  new NotificationUpdateStatusRule()],
+            'notifications' => ['required', 'array'],
             'notifications.*' => ['int'],
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,6 +203,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
+                    Route::put('status/{status}', 'Api\Manager\NotificationController@updateStatus');
                 });
             });
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,7 +203,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
-                    Route::put('status/{status}', 'Api\Manager\NotificationController@updateStatus');
+                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
                 });
             });
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,7 +203,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
-                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
+                    Route::put('type/{notification_type}', 'Api\Manager\NotificationController@updateType');
                 });
             });
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -203,7 +203,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
-                    Route::put('type/{notification_type}', 'Api\Manager\NotificationController@updateType');
+                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
                 });
             });
         });


### PR DESCRIPTION
## task
-Closes JKA-841

## 概要
- マネージャー側 お知らせ 一括（選択）表示ステータス変更API

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/notification/type/always のリクエストボディに
```
{
 "notifications" : [1,2]
}
```
PUTで送信し、turue が返ってくること、データベース上で情報が更新されていることを確認

## 考慮して欲しいこと
- 特にありません
## 確認してほしいこと
- 特にありません