### PR TITLE
JKA-912 空の配列を返す（Tokeshi）

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
+use Composer\DependencyResolver\Request;
 
 class AttendanceController extends Controller
 {
@@ -140,5 +141,14 @@ class AttendanceController extends Controller
                 'result' => false,
             ], 500);
         }
+    }
+    /** 
+     * 完了済みレッスン数と完了済みチャプター数を取得するAPI
+     * 
+     * 
+     */
+    public function showStatus()
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -142,10 +142,10 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
-    /** 
+    /**
      * 完了済みレッスン数と完了済みチャプター数を取得するAPI
-     * 
-     * 
+     *
+     *
      */
     public function showStatus()
     {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -15,7 +15,6 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
-use Composer\DependencyResolver\Request;
 
 class AttendanceController extends Controller
 {
@@ -142,12 +141,13 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
+
     /** 
-     * 完了済みレッスン数と完了済みチャプター数を取得するAPI
+     * 本日のレッスン・チャプター完了数の取得API
      * 
      * 
      */
-    public function showStatus()
+    public function showStatusToday()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -142,10 +142,10 @@ class AttendanceController extends Controller
         }
     }
 
-    /** 
+    /**
      * 本日のレッスン・チャプター完了数の取得API
-     * 
-     * 
+     *
+     *
      */
     public function showStatusToday()
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -195,11 +195,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         });
 
                         //マネージャー生徒学習状況
-                        Route::prefix('attendance')->group(
-                            function () {
-                                Route::get('status/{period}', 'Api\Manager\AttendanceController@showStatus');
-                            }
-                        );
+                        Route::prefix('attendance/status')->group(function () {
+                            Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                        });
                     });
                     // マネージャー-受講
                     Route::prefix('attendance')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -193,7 +193,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('notification')->group(function () {
                             Route::post('/', 'Api\Manager\NotificationController@store');
                         });
-
                         //マネージャー生徒学習状況
                         Route::prefix('attendance/status')->group(function () {
                             Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');

--- a/routes/api.php
+++ b/routes/api.php
@@ -194,8 +194,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('/', 'Api\Manager\NotificationController@store');
                         });
                         //マネージャー生徒学習状況
-                        Route::prefix('attendance/status')->group(function () {
-                            Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                        Route::prefix('attendance')->group(function () {
+                            Route::prefix('status')->group(function () {
+                                Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                            });
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -193,50 +193,57 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('notification')->group(function () {
                             Route::post('/', 'Api\Manager\NotificationController@store');
                         });
+
+                        //マネージャー生徒学習状況
+                        Route::prefix('attendance')->group(
+                            function () {
+                                Route::get('status/{period}', 'Api\Manager\AttendanceController@showStatus');
+                            }
+                        );
                     });
-                });
-                // マネージャー-受講
-                Route::prefix('attendance')->group(function () {
-                    Route::post('/', 'Api\Manager\AttendanceController@store');
-                    Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
-                });
-                Route::prefix('instructor')->group(function () {
-                });
-                // マネージャー-生徒
-                Route::prefix('student')->group(function () {
-                    Route::get('{student_id}', 'Api\Manager\StudentController@show');
-                    Route::post('/', 'Api\Manager\StudentController@store');
-                });
-                // マネージャー-お知らせ
-                Route::prefix('notification')->group(function () {
-                    Route::get('index', 'Api\Manager\NotificationController@index');
-                    Route::prefix('{notification_id}')->group(function () {
-                        Route::get('/', 'Api\Manager\NotificationController@show');
-                        Route::patch('/', 'Api\Manager\NotificationController@update');
-                        Route::delete('/', 'Api\Manager\NotificationController@delete');
+                    // マネージャー-受講
+                    Route::prefix('attendance')->group(function () {
+                        Route::post('/', 'Api\Manager\AttendanceController@store');
+                        Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
                     });
-                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
+                    Route::prefix('instructor')->group(function () {
+                    });
+                    // マネージャー-生徒
+                    Route::prefix('student')->group(function () {
+                        Route::get('{student_id}', 'Api\Manager\StudentController@show');
+                        Route::post('/', 'Api\Manager\StudentController@store');
+                    });
+                    // マネージャー-お知らせ
+                    Route::prefix('notification')->group(function () {
+                        Route::get('index', 'Api\Manager\NotificationController@index');
+                        Route::prefix('{notification_id}')->group(function () {
+                            Route::get('/', 'Api\Manager\NotificationController@show');
+                            Route::patch('/', 'Api\Manager\NotificationController@update');
+                            Route::delete('/', 'Api\Manager\NotificationController@delete');
+                        });
+                        Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
+                    });
                 });
             });
         });
     });
-});
 
