### PR TITLE
JKA-815 講師側（マネージャー側）受講生詳細画面の学習状況API フォームリクエストの作成(とさか)

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\Manager;
 use Exception;
 use App\Model\Course;
 use App\Model\Lesson;
-use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Attendance;
 use App\Model\Instructor;
@@ -13,12 +12,13 @@ use App\Model\LessonAttendance;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
+use App\Http\Requests\Manager\AttendanceStatusRequest;
+
 
 class AttendanceController extends Controller
 {
@@ -151,7 +151,7 @@ class AttendanceController extends Controller
      * @param int $attendance_id
      * @return JsonResponse
      */
-    public function status(int $attendance_id): JsonResponse
+    public function status(AttendanceStatusRequest $request, int $attendance_id): JsonResponse
     {
         // ログイン中のインストラクターのIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -148,11 +148,13 @@ class AttendanceController extends Controller
     /**
      * マネージャー受講状況取得API
      *
-     * @param int $attendance_id
+     * @param AttendanceStatusRequest $request
      * @return JsonResponse
      */
-    public function status(AttendanceStatusRequest $request, int $attendance_id): JsonResponse
+    public function status(AttendanceStatusRequest $request): JsonResponse
     {
+        $attendanceId = $request->attendance_id;
+
         // ログイン中のインストラクターのIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
         // マネージャーとその配下のインストラクターのIDを取得
@@ -162,7 +164,7 @@ class AttendanceController extends Controller
 
         // 指定されたattendance_idに関連するAttendanceレコードを取得
 
-        $attendance = Attendance::with(['course.chapters.lessons.lessonAttendances'])->findOrFail($attendance_id);
+        $attendance = Attendance::with(['course.chapters.lessons.lessonAttendances'])->findOrFail($attendanceId);
 
         // コースのインストラクターが現在のインストラクターまたはその配下のインストラクターでなければエラー応答
         if (!in_array($attendance->course->instructor_id, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -19,7 +19,6 @@ use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
 use App\Http\Requests\Manager\AttendanceStatusRequest;
 
-
 class AttendanceController extends Controller
 {
     /**

--- a/app/Http/Requests/Manager/AttendanceStatusRequest.php
+++ b/app/Http/Requests/Manager/AttendanceStatusRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'attendance_id' => ['required', 'integer', 'exists:attendances,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'attendance_id' => $this->route('attendance_id'),
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-815

## 概要
- マネージャー 受講生詳細画面の学習状況を取得するAPIを作成　子課題
フォームリクエストの作成

## 動作確認手順
- ポストマンにてGETリクエストで/api/v1/instructor/attendance/{attendance_id}/statusを実行
{attendance_id}　にnを入れると下記が返る

レスポンス
```
{
    "message": "The given data was invalid.",
    "errors": {
        "attendance_id": [
            "The attendance id must be an integer."
        ]
    }
}
```
リクエストファイル作成前の状態で
{attendance_id}　にnを入れると下記が返るため、機能していることを確認済み。

レスポンス
```
{
    "message": "Argument 1 passed to App\\Http\\Controllers\\Api\\Manager\\AttendanceController::status() must be of the type int, string given, called in /var/www/html/laravelapp/vendor/laravel/framework/src/Illuminate/Routing/Controller.php on line 54",
    "exception": "Symfony\\Component\\Debug\\Exception\\FatalThrowableError",
    "file": "/var/www/html/laravelapp/app/Http/Controllers/Api/Manager/AttendanceController.php",
    "line": 152,
    "trace": [
        {
            "file": "/var/www/html/laravelapp/vendor/laravel/framework/src/Illuminate/Routing/Controller.php",
            "line": 54,
            "function": "status",
            "class": "App\\Http\\Controllers\\Api\\Manager\\AttendanceController",
            "type": "->"
        },
        {
～～～～～～
```


## 考慮してほしいこと
- 今回は特にありません。

## 確認してほしいこと
- 今回は特にありません。