### PR TITLE
JKA-915 本日完了したチャプターの数を取得し、APIを返却する(Tokeshi)

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -174,9 +174,7 @@ class AttendanceController extends Controller
                     ->whereIn('lesson_id', $allLessonsId)
                     ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
                     ->count();
-                // dd($compleatedLessonsCount);ここで、最新レッスンの完了済みを取得できているか確認
                 return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $compleatedLessonsCount;
-                // dd($compleatedLessonsCount);ここで更新日時が表であるかどうか確認
             })
             //ユニークなチャプターID取得と出席のIDを取得
             ->map(function (LessonAttendance $lessonAttendance) {


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-915

## 概要
- 本日完了したチャプターの数を取得し、APIを返却する


## 動作確認手順
1.Postmanでマネージャー権限のあるinstructorでログイン
2.Postmanで下記を入力
URL
 ```http://localhot:8080//api/v1/manager/course/{course_id}/attendance/status/today```
リクエスト
```GET```
Headers
```Key ```Referer, Origin
```Value``` http://localhost:3000/
3. adminerにてDB情報を変更する

<img width="1057" alt="Screenshot 2024-07-07 at 22 33 22" src="https://github.com/yukihiroLaravel/juko_laravel/assets/36120057/443d28df-2fd4-4e1c-9f8a-e6ff21a7adcc">

4. Postmanにデータが返ってくるを確認　

<img width="923" alt="Screenshot 2024-07-07 at 22 33 05" src="https://github.com/yukihiroLaravel/juko_laravel/assets/36120057/40c8bfbd-32b7-4706-a9ec-d1e4640f993a">
## 考慮して欲しいこと
特になし

## 確認して欲しい事
コードの書き方に関して、おかしなところがないかどうか


