### PR TITLE
マネージャー側 お知らせ 一括（選択）削除API作成 フォームリクエストの作成 (近藤)

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -5,19 +5,19 @@ namespace App\Http\Controllers\Api\Manager;
 use Exception;
 use App\Model\Instructor;
 use App\Model\Notification;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use App\Model\ViewedOnceNotification;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
-use App\Http\Requests\Manager\NotificationBulkDeleteRequest;
 use App\Http\Resources\Manager\NotificationShowResource;
 use App\Http\Requests\Manager\NotificationPutTypeRequest;
 use App\Http\Resources\Manager\NotificationIndexResource;
+use App\Http\Requests\Manager\NotificationBulkDeleteRequest;
 
 class NotificationController extends Controller
 {
@@ -73,7 +73,7 @@ class NotificationController extends Controller
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
                 'result' => false,
-                'message' => 'Forbidden, not allowed to access this notification.',
+                'message' => 'Forbidden.',
             ], 403);
         }
 
@@ -106,7 +106,7 @@ class NotificationController extends Controller
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
             return response()->json([
                 'result' => false,
-                'message' => 'Forbidden, not allowed to update this notification.',
+                'message' => 'Forbidden.',
             ], 403);
         }
 
@@ -149,7 +149,7 @@ class NotificationController extends Controller
         if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
             return response()->json([
                 'result' => false,
-                'message' => 'Forbidden, not allowed to update this notification.',
+                'message' => 'Forbidden.',
             ], 403);
         }
 
@@ -201,16 +201,16 @@ class NotificationController extends Controller
         if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
             return response()->json([
                 'result' => false,
-                'message' => 'Forbidden, not allowed to update this notification.',
+                'message' => 'Forbidden.',
             ], 403);
         }
 
         DB::beginTransaction();
         try {
-            // viewed_once_notificationsテーブルのレコードを一括削除
+            // お知らせの閲覧状態を削除
             ViewedOnceNotification::whereIn('notification_id', $notificationIds)->delete();
 
-            // notificationsテーブルのレコードを一括削除
+            // お知らせを削除
             Notification::whereIn('id', $notificationIds)->delete();
 
             // コミット

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -189,20 +189,19 @@ class NotificationController extends Controller
         // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
 
         // 選択されたお知らせリストを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();
         $notificationIds = $notifications->pluck('id')->toArray();
+        $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
         // アクセス権のチェック
-        if (
-            $notifications->contains(function ($notification) use ($manager) {
-                return $notification->instructor_id !== $manager->id;
-            })
-        ) {
+        if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
             return response()->json([
                 'result' => false,
-                'message' => 'Forbidden, not allowed to update these notifications.',
+                'message' => 'Forbidden, not allowed to update this notification.',
             ], 403);
         }
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -193,12 +193,11 @@ class NotificationController extends Controller
         // 選択されたお知らせリストを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();
         $notificationIds = $notifications->pluck('id')->toArray();
-        $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
         // アクセス権のチェック
         if (
-            collect($notificationsInstructorIds)->contains(function ($notificationInstructorId) use ($manager) {
-                return $notificationInstructorId !== $manager->id;
+            $notifications->contains(function ($notification) use ($manager) {
+                return $notification->instructor_id !== $manager->id;
             })
         ) {
             return response()->json([

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -186,7 +186,7 @@ class NotificationController extends Controller
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
-        
+
         // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::find($instructorId);

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -189,7 +189,6 @@ class NotificationController extends Controller
         // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
 
         // 選択されたお知らせリストを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -15,6 +15,7 @@ use App\Model\ViewedOnceNotification;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
 use App\Http\Requests\Manager\NotificationUpdateRequest;
+use App\Http\Requests\Manager\NotificationBulkDeleteRequest;
 use App\Http\Resources\Manager\NotificationShowResource;
 use App\Http\Requests\Manager\NotificationPutTypeRequest;
 use App\Http\Resources\Manager\NotificationIndexResource;
@@ -178,19 +179,18 @@ class NotificationController extends Controller
     /**
      * お知らせ一覧-一括削除API
      *
-     * @param Request $request
+     * @param NotificationBulkDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete(Request $request): JsonResponse
+    public function bulkDelete(NotificationBulkDeleteRequest $request): JsonResponse
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
-
+        
         // 配下の講師情報を取得
         /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
+        $manager = Instructor::find($instructorId);
+        $instructorIds = [$manager->id];
 
         // 選択されたお知らせリストを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();

--- a/app/Http/Requests/Manager/NotificationBulkDeleteRequest.php
+++ b/app/Http/Requests/Manager/NotificationBulkDeleteRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationBulkDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'notifications' => ['required', 'array', 'min:1'],
+            'notifications.*' => ['required', 'integer', 'exists:notifications,id,deleted_at,NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
## task
- https://gut-familie.atlassian.net/browse/JKA-878
## 概要
- マネージャー側 お知らせ 一括（選択）削除API作成 フォームリクエストの作成
## 動作確認
- `http://localhost:8080/login/instructor` インストラクターでログイン
- `http://localhost:8080/api/v1/instructor/notification/index` お知らせ一覧でお知らせ情報があることを確認
- `http://localhost:8080/api/v1/manager/notification` DELETEメソッドで実行すると以下が返ってきた
```
{
    "result": true
}
```
- `http://localhost:8080/api/v1/instructor/notification/index` お知らせ一覧を確認するとお知らせがなくなっていることを確認
- 以下のように登録していない講師idが選択されるとエラーが返ってきた
```
{
    "notifications" : [1,2]
}
```
## 考慮して欲しいこと
- NotificationControllerの配下の講師情報を取得する部分で、登録していない講師idが選択されてもエラーが返ってこなかったため、コードを変更しております。
## 確認して欲しい事
- 特にありません。