### PR TITLE
#856 マネージャー側受講状況APIロジックの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -104,14 +104,14 @@ class AttendanceController extends Controller
     public function status(int $attendance_id): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $manager= Instructor::with('managings')->find($instructorId);
+        $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
         /** @var Attendance */
 
         $attendance = Attendance::with('course.chapters')->findOrFail($attendance_id);
 
-        if (!in_array($attendance->course->instructor_id , $instructorIds, true)) {
+        if (!in_array($attendance->course->instructor_id, $instructorIds, true)) {
             return response()->json([
                 "result" => false,
                 "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
@@ -138,7 +138,5 @@ class AttendanceController extends Controller
         ];
 
         return response()->json($response, 200);
-    
-
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -95,8 +95,9 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
+
     /**
-    * マネージャー側受講状況API
+     * マネージャー側受講状況API
      *
      * @param int $attendance_id
      * @return JsonResponse
@@ -107,14 +108,14 @@ class AttendanceController extends Controller
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
-        /** @var Attendance */
 
+        /** @var Attendance */
         $attendance = Attendance::with('course.chapters')->findOrFail($attendance_id);
 
         if (!in_array($attendance->course->instructor_id, $instructorIds, true)) {
             return response()->json([
                 "result" => false,
-                "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
+                "message" => "Forbidden.",
             ], 403);
         }
         $response = [

--- a/routes/api.php
+++ b/routes/api.php
@@ -181,8 +181,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('attendance')->group(function () {
                     Route::post('/', 'Api\Manager\AttendanceController@store');
                 // マネージャー-生徒学習状況
-                Route::prefix('{attendance_id}')->group(function () {
-                    Route::get('status', 'Api\Manager\AttendanceController@status');
+                    Route::prefix('{attendance_id}')->group(function () {
+                        Route::get('status', 'Api\Manager\AttendanceController@status');
                     });
                 });
                 // マネージャー-講師

--- a/routes/api.php
+++ b/routes/api.php
@@ -180,7 +180,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-受講
                 Route::prefix('attendance')->group(function () {
                     Route::post('/', 'Api\Manager\AttendanceController@store');
-                // マネージャー-生徒学習状況
+                    // マネージャー-生徒学習状況
                     Route::prefix('{attendance_id}')->group(function () {
                         Route::get('status', 'Api\Manager\AttendanceController@status');
                     });


### PR DESCRIPTION
#856 マネージャー側受講状況APIロジック作成（いのうえ） 
- closes #JKA-856
## 概要
- ロジックの作成
## 動作確認
- postmanでマネージャー権限のあるmanagerログイン
- http://localhost:8080/api/v1/manager/attendance/1
## 考慮して欲しいこと
- 特に無し
## 確認して欲しいこと
- 特に無し