### PR TITLE
JKA-883 講師側ダッシュボード レッスン完了数・チャプター完了数の本日・今月を同一APIに統一 空の配列を返す（あべ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -214,7 +214,7 @@ class AttendanceController extends Controller
      *
      * @return JsonResponse
      */
-    public function showAttendanceStatus(): JsonResponse
+    public function showStatus(): JsonResponse
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -210,6 +210,16 @@ class AttendanceController extends Controller
     }
 
     /**
+     * 講座受講状況
+     *
+     * @return JsonResponse
+     */
+    public function showAttendanceStatus(): JsonResponse
+    {
+        return response()->json([]);
+    }
+
+    /**
      * 講座受講状況-当日
      *
      * @param AttendanceShowTodayRequest $request
@@ -231,25 +241,25 @@ class AttendanceController extends Controller
         $completedChaptersCount = $attendances->flatMap(function (Attendance $attendance) {
             return $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
         })
-        ->filter(function (LessonAttendance $lessonAttendance) {
-            // チャプターに含まれているレッスンが全て完了されているかつ、最新のレッスンの完了済みステータスへの更新日時が当日の日時という条件で絞り込む
-            $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
-            $totalLessonsCount = $allLessonsId->count();
-            $compleatedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
-                ->whereIn('lesson_id', $allLessonsId)
-                ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
-                ->count();
-            return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $compleatedLessonsCount;
-        })
-        ->map(function (LessonAttendance $lessonAttendance) {
-            // chapter_idとattendance_idをキーにもつ新しい配列を作成
-            return [
-                'chapter_id' => $lessonAttendance->lesson->chapter_id,
-                'attendance_id' => $lessonAttendance->attendance_id
-            ];
-        })
-        ->unique()
-        ->count();
+            ->filter(function (LessonAttendance $lessonAttendance) {
+                // チャプターに含まれているレッスンが全て完了されているかつ、最新のレッスンの完了済みステータスへの更新日時が当日の日時という条件で絞り込む
+                $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
+                $totalLessonsCount = $allLessonsId->count();
+                $compleatedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
+                    ->whereIn('lesson_id', $allLessonsId)
+                    ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
+                    ->count();
+                return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $compleatedLessonsCount;
+            })
+            ->map(function (LessonAttendance $lessonAttendance) {
+                // chapter_idとattendance_idをキーにもつ新しい配列を作成
+                return [
+                    'chapter_id' => $lessonAttendance->lesson->chapter_id,
+                    'attendance_id' => $lessonAttendance->attendance_id
+                ];
+            })
+            ->unique()
+            ->count();
 
         return response()->json([
             'completed_lessons_count' => $completedLessonsCount,
@@ -279,25 +289,25 @@ class AttendanceController extends Controller
         $completedChaptersCount = $attendances->flatMap(function (Attendance $attendance) {
             return $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
         })
-        ->filter(function (LessonAttendance $lessonAttendance) {
-            // チャプターに含まれているレッスンが全て完了されているかつ、最新のレッスンの完了済みステータスへの更新日時が今月の日時という条件で絞り込む
-            $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
-            $totalLessonsCount = $allLessonsId->count();
-            $compleatedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
-                ->whereIn('lesson_id', $allLessonsId)
-                ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
-                ->count();
-            return $lessonAttendance->updated_at->isCurrentMonth() && $totalLessonsCount === $compleatedLessonsCount;
-        })
-        ->map(function (LessonAttendance $lessonAttendance) {
-            // chapter_idとattendance_idをキーにもつ新しい配列を作成
-            return [
-                'chapter_id' => $lessonAttendance->lesson->chapter_id,
-                'attendance_id' => $lessonAttendance->attendance_id
-            ];
-        })
-        ->unique()
-        ->count();
+            ->filter(function (LessonAttendance $lessonAttendance) {
+                // チャプターに含まれているレッスンが全て完了されているかつ、最新のレッスンの完了済みステータスへの更新日時が今月の日時という条件で絞り込む
+                $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
+                $totalLessonsCount = $allLessonsId->count();
+                $compleatedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
+                    ->whereIn('lesson_id', $allLessonsId)
+                    ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
+                    ->count();
+                return $lessonAttendance->updated_at->isCurrentMonth() && $totalLessonsCount === $compleatedLessonsCount;
+            })
+            ->map(function (LessonAttendance $lessonAttendance) {
+                // chapter_idとattendance_idをキーにもつ新しい配列を作成
+                return [
+                    'chapter_id' => $lessonAttendance->lesson->chapter_id,
+                    'attendance_id' => $lessonAttendance->attendance_id
+                ];
+            })
+            ->unique()
+            ->count();
 
         return response()->json([
             'completed_lessons_count' => $completedLessonsCount,

--- a/routes/api.php
+++ b/routes/api.php
@@ -111,8 +111,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('attendance')->group(function () {
                         Route::get('status', 'Api\Instructor\AttendanceController@show');
                         Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
-                        Route::get('status/today', 'Api\Instructor\AttendanceController@showStatusToday');
-                        Route::get('status/this-month', 'Api\Instructor\AttendanceController@showStatusThisMonth');
+                        Route::get('status/{period}', 'Api\Instructor\AttendanceController@showStatus');
                     });
                 });
             });


### PR DESCRIPTION
## task
-Closes JKA-883
https://gut-familie.atlassian.net/browse/JKA-883?atlOrigin=eyJpIjoiOTY4ZWZmMzI5ZDhmNGQ5Mjk3NWI1MjBjOGM1MTI5MDUiLCJwIjoiaiJ9

## 概要
- 空の配列を返す

## 動作確認手順
- postmanでマネージャー権限のあるinstructorでログイン
- http://localhost:8080/api/v1/instructor/course/1/attendance/status/1 をGETで送信し、[] が返ってくることを確認

## 考慮して欲しいこと
- 特にありません
## 確認してほしいこと
- 特にありません