### PR TITLE
JKA-815 講師側（マネージャー側）受講生詳細画面の学習状況API ロジックの作成（とさか）

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -159,7 +159,7 @@ class AttendanceController extends Controller
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
-        
+
         // 指定されたattendance_idに関連するAttendanceレコードを取得
 
         $attendance = Attendance::with(['course.chapters.lessons.lessonAttendances'])->findOrFail($attendance_id);

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -6,9 +6,13 @@ use Exception;
 use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Attendance;
+use App\Model\Chapter;
+use App\Model\Attendance;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
@@ -142,26 +146,69 @@ class AttendanceController extends Controller
         }
     }
     /**
-     * 講師側受講状況API
+     * マネージャー受講状況取得API
      *
      * @param int $attendance_id
      * @return JsonResponse
      */
-    public function status()
+    public function status(int $attendance_id): JsonResponse
     {
-        return response()->json([]);
-        // $attendanceId = $request->attendance_id;
+        // ログイン中のインストラクターのIDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        // マネージャーとその配下のインストラクターのIDを取得
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+        
+        // 指定されたattendance_idに関連するAttendanceレコードを取得
 
-        // /** @var Attendance */
-        // $attendance = Attendance::with(['course.chapters.lessons.lessonAttendances'])->findOrFail($attendanceId);
+        $attendance = Attendance::with(['course.chapters.lessons.lessonAttendances'])->findOrFail($attendance_id);
 
-        // if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
-        //     return response()->json([
-        //         "result" => false,
-        //         "message" => "Unauthorized: The authenticated instructor does not have permission to delete this attendance record",
-        //     ], 403);
-        // }
+        // コースのインストラクターが現在のインストラクターまたはその配下のインストラクターでなければエラー応答
+        if (!in_array($attendance->course->instructor_id, $instructorIds, true)) {
+            return response()->json([
+                "result" => false,
+                "message" => "Unauthorized: The authenticated instructor does not have permission to view this attendance record",
+            ], 403);
+        }
 
-        // return new AttendanceStatusResource($attendance);
+        // 受講状況のデータを構築
+        $response = [
+            'data' => [
+                'attendance_id' => $attendance->id,
+                'progress' => $attendance->progress,
+                'course' => [
+                    'course_id' => $attendance->course->id,
+                    'title' => $attendance->course->title,
+                    'status' => $attendance->course->status,
+                    'image' => $attendance->course->image,
+                    'chapters' => $this->mapChapters($attendance->course->chapters, $attendance),
+                ],
+            ],
+        ];
+
+        return response()->json($response, 200);
+    }
+
+    /**
+     * チャプターの進捗計算
+     *
+     * @param Collection $chapters
+     * @param Attendance $attendance
+     * @return array
+     */
+    private function mapChapters(Collection $chapters, Attendance $attendance): array
+        // 各チャプターの進捗を計算する
+    {
+        return $chapters->map(function (Chapter $chapter) use ($attendance) {
+            $chapterProgress = $chapter->calculateChapterProgress($attendance);
+            return [
+                'chapter_id' => $chapter->id,
+                'title' => $chapter->title,
+                'status' => $chapter->status,
+                'progress' => $chapterProgress,
+            ];
+        })
+        ->toArray();
     }
 }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-815

## 概要
- マネージャー 受講生詳細画面の学習状況を取得するAPIを作成　子課題
ロジックの作成

## 動作確認手順
- ポストマンにてGETリクエストで/api/v1/instructor/attendance/{attendance_id}/statusを実行
{attendance_id}は動的のため、１を入れると下記レスポンスが返ってくる

レスポンス
```
{
    "data": {
        "attendance_id": 1,
        "progress": 10,
        "course": {
            "course_id": 1,
            "title": "PHP入門講座",
            "status": "public",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "chapter": [
                {
                    "chapter_id": 1,
                    "title": "PHPとは？",
                    "status": "public"
                },
                {
                    "chapter_id": 2,
                    "title": "PHPの基礎を学ぼう",
                    "status": "public"
                },
                {
                    "chapter_id": 3,
                    "title": "PHPの応用にチャレンジしよう",
                    "status": "public"
                }
            ]
        }
    }
}
```
が返ってくることを確認

存在しない50を入れるとエラーメッセージが返ってくる
レスポンス
```
{
    "message": "No query results for model [App\\Model\\Attendance] 50",
    "exception": "Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException",
    "file": "/var/www/html/laravelapp/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php",
    "line": 224,
    "trace": [
        {
            "file": "/var/www/html/laravelapp/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php",
            "line": 200,
            "function": "prepareException",
            "class": "Illuminate\\Foundation\\Exceptions\\Handler",
            "type": "->"
        },
```


## 考慮してほしいこと
- 今回は特にありません。

## 確認してほしいこと
- エラーメッセージが気になりますが、attendance_idに50が無いエラーと思ってます。認識に相違がないかご確認よろしくお願いいたします。