### PR TITLE
JKA-869　②空の配列を返すルーターとコントローラの作成（オオハシ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -99,4 +99,10 @@ class NotificationController extends Controller
             'result' => true,
         ]);
     }
+
+    public function delete()
+    {
+        return response()->json([]);
+    }
+
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -104,5 +104,4 @@ class NotificationController extends Controller
     {
         return response()->json([]);
     }
-
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,6 +135,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', 'Api\Instructor\NotificationController@index');
+                Route::delete('{notification_id}', 'Api\Instructor\NotificationController@delete');
             });
         });
 


### PR DESCRIPTION
## Task  
- 講師側 お知らせ削除API作成
## 概要
- 空の配列を返すルータとコントローラの作成

## 動作確認手順
- postmanでhttp://localhost:8080/login/instructorでログイン
- http://localhost:8080/api/v1/instructor/notification/1 をDELETEで送信し、[] が返ってくることを確認

## 考慮して欲しいこと
- 特にありません
## 確認してほしいこと
- 特にありません