### PR TITLE
jka-922マネージャー(講師側) チャプター作成画面 選択済チャプターを削除するAPI作成 2.空の配列を返すルーターとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -6,6 +6,7 @@ use Exception;
 use App\Model\Course;
 use App\Model\Chapter;
 use App\Model\Instructor;
+use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -183,6 +184,18 @@ class ChapterController extends Controller
         return response()->json([
             "result" => true
         ]);
+    }
+
+    /**
+     * 複数のチャプター削除API
+     *
+     * @param Request $request
+     * @param int $course_id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function bulkDelete(Request $request, $course_id)
+    {
+        return response()->json([]);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -173,6 +173,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('sort', 'Api\Manager\ChapterController@sort');
                             Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::put('status', 'Api\Manager\ChapterController@putStatus');
+                            Route::delete('/', 'Api\Manager\ChapterController@bulkDelete');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');


### PR DESCRIPTION
## タスク
- Closes #590

## 概要
- **2.空の配列を返すルーターとコントローラの作成**

## 動作確認手順

**1. Postmanでマネージャー権限のあるinstructorでログイン**
`InstructorSeeder.php`
`'type' => 'manager'`のinstructorを選ぶ

**2. Postmanにて下記を入力**
- URL
http://localhost:8080/api/v1/manager/course/1/chapter
- リクエスト
DELETE
- リクエストボディ
RAW　JSON
{
    "chapters": [1, 2, 3]
}
- レスポンス
[] 
が返ってくることを確認

## 考慮して欲しいこと
- 特になし
## 確認して欲しいこと
- 特になし