### PR TITLE
JKA-815 講師側（マネージャー側）受講生詳細画面の学習状況API 空の配列を返すルーター作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -141,4 +141,27 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
+    /**
+     * 講師側受講状況API
+     *
+     * @param int $attendance_id
+     * @return JsonResponse
+     */
+    public function status()
+    {
+        return response()->json([]);
+        // $attendanceId = $request->attendance_id;
+
+        // /** @var Attendance */
+        // $attendance = Attendance::with(['course.chapters.lessons.lessonAttendances'])->findOrFail($attendanceId);
+
+        // if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
+        //     return response()->json([
+        //         "result" => false,
+        //         "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
+        //     ], 403);
+        // }
+
+        // return new AttendanceStatusResource($attendance);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -198,7 +198,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-受講
                 Route::prefix('attendance')->group(function () {
                     Route::post('/', 'Api\Manager\AttendanceController@store');
-                    Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
+                    // 講師-生徒学習状況
+                    Route::prefix('{attendance_id}')->group(function () {
+                        Route::get('status', 'Api\Manager\AttendanceController@status');
+                        Route::delete('/', 'Api\Manager\AttendanceController@delete');
+                    });
                 });
                 Route::prefix('instructor')->group(function () {
                 });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-815

## 概要
- 講師側 受講生詳細画面の学習状況を取得するAPIを作成　子課題
空の配列を返すルータとコントローラの作成

## 動作確認手順
- GETリクエストで/api/v1/instructor/attendance/{attendance_id}/statusを実行
attendance_idを入力すると空の配列が返ってくる
{attendance_id}は動的のため、１を入れた。

レスポンス
[]
が返ってくることを確認

## 考慮してほしいこと
- 今回は特にありません。

## 確認してほしいこと
- 今回は特にありません。