### PR TITLE
#917空の配列を返すルーターとコントローラの作成(あちょこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -146,8 +146,8 @@ class AttendanceController extends Controller
     *
     *
     */
-   public function showStatusThisMonth()
-   {
-       return response()->json([]);
-   }
+    public function showStatusThisMonth()
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -141,4 +141,13 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
+    /**
+    * 今月のレッスン・チャプター完了数の取得API
+    *
+    *
+    */
+   public function showStatusThisMonth()
+   {
+       return response()->json([]);
+   }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -193,6 +193,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('notification')->group(function () {
                             Route::post('/', 'Api\Manager\NotificationController@store');
                         });
+                        //マネージャー生徒学習状況
+                        Route::prefix('attendance')->group(function () {
+                            Route::prefix('status')->group(function () {
+                                Route::get('this-month', 'Api\Manager\AttendanceController@showStatusThisMonth');
+                            });
+                        });
                     });
                 });
                 // マネージャー-受講


### PR DESCRIPTION
## Task
https://gut-familie.atlassian.net/browse/JKA-917

## 概要
- 空の配列を返すルーターとコントローラの作成

## 動作確認手順
- postmanでhttp://localhost:8080/login/instructorでログイン
- 次にhttp://localhost:8080/api/v1/manager/course/{course_id}/attendance/status/this-month をGET形式で送信すると空の配列が返ってくる

## 確認して欲しいこと
featureブランチ名に名前を入れ忘れてしまったのですが、修正方法はありますか？