### PR TITLE
マネージャー（講師）側 お知らせ削除API作成 デベロップへマージ（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -9,15 +9,14 @@ use App\Model\Notification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Manager\NotificationDeleteRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
 use App\Http\Requests\Manager\NotificationStoreRequest;
+use App\Http\Requests\Manager\NotificationDeleteRequest;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
 use App\Http\Resources\Manager\NotificationShowResource;
 use App\Http\Requests\Manager\NotificationPutTypeRequest;
-use Illuminate\Http\JsonResponse;
 use App\Http\Resources\Manager\NotificationIndexResource;
 
 class NotificationController extends Controller
@@ -129,10 +128,10 @@ class NotificationController extends Controller
      */
     public function update(NotificationUpdateRequest $request)
     {
-        // ユーザーID取得
+        // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
-        // 配下のインストラクター情報を取得
+        // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -81,16 +81,16 @@ class NotificationController extends Controller
      */
     public function delete($notification_id)
     {
-        // ログインユーザーのID取得
+        // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
-        // 配下のインストラクター情報を取得
+        // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        // 指定されたお知らせIDでお知らせを取得
+        // 指定されたお知らせを取得
         /** @var Notification $notification */
         $notification = Notification::findOrFail($notification_id);
 
@@ -101,8 +101,6 @@ class NotificationController extends Controller
                 'message' => 'Forbidden, not allowed to update this notification.',
             ], 403);
         }
-
-        $notification->delete();
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -10,6 +10,7 @@ use App\Model\Notification;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Resources\Manager\NotificationShowResource;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
 class NotificationController extends Controller
@@ -65,12 +66,22 @@ class NotificationController extends Controller
         // アクセス権限のチェック
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
-            'result' => false,
-            'message' => 'Forbidden, not allowed to access this notification.',
+                'result' => false,
+                'message' => 'Forbidden, not allowed to access this notification.',
             ], 403);
         }
 
         return new NotificationShowResource($notification);
+    }
+
+    /**
+     * お知らせ詳細-削除
+     *
+     * @return NotificationShowResource|\Illuminate\Http\JsonResponse
+     */
+    public function delete(): JsonResponse
+    {
+        return response()->json([]);
     }
 
     /**
@@ -110,7 +121,7 @@ class NotificationController extends Controller
             'title' => $request->title,
             'content' => $request->content,
         ])
-        ->save();
+            ->save();
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -82,6 +82,7 @@ class NotificationController extends Controller
     /**
      * お知らせ詳細-削除
      *
+     * @param NotificationDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function delete(NotificationDeleteRequest $request)

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -8,6 +8,7 @@ use App\Model\Notification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\NotificationDeleteRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
@@ -83,7 +84,7 @@ class NotificationController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function delete($notification_id)
+    public function delete(NotificationDeleteRequest $request)
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -96,7 +97,7 @@ class NotificationController extends Controller
 
         // 指定されたお知らせを取得
         /** @var Notification $notification */
-        $notification = Notification::findOrFail($notification_id);
+        $notification = Notification::findOrFail($request->notification_id);
 
         // アクセス権限のチェック
         if (!in_array($notification->instructor_id, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -105,10 +105,21 @@ class NotificationController extends Controller
                 'message' => 'Forbidden, not allowed to update this notification.',
             ], 403);
         }
-
-        return response()->json([
-            'result' => true,
-        ]);
+        DB::beginTransaction();
+        try {
+            $notification->students()->detach();
+            $notification->delete();
+            DB::commit();
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -77,7 +77,6 @@ class NotificationController extends Controller
     /**
      * お知らせ詳細-削除
      *
-     * @return NotificationShowResource|\Illuminate\Http\JsonResponse
      */
     public function delete(): JsonResponse
     {

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -76,7 +76,7 @@ class NotificationController extends Controller
 
     /**
      * お知らせ詳細-削除
-     * 
+     *
      * @return \Illuminate\Http\JsonResponse
      */
     public function delete($notification_id)

--- a/app/Http/Requests/Manager/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Manager/NotificationDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_id' => $this->route('notification_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'notification_id' => ['required', 'integer', 'exists:notifications,id,deleted_at,NULL'],
+        ];
+    }
+}

--- a/app/Http/Resources/Manager/StudentShowResource.php
+++ b/app/Http/Resources/Manager/StudentShowResource.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class StudentShowResource extends JsonResource
 {
-    /** @var \App\Model\Student */
+    /** @var Student */
     public $resource;
 
     /**
@@ -20,21 +20,21 @@ class StudentShowResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'student_id' => $this->id,
-            'given_name_by_instructor' => $this->given_name_by_instructor,
-            'nick_name' => $this->nick_name,
-            'last_name' => $this->last_name,
-            'first_name' => $this->first_name,
-            'occupation' => $this->occupation,
-            'email' => $this->email,
-            'purpose' => $this->purpose,
-            'age' => $this->calcAge(new CarbonImmutable()),
-            'birth_date' => $this->birth_date->format('Y/m/d'),
-            'sex' => $this->sex,
-            'address' => $this->address,
-            'created_at' => $this->created_at->format('Y/m/d'),
-            'last_login_at' => $this->last_login_at->format('Y/m/d'),
-            'profile_image' => $this->profile_image,
+            'student_id' => $this->resource->id,
+            'given_name_by_instructor' => $this->resource->given_name_by_instructor,
+            'nick_name' => $this->resource->nick_name,
+            'last_name' => $this->resource->last_name,
+            'first_name' => $this->resource->first_name,
+            'occupation' => $this->resource->occupation,
+            'email' => $this->resource->email,
+            'purpose' => $this->resource->purpose,
+            'birth_date' => $this->resource->birth_date->format('Y/m/d'),
+            'age' => $this->resource->calcAge(new CarbonImmutable()),
+            'gender' => $this->resource->gender,
+            'address' => $this->resource->address,
+            'created_at' => $this->resource->created_at->format('Y/m/d'),
+            'last_login_at' => $this->resource->last_login_at->format('Y/m/d'),
+            'profile_image' => $this->resource->profile_image,
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,9 +50,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
         // 受講生-お知らせ
         Route::prefix('notification')->group(function () {
-            Route::get('{notification_id}', 'Api\Student\NotificationController@show');
             Route::get('index', 'Api\Student\NotificationController@index');
             Route::get('read', 'Api\Student\NotificationController@read');
+            Route::get('{notification_id}', 'Api\Student\NotificationController@show');
         });
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -207,6 +207,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
+                        Route::delete('/', 'Api\Manager\NotificationController@delete');
                     });
                 });
             });


### PR DESCRIPTION
## task
-Closes JKA-864

## 概要
- マネージャー（講師）側 お知らせ削除API作成

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/manager/notification/1 をDELETEで送信し、{"result":true} が返ってくること、データベースで論理削除されていることを確認
