### PR TITLE
マネージャー側 お知らせ 一括（選択）削除API作成 ロジックの作成 (近藤)

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -194,7 +194,7 @@ class NotificationController extends Controller
 
         // 選択されたお知らせリストを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();
-        // dd($notifications);
+        $notificationIds = $notifications->pluck('id')->toArray();
         $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
         // アクセス権限のチェック
@@ -208,10 +208,10 @@ class NotificationController extends Controller
         DB::beginTransaction();
         try {
             // viewed_once_notificationsテーブルのレコードを一括削除
-            ViewedOnceNotification::whereIn('notification_id', $notifications)->delete();
+            ViewedOnceNotification::whereIn('notification_id', $notificationIds)->delete();
 
             // notificationsテーブルのレコードを一括削除
-            Notification::whereIn('id', $notifications)->delete();
+            Notification::whereIn('id', $notificationIds)->delete();
 
             // コミット
             DB::commit();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -194,6 +194,7 @@ class NotificationController extends Controller
 
         // 選択されたお知らせリストを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();
+        $notificationIds = $notifications->pluck('id')->toArray();
         $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
         // アクセス権限のチェック
@@ -207,10 +208,10 @@ class NotificationController extends Controller
         DB::beginTransaction();
         try {
             // viewed_once_notificationsテーブルのレコードを一括削除
-            ViewedOnceNotification::whereIn('notification_id', $notifications)->delete();
+            ViewedOnceNotification::whereIn('notification_id', $notificationIds)->delete();
 
             // notificationsテーブルのレコードを一括削除
-            Notification::whereIn('id', $notifications)->delete();
+            Notification::whereIn('id', $notificationIds)->delete();
 
             // コミット
             DB::commit();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -5,11 +5,13 @@ namespace App\Http\Controllers\Api\Manager;
 use Exception;
 use App\Model\Instructor;
 use App\Model\Notification;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use App\Model\ViewedOnceNotification;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
@@ -173,8 +175,56 @@ class NotificationController extends Controller
         }
     }
 
-    public function bulkDelete(): JsonResponse
+    /**
+     * お知らせ一覧-一括削除API
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function bulkDelete(Request $request): JsonResponse
     {
-        return response()->json([]);
+        // 認証している講師のIDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        // 配下の講師情報を取得
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        // 選択されたお知らせリストを取得
+        $notifications = Notification::whereIn('id', $request->notifications)->get();
+        // dd($notifications);
+        $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
+
+        // アクセス権限のチェック
+        if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Forbidden, not allowed to update this notification.',
+            ], 403);
+        }
+
+        DB::beginTransaction();
+        try {
+            // viewed_once_notificationsテーブルのレコードを一括削除
+            ViewedOnceNotification::whereIn('notification_id', $notifications)->delete();
+
+            // notificationsテーブルのレコードを一括削除
+            Notification::whereIn('id', $notifications)->delete();
+
+            // コミット
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -194,7 +194,6 @@ class NotificationController extends Controller
 
         // 選択されたお知らせリストを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();
-        $notificationIds = $notifications->pluck('id')->toArray();
         $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
         // アクセス権限のチェック
@@ -208,10 +207,10 @@ class NotificationController extends Controller
         DB::beginTransaction();
         try {
             // viewed_once_notificationsテーブルのレコードを一括削除
-            ViewedOnceNotification::whereIn('notification_id', $notificationIds)->delete();
+            ViewedOnceNotification::whereIn('notification_id', $notifications)->delete();
 
             // notificationsテーブルのレコードを一括削除
-            Notification::whereIn('id', $notificationIds)->delete();
+            Notification::whereIn('id', $notifications)->delete();
 
             // コミット
             DB::commit();

--- a/app/Model/ViewedOnceNotification.php
+++ b/app/Model/ViewedOnceNotification.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Model;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ViewedOnceNotification extends Model
+{
+    protected $table = 'viewed_once_notifications';
+
+    protected $fillable = [
+        'notification_id',
+        'student_id',
+    ];
+
+    public function notification()
+    {
+        return $this->belongsTo(Notification::class, 'notification_id');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
         $this->call(LessonSeeder::class);
         $this->call(LessonAttendanceSeeder::class);
         $this->call(NotificationSeeder::class);
+        $this->call(ViewedOnceNotificationSeeder::class);
         $this->call(ManageInstructorsSeeder::class);
     }
 }

--- a/database/seeds/ViewedOnceNotificationSeeder.php
+++ b/database/seeds/ViewedOnceNotificationSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Model\ViewedOnceNotification;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Seeder;
+
+class ViewedOnceNotificationSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        ViewedOnceNotification::insert([
+            [
+                'notification_id' => 2,
+                'student_id' => 2,
+                'created_at' => CarbonImmutable::now(),
+                'updated_at' => CarbonImmutable::now(),
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## task
- [https://gut-familie.atlassian.net/browse/JKA-839]()
## 概要
- マネージャー側 お知らせ 一括（選択）削除API作成 ロジックの作成
## 動作確認
- `http://localhost:8080/login/instructor` インストラクターでログイン
- `http://localhost:8080/api/v1/instructor/notification/index` お知らせ一覧でお知らせ情報があることを確認
- `http://localhost:8080/api/v1/manager/notification` DELETEメソッドで実行すると以下が返ってきた
```
{
    "result": true
}
```
- `http://localhost:8080/api/v1/instructor/notification/index` お知らせ一覧を確認するとお知らせがなくなっていることを確認

## 考慮して欲しいこと
- リクエストファイルを作成していないのでバリデーションエラーは出ないようになっております。
- コンフリクトが発生しないようにする為、小林さんのコードを元に作成しまして新しくモデルとシーダーを作っております。
## 確認して欲しいこと
- 特にありません。