### PR TITLE
JKA-871 講師側 お知らせ削除API作成~④フォームリクエストの作成 (オオハシ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -16,9 +16,7 @@ use Illuminate\Support\Facades\DB;
 use App\Model\ViewedOnceNotification;
 use Illuminate\Support\Facades\Log;
 use Exception;
-use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\NotificationDeleteRequest;
-
 
 class NotificationController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -17,6 +17,8 @@ use App\Model\ViewedOnceNotification;
 use Illuminate\Support\Facades\Log;
 use Exception;
 use Illuminate\Http\Request;
+use App\Http\Requests\Instructor\NotificationDeleteRequest;
+
 
 class NotificationController extends Controller
 {
@@ -105,10 +107,16 @@ class NotificationController extends Controller
         ]);
     }
 
-    public function delete(Request $request, $notification_id)
+    /**
+     * お知らせ削除
+     *
+     * @param NotificationDeleteRequest $request
+     * @return JsonResponse
+     */
+    public function delete(NotificationDeleteRequest $request): JsonResponse
     {
         $instructor = Auth::guard('instructor')->user();
-        $notification = Notification::findOrFail($notification_id);
+        $notification = Notification::findOrFail($request->notification_id);
 
         if ($notification->instructor_id !== $instructor->id) {
             return response()->json([
@@ -120,7 +128,7 @@ class NotificationController extends Controller
         DB::beginTransaction();
 
         try {
-            ViewedOnceNotification::where('notification_id', $notification_id)->delete();
+            ViewedOnceNotification::where('notification_id', $notification->id)->delete();
             $notification->delete();
 
             DB::commit();

--- a/app/Http/Requests/Instructor/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Instructor/NotificationDeleteRequest.php
@@ -22,7 +22,7 @@ class NotificationDeleteRequest extends FormRequest
             'notification_id' => $this->route('notification_id'),
         ]);
     }
-    
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -32,10 +32,10 @@ class NotificationDeleteRequest extends FormRequest
     {
         return [
             'notification_id' => [
-                'required', 
-                'integer', 
+                'required',
+                'integer',
                 'exists:notifications,id,deleted_at,NULL'
             ],
         ];
-    }    
+    }
 }

--- a/app/Http/Requests/Instructor/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Instructor/NotificationDeleteRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_id' => $this->route('notification_id'),
+        ]);
+    }
+    
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'notification_id' => [
+                'required', 
+                'integer', 
+                'exists:notifications,id,deleted_at,NULL'
+            ],
+        ];
+    }    
+}


### PR DESCRIPTION
## 概要
- 講師側お知らせ削除API作成のフォームリクエストの作成
## 動作確認
- http://localhost:8080/login/instructor にて、POSTリクエストで、bodyのキーにemailとpasswordを。値にtest_instructor2@example.comとpasswordをそれぞれ入力し、instructor2にログイン
## 確認していただきたいこと
- DELETEリクエストでhttp://localhost:8080/api/v1/instructor/notification/2 を送信し、
'result' => true,と表示されるか
- アドマイナー上で、viewedonce_notificationsテーブルのid1(notificatino_id2に関係するもの)に一致するものが削除され、かつ、notificationsテーブルのid2番が削除されているか
- ログインをinstructor２のまま、DELETEリクエストでhttp://localhost:8080/api/v1/instructor/notification/1 で送信したときに、
'result' => false,
                'message' => 'Notification is not associated with the instructor\'s course.',と表示されるか
- 前回のレビューで頂いたものが解決されているか
## 考慮していただきたいこと
- 特にありません