### PR TITLE
JKA-864 マネージャー（講師）側 お知らせ削除API作成（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -81,16 +81,16 @@ class NotificationController extends Controller
      */
     public function delete($notification_id)
     {
-        // ログインユーザーのID取得
+        // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
-        // 配下のインストラクター情報を取得
+        // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        // 指定されたお知らせIDでお知らせを取得
+        // 指定されたお知らせを取得
         /** @var Notification $notification */
         $notification = Notification::findOrFail($notification_id);
 
@@ -101,8 +101,6 @@ class NotificationController extends Controller
                 'message' => 'Forbidden, not allowed to update this notification.',
             ], 403);
         }
-
-        $notification->delete();
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -105,10 +105,21 @@ class NotificationController extends Controller
                 'message' => 'Forbidden, not allowed to update this notification.',
             ], 403);
         }
-
-        return response()->json([
-            'result' => true,
-        ]);
+        DB::beginTransaction();
+        try {
+            $notification->students()->detach();
+            $notification->delete();
+            DB::commit();
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -76,7 +76,7 @@ class NotificationController extends Controller
 
     /**
      * お知らせ詳細-削除
-     * 
+     *
      * @return \Illuminate\Http\JsonResponse
      */
     public function delete($notification_id)


### PR DESCRIPTION
## task
-Closes JKA-864

## 概要
- マネージャー（講師）側 お知らせ削除API作成

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/notification/1 をDELETEで送信し、{"result":true} が返ってくること、データベースで論理削除されていることを確認

## 考慮して欲しいこと
- 特にありません
## 確認してほしいこと
- urlパラメーターのみをリクエストとして受け取る時もRequest.phpは作成した方がいいのでしょうか？