### PR TITLE
講師チャプターレッスン公開非公開API 空の配列を返すルーターとコントローラの作成（小林）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -7,7 +7,6 @@ use App\Model\Course;
 use App\Model\Chapter;
 use App\Model\Instructor;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
@@ -295,13 +294,5 @@ class ChapterController extends Controller
         return response()->json([
             'result' => true,
         ]);
-    }
-
-    /**
-     * 選択済みのレッスン公開/非公開API
-     */
-    public function updateLessonStatus()
-    {
-        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -7,6 +7,7 @@ use App\Model\Course;
 use App\Model\Chapter;
 use App\Model\Instructor;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
@@ -294,5 +295,13 @@ class ChapterController extends Controller
         return response()->json([
             'result' => true,
         ]);
+    }
+
+    /**
+     * 選択済みのレッスン公開/非公開API
+     */
+    public function updateLessonStatus()
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -5,12 +5,9 @@ namespace App\Http\Controllers\Api\Instructor;
 use Exception;
 use App\Model\Lesson;
 use App\Model\Attendance;
-use App\Model\Chapter;
-use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -303,14 +300,5 @@ class LessonController extends Controller
                 'result' => false,
             ]);
         }
-    }
-
-    /**
-     * レッスンの公開/非公開ステータスを更新
-     *
-     */
-    public function updateLessonStatus()
-    {
-        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -301,4 +301,13 @@ class LessonController extends Controller
             ]);
         }
     }
+
+    /**
+     * 選択済みのレッスン公開/非公開API
+     */
+    public function updateVisibilityStatus()
+    {
+        return response()->json([]);
+    }
+
 }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -309,5 +309,4 @@ class LessonController extends Controller
     {
         return response()->json([]);
     }
-
 }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -5,9 +5,12 @@ namespace App\Http\Controllers\Api\Instructor;
 use Exception;
 use App\Model\Lesson;
 use App\Model\Attendance;
+use App\Model\Chapter;
+use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -300,5 +303,14 @@ class LessonController extends Controller
                 'result' => false,
             ]);
         }
+    }
+
+    /**
+     * レッスンの公開/非公開ステータスを更新
+     *
+     */
+    public function updateLessonStatus()
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -305,7 +305,7 @@ class LessonController extends Controller
     /**
      * 選択済みのレッスン公開/非公開API
      */
-    public function updateVisibilityStatus()
+    public function putStatus()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -303,7 +303,7 @@ class LessonController extends Controller
     }
 
     /**
-     * 選択済みのレッスン公開/非公開API
+     * 選択済みのレッスンステータス一括更新API
      */
     public function putStatus()
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -78,6 +78,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::post('/', 'Api\Instructor\ChapterController@store');
                         Route::post('sort', 'Api\Instructor\ChapterController@sort');
                         Route::put('status', 'Api\Instructor\ChapterController@putStatus');
+                        Route::patch('{chapter_id}/lessons/status', 'Api\Instructor\ChapterController@updateLessonStatus');
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', 'Api\Instructor\ChapterController@show');
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
@@ -137,11 +138,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', 'Api\Instructor\NotificationController@index');
                 Route::delete('/', 'Api\Instructor\NotificationController@bulkDelete');
-            });
-
-            // レッスンの公開/非公開ステータスを更新
-            Route::prefix('course/{course_id}/chapter/{chapter_id}')->group(function () {
-                Route::patch('lessons/status', 'Api\Instructor\LessonController@updateLessonStatus');
             });
         });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,6 +138,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', 'Api\Instructor\NotificationController@index');
                 Route::delete('/', 'Api\Instructor\NotificationController@bulkDelete');
             });
+
+            // レッスンの公開/非公開ステータスを更新
+            Route::prefix('course/{course_id}/chapter/{chapter_id}')->group(function () {
+                Route::patch('lessons/status', 'Api\Instructor\LessonController@updateLessonStatus');
+            });
         });
 
         // マネージャーAPI

--- a/routes/api.php
+++ b/routes/api.php
@@ -87,7 +87,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
-                                Route::patch('status', 'Api\Instructor\LessonController@updateVisibilityStatus');
+                                Route::put('status', 'Api\Instructor\LessonController@updateVisibilityStatus');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -87,7 +87,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
-                                Route::put('status', 'Api\Instructor\LessonController@updateVisibilityStatus');
+                                Route::put('status', 'Api\Instructor\LessonController@putStatus');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -78,7 +78,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::post('/', 'Api\Instructor\ChapterController@store');
                         Route::post('sort', 'Api\Instructor\ChapterController@sort');
                         Route::put('status', 'Api\Instructor\ChapterController@putStatus');
-                        Route::patch('{chapter_id}/lessons/status', 'Api\Instructor\ChapterController@updateLessonStatus');
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', 'Api\Instructor\ChapterController@show');
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
@@ -88,6 +87,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
+                                Route::patch('status', 'Api\Instructor\LessonController@updateVisibilityStatus');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-891
## 概要
- 講師側 チャプター作成画面 選択済レッスンを公開/非公開にするAPI作成　子課題
  空の配列を返すルータとコントローラの作成
## 動作確認手順
- PUTリクエストで　http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/status
  を実行すると空の配列が返ってきた
## 考慮してほしいこと
- 今回は特にありません。
## 確認してほしいこと
- 今回は特にありません。