### PR TITLE
JKA-864 空の配列を返す（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -10,6 +10,7 @@ use App\Model\Notification;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Resources\Manager\NotificationShowResource;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
 class NotificationController extends Controller
@@ -65,12 +66,22 @@ class NotificationController extends Controller
         // アクセス権限のチェック
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
-            'result' => false,
-            'message' => 'Forbidden, not allowed to access this notification.',
+                'result' => false,
+                'message' => 'Forbidden, not allowed to access this notification.',
             ], 403);
         }
 
         return new NotificationShowResource($notification);
+    }
+
+    /**
+     * お知らせ詳細-削除
+     *
+     * @return NotificationShowResource|\Illuminate\Http\JsonResponse
+     */
+    public function delete(): JsonResponse
+    {
+        return response()->json([]);
     }
 
     /**
@@ -110,7 +121,7 @@ class NotificationController extends Controller
             'title' => $request->title,
             'content' => $request->content,
         ])
-        ->save();
+            ->save();
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -77,7 +77,6 @@ class NotificationController extends Controller
     /**
      * お知らせ詳細-削除
      *
-     * @return NotificationShowResource|\Illuminate\Http\JsonResponse
      */
     public function delete(): JsonResponse
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -207,6 +207,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
+                        Route::delete('/', 'Api\Manager\NotificationController@delete');
                     });
                 });
             });


### PR DESCRIPTION
## task
-Closes JKA-864

## 概要
- 空の配列を返す

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/notification/1 をDELETEで送信し、[] が返ってくることを確認

## 考慮して欲しいこと
- 特にありません
## 確認してほしいこと
- 特にありません