### PR TITLE
JKA-994 自分と配下のinstructorの講座情報のみにアクセスできるロジック(マネージャーの認証ロジック)

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -164,7 +164,7 @@ class AttendanceController extends Controller
         //自分と配下のnstructorのコースでなければエラー応答
         $course = Course::FindOrFail($request->course_id);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
-            // Error response 
+            // Error response
             return response()->json([
                 'result'  => false,
                 'message' => "Forbidden, not allowed to edit this course.",

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -162,12 +162,12 @@ class AttendanceController extends Controller
         //instructorIdsにinstructor_idを追加
         $instructorIds[] = $instructorId;
         //自分と配下のnstructorのコースでなければエラー応答
-        $course = Course::FindOrFail($request->course_id);
+        $course = Course::findOrFail($request->course_id);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
             // Error response 
             return response()->json([
                 'result'  => false,
-                'message' => "Forbidden, not allowed to edit this course.",
+                'message' => "Forbidden, not allowed to access this course.",
             ], 403);
         }
 
@@ -207,7 +207,6 @@ class AttendanceController extends Controller
             ->count();
 
         return response()->json([
-            'coures' => $course,
             'completed_lessons_conut' => $completedLessonsCount,
             'completed_chapters_count' => $completedChaptersCount
         ]);

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -152,6 +152,25 @@ class AttendanceController extends Controller
     {
         //変数にAttendanceのリレーションをロードし、course_idがリクエストのcourse_idと一致するものを取得
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+
+        //変数にAuthのguardを使用して現在ログインしているinstructorのidを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        //instructor_idをキーにしてmanagingsリレーションをロードし、instructor_idが一致するものを取得
+        $manager = Instructor::with('managings')->find($instructorId);
+        //managingsリレーションのidを取得
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        //instructorIdsにinstructor_idを追加
+        $instructorIds[] = $instructorId;
+        //自分と配下のnstructorのコースでなければエラー応答
+        $course = Course::FindOrFail($request->course_id);
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
+            // Error response 
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to edit this course.",
+            ], 403);
+        }
+
         // 今日完了したレッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
             $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
@@ -188,6 +207,7 @@ class AttendanceController extends Controller
             ->count();
 
         return response()->json([
+            'coures' => $course,
             'completed_lessons_conut' => $completedLessonsCount,
             'completed_chapters_count' => $completedChaptersCount
         ]);


### PR DESCRIPTION
## issue
-  https://gut-familie.atlassian.net/browse/JKA-944

## 概要
- 自分と配下のinstructorの講座情報のみにアクセスできるロジック(マネージャーの認証ロジック)

## 動作確認手順
1.Postmanでマネージャー権限のあるinstructorでログイン

2.Postmanで下記を入力
URL
http://localhot:8080//api/v1/manager/course/{course_id}/attendance/status/today
リクエスト
```GET```

Headers
```Key``` Referer, Origin
```Value``` http://localhost:3000/
3.Postmanにデータが返ってくるを確認しました
- Manager権限を持つidでエラーが出ないことを確認（id_1 とid_4）
- それ以外の権限だとエラーが返ってくることを確認
<img width="977" alt="Screenshot 2024-07-14 at 0 15 32" src="https://github.com/user-attachments/assets/836ec668-ed92-4671-b271-7e89dcbc0080">
　
<img width="918" alt="Screenshot 2024-07-14 at 0 14 36" src="https://github.com/user-attachments/assets/e4237e32-e407-4d4a-ad9f-d22d19fdc5d3">



## 考慮して欲しいこと
サンプルのコードを参考にしてますが、理解度は7割程度です
また、処理内容を理解するためにコメントアウトで何を実行しているかを記述しています

## 確認して欲しい事
特になし
