### PR TITLE
JKA-931 空の配列を返すルーターとコントローラの作成（ゆうへい）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -186,6 +186,14 @@ class ChapterController extends Controller
     }
 
     /**
+     * 複数のチャプター公開/非公開API
+     */
+    public function patchStatus($course_id)
+    {
+        return response()->json([]);
+    }
+
+    /**
      * チャプター並び替えAPI
      *
      * @param ChapterSortRequest $request

--- a/routes/api.php
+++ b/routes/api.php
@@ -173,6 +173,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('sort', 'Api\Manager\ChapterController@sort');
                             Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::put('status', 'Api\Manager\ChapterController@putStatus');
+                            Route::patch('status', 'Api\Manager\ChapterController@patchStatus');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-931
- https://gut-familie.atlassian.net/browse/JKA-893

## 概要
- [講師側 チャプター作成画面 選択済チャプターを公開/非公開にするAPI作成](https://gut-familie.atlassian.net/browse/JKA-893)における、空の配列を返すルーターとコントローラの作成。

## 動作確認手順
- Postmanにて確認
    - HTTTPメソッド：PATCH
    - URL：http://localhost:8080/api/v1/manager/course/1/chapter/status
    - Headers
        - X-XSRF-TOKEN: {{XSRF-TOKEN}}
        - Referer: http://localhost:3000/
        - Origin: http://localhost:3000/
    - Body
        - status: "public" or "private"
        - chapters: [1, 2, 3, 4, 5]
    - Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```

## 考慮して欲しいこと
- 特になし。

## 確認して欲しいこと
- 空配列が戻り値として返ってきているか。