-Route::prefix('v1')->group(function () {
-    Route::prefix('student')->group(function () {
-        Route::post('/', 'Api\Student\StudentController@store');
-        Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
+    Route::prefix('v1')->group(function () {
+        Route::prefix('student')->group(function () {
+            Route::post('/', 'Api\Student\StudentController@store');
+            Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
+        });
     });
-});
 
-// 講師側API
-Route::prefix('v1')->group(function () {
-    Route::prefix('instructor')->group(function () {
-        Route::prefix('notification')->group(function () {
-            Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
-            Route::prefix('{notification_id}')->group(function () {
-                Route::get('/', 'Api\Instructor\NotificationController@show');
-                Route::patch('/', 'Api\Instructor\NotificationController@update');
+    // 講師側API
+    Route::prefix('v1')->group(function () {
+        Route::prefix('instructor')->group(function () {
+            Route::prefix('notification')->group(function () {
+                Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
+                Route::prefix('{notification_id}')->group(function () {
+                    Route::get('/', 'Api\Instructor\NotificationController@show');
+                    Route::patch('/', 'Api\Instructor\NotificationController@update');
+                });
             });
         });
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -198,49 +198,49 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
                         });
                     });
-                    // マネージャー-受講
-                    Route::prefix('attendance')->group(function () {
-                        Route::post('/', 'Api\Manager\AttendanceController@store');
-                        Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
+                });
+                // マネージャー-受講
+                Route::prefix('attendance')->group(function () {
+                    Route::post('/', 'Api\Manager\AttendanceController@store');
+                    Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
+                });
+                Route::prefix('instructor')->group(function () {
+                });
+                // マネージャー-生徒
+                Route::prefix('student')->group(function () {
+                    Route::get('{student_id}', 'Api\Manager\StudentController@show');
+                    Route::post('/', 'Api\Manager\StudentController@store');
+                });
+                // マネージャー-お知らせ
+                Route::prefix('notification')->group(function () {
+                    Route::get('index', 'Api\Manager\NotificationController@index');
+                    Route::prefix('{notification_id}')->group(function () {
+                        Route::get('/', 'Api\Manager\NotificationController@show');
+                        Route::patch('/', 'Api\Manager\NotificationController@update');
+                        Route::delete('/', 'Api\Manager\NotificationController@delete');
                     });
-                    Route::prefix('instructor')->group(function () {
-                    });
-                    // マネージャー-生徒
-                    Route::prefix('student')->group(function () {
-                        Route::get('{student_id}', 'Api\Manager\StudentController@show');
-                        Route::post('/', 'Api\Manager\StudentController@store');
-                    });
-                    // マネージャー-お知らせ
-                    Route::prefix('notification')->group(function () {
-                        Route::get('index', 'Api\Manager\NotificationController@index');
-                        Route::prefix('{notification_id}')->group(function () {
-                            Route::get('/', 'Api\Manager\NotificationController@show');
-                            Route::patch('/', 'Api\Manager\NotificationController@update');
-                            Route::delete('/', 'Api\Manager\NotificationController@delete');
-                        });
-                        Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
-                    });
+                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
                 });
             });
         });
     });
+});
 
-    Route::prefix('v1')->group(function () {
-        Route::prefix('student')->group(function () {
-            Route::post('/', 'Api\Student\StudentController@store');
-            Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
-        });
+Route::prefix('v1')->group(function () {
+    Route::prefix('student')->group(function () {
+        Route::post('/', 'Api\Student\StudentController@store');
+        Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
     });
+});
 
-    // 講師側API
-    Route::prefix('v1')->group(function () {
-        Route::prefix('instructor')->group(function () {
-            Route::prefix('notification')->group(function () {
-                Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
-                Route::prefix('{notification_id}')->group(function () {
-                    Route::get('/', 'Api\Instructor\NotificationController@show');
-                    Route::patch('/', 'Api\Instructor\NotificationController@update');
-                });
+// 講師側API
+Route::prefix('v1')->group(function () {
+    Route::prefix('instructor')->group(function () {
+        Route::prefix('notification')->group(function () {
+            Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
+            Route::prefix('{notification_id}')->group(function () {
+                Route::get('/', 'Api\Instructor\NotificationController@show');
+                Route::patch('/', 'Api\Instructor\NotificationController@update');
             });
         });
     });


### PR DESCRIPTION
## issue
- #912 JKA  空の配列を返すルーターとコントローラの作成
- https://gut-familie.atlassian.net/browse/JKA-912

## 概要
- ControllerにshowStatusメソッドを記述
- api.phpにRouteを新たに記述

## 動作確認手順
- 下記コマンドを実行
- docker exec -it  laravel_app bashにてログイン後、http://localhost:8080/　
にてバックエンド起動確認する
- POSTmanを使用して通信を確認する
URL：
http://localhost:8080/api/v1/manager/course/{course_id}/attendance/status/today
- メソッド：GET
- レスポンス：空の配列→ []が表示されることを確認する

## 確認して欲しい事
- Routeに記述したコードの書いてる箇所がおかしくないかチェックお願いします
- また、全体的におかしなとこあればアドバイスをよろしくお願いします

