### PR TITLE
マネージャー側 お知らせ 一括（選択）削除API作成 空の配列を返すルーターとコントローラの作成 (近藤)

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -173,7 +173,7 @@ class NotificationController extends Controller
         }
     }
 
-    public function blnkDelete(): JsonResponse
+    public function bulkDelete(): JsonResponse
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -171,4 +171,9 @@ class NotificationController extends Controller
             ], 500);
         }
     }
+
+    public function blnkDelete()
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -8,6 +8,7 @@ use App\Model\Notification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
@@ -172,7 +173,7 @@ class NotificationController extends Controller
         }
     }
 
-    public function blnkDelete()
+    public function blnkDelete(): JsonResponse
     {
         return response()->json([]);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -209,6 +209,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
                     Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
+                    Route::delete('{notification_id}', 'Api\Manager\NotificationController@blnkDelete');
                 });
             });
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -209,7 +209,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
                     Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
-                    Route::delete('/', 'Api\Manager\NotificationController@blnkDelete');
+                    Route::delete('/', 'Api\Manager\NotificationController@bulkDelete');
                 });
             });
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -209,7 +209,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                     });
                     Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
-                    Route::delete('{notification_id}', 'Api\Manager\NotificationController@blnkDelete');
+                    Route::delete('/', 'Api\Manager\NotificationController@blnkDelete');
                 });
             });
         });


### PR DESCRIPTION
## task
- JKA-839
## 概要
- マネージャー側 お知らせ 一括（選択）削除API作成 空の配列を返すルーターとコントローラの作成
## 動作確認
- `http://localhost:8080/login/instructor` 講師でログイン
- `http://localhost:8080/api/v1/instructor/notification/index` お知らせがあることを確認
- `http://localhost:8080/api/v1/manager/notification` 実行後、空の配列が返ってくることを確認
## 確認、考慮して欲しいこと
- 特にありません