### PR TITLE
JKA-864 マネージャー（講師）側 お知らせ削除　リクエストクラス作成（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -82,6 +82,7 @@ class NotificationController extends Controller
     /**
      * お知らせ詳細-削除
      *
+     * @param NotificationDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function delete(NotificationDeleteRequest $request)

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -8,6 +8,7 @@ use App\Model\Notification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\NotificationDeleteRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
@@ -83,7 +84,7 @@ class NotificationController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function delete($notification_id)
+    public function delete(NotificationDeleteRequest $request)
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -96,7 +97,7 @@ class NotificationController extends Controller
 
         // 指定されたお知らせを取得
         /** @var Notification $notification */
-        $notification = Notification::findOrFail($notification_id);
+        $notification = Notification::findOrFail($request->notification_id);
 
         // アクセス権限のチェック
         if (!in_array($notification->instructor_id, $instructorIds, true)) {

--- a/app/Http/Requests/Manager/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Manager/NotificationDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_id' => $this->route('notification_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'notification_id' => ['required', 'integer', 'exists:notifications,id,deleted_at,NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
## task
-Closes JKA-864

## 概要
- マネージャー（講師）側 お知らせ削除API作成

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/notification/1 をDELETEで送信し、{"result":true} が返ってくること、データベースで論理削除されていることを確認
