### PR TITLE
空の配列を返す（JKA-830_マネージャー側（講師） 講師一覧APIの作成_西田　修

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -17,7 +17,7 @@ class InstructorController extends Controller
 {
     /**
      * 講師一覧API
-     * 
+     *
      * @return JsonResponse
      */
     public function index()

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -16,6 +16,16 @@ use App\Http\Resources\Manager\InstructorShowResource;
 class InstructorController extends Controller
 {
     /**
+     * 講師一覧API
+     * 
+     * @return JsonResponse
+     */
+    public function index()
+    {
+        return response()->json([]);
+    }
+
+    /**
      * 講師情報取得API
      *
      * @param InstructorShowRequest $request

--- a/routes/api.php
+++ b/routes/api.php
@@ -146,6 +146,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('manager')->group(function () {
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {
+                    Route::get('index','Api\Manager\Instructor\InstructorController@index');
                     Route::prefix('{instructor_id}')->group(function () {
                         Route::get('/', 'Api\Manager\Instructor\InstructorController@show');
                         Route::post('/', 'Api\Manager\Instructor\InstructorController@update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -146,7 +146,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('manager')->group(function () {
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {
-                    Route::get('index','Api\Manager\Instructor\InstructorController@index');
+                    Route::get('index', 'Api\Manager\Instructor\InstructorController@index');
                     Route::prefix('{instructor_id}')->group(function () {
                         Route::get('/', 'Api\Manager\Instructor\InstructorController@show');
                         Route::post('/', 'Api\Manager\Instructor\InstructorController@update');


### PR DESCRIPTION
## 概要
- （JKA-830マネージャー側（講師） 講師一覧APIの作成）APIー空の配列を返す
## 動作確認手順
- 以下はPostmanでの操作
- Headersにアクセス元のURLを設定  
   Referer → http://localhost:3000/  
   Origin → http://localhost:3000/
- "http://localhost:8080/api/v1/manager/instructor/index" にGET送信する
- 空の配列が返ってきているかを確認