### PR TITLE
#jka-886 マネージャー側ダッシュボード本日のレッスン・チャプター完了数の取得API　空の配列を返す

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -92,8 +92,9 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
-    
-    public function showStatusToday(){
+
+    public function showStatusToday()
+    {
         return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -92,4 +92,7 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
+    public function showStatusToday(){
+        return response()->json();
+    }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -92,6 +92,7 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
+    
     public function showStatusToday(){
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -92,7 +92,8 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
-    public function showStatusToday(){
+    public function showStatusToday()
+    {
         return response()->json();
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -93,6 +93,6 @@ class AttendanceController extends Controller
         }
     }
     public function showStatusToday(){
-        return response()->json();
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -92,7 +92,8 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
-    public function showStatusToday(){
+    public function showStatusToday()
+    {
         return response()->json([]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -190,7 +190,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         });
                         //マネージャー-講座-受講
                         Route::prefix('attendance')->group(function() {
-                            Route::get('status/today', 'Api\Manager\AttendanceController@showStatusToday');
+                            Route::prefix('status')->group(function() {
+                                Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                            });
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -189,8 +189,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             });
                         });
                         //マネージャー-講座-受講
-                        Route::prefix('attendance')->group(function() {
-                            Route::prefix('status')->group(function() {
+                        Route::prefix('attendance')->group(function () {
+                            Route::prefix('status')->group(function () {
                                 Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
                             });
                         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -188,6 +188,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 });
                             });
                         });
+                        //マネージャー-講座-受講
+                        Route::prefix('attendance')->group(function() {
+                            Route::get('status/today', 'Api\Manager\AttendanceController@showStatusToday');
+                        });
                     });
                 });
                 // マネージャー-受講

--- a/routes/api.php
+++ b/routes/api.php
@@ -189,7 +189,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             });
                         });
                         //マネージャー-講座-受講
-                        Route::prefix('attendance')->group(function() {
+                        Route::prefix('attendance')->group(function () {
                             Route::get('status/today', 'Api\Manager\AttendanceController@showStatusToday');
                         });
                     });


### PR DESCRIPTION
## Issue
- Closes #jka-886 
## 概要
- 「マネージャー側ダッシュボード本日のレッスン・チャプター完了数」の取得API
- 空の配列を返すルーターとコントローラの作成
　
## 動作確認手順
- postmanにて
- http://localhost:8080/api/v1/manager/course/1/attendance/status/today
- にアクセスし空の配列が返ってくる
## 考慮してほしいこと
ありません
## 確認してほしいこと
ブランチ操作が間違っているところがあり、再度ブランチを作成しやり直したのでブランチがごちゃごちゃしています。上手い整理方法などがあれば教えていただきたいです。