### PR TITLE
JKA-913 本日完了したレッスンの数を取得し、APIを返却する

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -152,27 +152,14 @@ class AttendanceController extends Controller
     {
         //変数にAttendanceのリレーションをロードし、course_idがリクエストのcourse_idと一致するものを取得
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
-        // dd($attendances);
-        //デバッグするため記述
-        // $attendances->each(function (Attendance $attendance) {
-        //     $attendance->lessonAttendances->each(function (LessonAttendance $lessonAttendance) {
-        //         if ($lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday()) {
-        //             dd($lessonAttendance);
-        //         }
-        //     });
-        // });
-
         // 今日完了したレッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
             $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
-                return $lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday();
+                return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $lessonAttendance->updated_at->isToday();
             });
-            //デバッグするため記述
-            // dd($compleatedLessonAttendances);
             return $compleatedLessonAttendances;
         });
         $completedLessonsCount = $completedLessonsCount->count();
-        //dd($completedLessonsCount);
         return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -150,8 +150,29 @@ class AttendanceController extends Controller
      */
     public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {
-        $attendancd = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
-        dd($attendancd);
-        // return response()->json([]);
+        //変数にAttendanceのリレーションをロードし、course_idがリクエストのcourse_idと一致するものを取得
+        $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+        // dd($attendances);
+        //デバッグするため記述
+        // $attendances->each(function (Attendance $attendance) {
+        //     $attendance->lessonAttendances->each(function (LessonAttendance $lessonAttendance) {
+        //         if ($lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday()) {
+        //             dd($lessonAttendance);
+        //         }
+        //     });
+        // });
+
+        // 今日完了したレッスンの個数を取得
+        $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
+            $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
+                return $lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday();
+            });
+            //デバッグするため記述
+            // dd($compleatedLessonAttendances);
+            return $compleatedLessonAttendances;
+        });
+        $completedLessonsCount = $completedLessonsCount->count();
+        //dd($completedLessonsCount);
+        return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\AttendanceShowRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
@@ -147,8 +148,10 @@ class AttendanceController extends Controller
      *
      *
      */
-    public function showStatusToday()
+    public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {
-        return response()->json([]);
+        $attendancd = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+        dd($attendancd);
+        // return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -158,37 +158,8 @@ class AttendanceController extends Controller
                 return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $lessonAttendance->updated_at->isToday();
             });
             return $compleatedLessonAttendances;
-        })->count();
-
-        //今日完了したチャプターの個数を取得
-        $completedChaptersCount = $attendances->flatMap(function (Attendance $attendance) {
-            return $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
-            dd($completedChaptersCount);
         })
-
-            ->filter(function (LessonAttendance $lessonAttendance) {
-                //チャプターに含まれているレッスンが完了されているかつ、最新のレッスンの完了済みステータスへの更新日が当日の日時で絞り込む
-                $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
-                $totalLessonsCount = $allLessonsId->count();
-                $completedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
-                    ->whereIn('lesson_id', $allLessonsId)
-                    ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
-                    ->count();
-                return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $completedLessonsCount;
-            })
-            ->map(function (LessonAttendance $lessonAttendance) {
-                //chapter_idとattendance_idをkeyにもつ配列を作成
-                return [
-                    'chapter_id' => $lessonAttendance->lesson->chapter->id,
-                    'attendance_id' => $lessonAttendance->attendance_id
-                ];
-            })
-            ->unique()
             ->count();
-        // $completedLessonsCount = $completedLessonsCount->count();
-        return response()->json([
-            'completed_lessons_conut' => $completedLessonsCount,
-            'completed_chapters_count' => $completedChaptersCount
-        ]);
+        return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -158,8 +158,37 @@ class AttendanceController extends Controller
                 return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $lessonAttendance->updated_at->isToday();
             });
             return $compleatedLessonAttendances;
-        });
-        $completedLessonsCount = $completedLessonsCount->count();
-        return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
+        })->count();
+
+        //今日完了したチャプターの個数を取得
+        $completedChaptersCount = $attendances->flatMap(function (Attendance $attendance) {
+            return $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
+            dd($completedChaptersCount);
+        })
+
+            ->filter(function (LessonAttendance $lessonAttendance) {
+                //チャプターに含まれているレッスンが完了されているかつ、最新のレッスンの完了済みステータスへの更新日が当日の日時で絞り込む
+                $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
+                $totalLessonsCount = $allLessonsId->count();
+                $completedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
+                    ->whereIn('lesson_id', $allLessonsId)
+                    ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
+                    ->count();
+                return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $completedLessonsCount;
+            })
+            ->map(function (LessonAttendance $lessonAttendance) {
+                //chapter_idとattendance_idをkeyにもつ配列を作成
+                return [
+                    'chapter_id' => $lessonAttendance->lesson->chapter->id,
+                    'attendance_id' => $lessonAttendance->attendance_id
+                ];
+            })
+            ->unique()
+            ->count();
+        // $completedLessonsCount = $completedLessonsCount->count();
+        return response()->json([
+            'completed_lessons_conut' => $completedLessonsCount,
+            'completed_chapters_count' => $completedChaptersCount
+        ]);
     }
 }


### PR DESCRIPTION
## issue
- #JKA-913 本日完了したレッスンの数を取得し、APIを返却する

## 概要
- 本日の完了したレッスンの数を取得し、APIを返却する

## 動作確認手順

1. Postmanでマネージャー権限のあるinstructorでログイン
2. Postmanで下記を入力
- URL
``` http://localhot:8080//api/v1/manager/course/{course_id}/attendance/status/today```
- リクエスト
```GET```
- Headers
```Key```  Referer, Origin
```Value``` http://localhost:3000

3. Postmanにデータが返ってくるを確認
<img width="1392" alt="Screenshot 2024-07-01 at 21 45 02" src="https://github.com/yukihiroLaravel/juko_laravel/assets/36120057/05d22678-2ba2-41df-af71-1145baf52d55">




## 考慮して欲しいこと
- 一旦、コメントアウトしたものを記述しています。それ以外で問題ないか確認をお願いします。最後のマージ前にコメントアウトは修正します。

## 確認して欲しい事
特になし
