### PR TITLE
JKA-932 ロジックの作成（ゆうへい）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -183,7 +183,7 @@ class ChapterController extends Controller
             // 選択されたchapterを取得
             $chapters = Chapter::whereIn('id', $request->chapters)->with('course')->get();
 
-            $chapters->map(function($chapter) use ($instructorId, $request) {
+            $chapters->map(function ($chapter) use ($instructorId, $request) {
                 // チャプターに紐づく講師でない場合は許可しない
                 if ((int) $instructorId !== $chapter->course->instructor_id) {
                     throw new ValidationErrorException('Invalid instructor_id.');

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -195,7 +195,7 @@ class ChapterController extends Controller
             });
 
             // chaptersのstatusを一括で更新
-            Chapter->update([
+            $chapters->update([
                 'status' => $request->status,
             ]);
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -183,10 +183,14 @@ class ChapterController extends Controller
             // 選択されたchapterを取得
             $chapters = Chapter::whereIn('id', $request->chapters)->with('course')->get();
 
-            $chapters->map(function ($chapter) use ($instructorId) {
+            $chapters->map(function($chapter) use ($instructorId, $request) {
                 // チャプターに紐づく講師でない場合は許可しない
                 if ((int) $instructorId !== $chapter->course->instructor_id) {
                     throw new ValidationErrorException('Invalid instructor_id.');
+                }
+                // $chaptersの中に$course_idと一致しないidが含まれている場合はエラーを返す
+                if ((int) $request->course_id !== $chapter->course_id) {
+                    throw new ValidationErrorException('Invalid course_id.', 422);
                 }
             });
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -6,22 +6,22 @@ use Exception;
 use App\Model\Course;
 use App\Model\Chapter;
 use App\Model\Instructor;
-use App\Exceptions\ValidationErrorException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use App\Exceptions\ValidationErrorException;
 use App\Http\Requests\Instructor\ChapterShowRequest;
 use App\Http\Requests\Instructor\ChapterSortRequest;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
 use App\Http\Requests\Instructor\ChapterStoreRequest;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
 use App\Http\Resources\Instructor\ChapterShowResource;
+use App\Http\Requests\Instructor\BulkPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\Requests\Instructor\ChapterPutStatusRequest;
 use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
-use App\Http\Requests\Instructor\BulkPatchStatusRequest;
 
 class ChapterController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -20,6 +20,7 @@ use App\Http\Resources\Instructor\ChapterShowResource;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\Requests\Instructor\ChapterPutStatusRequest;
 use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
+use App\Http\Requests\Instructor\BulkPatchStatusRequest;
 
 class ChapterController extends Controller
 {
@@ -161,6 +162,19 @@ class ChapterController extends Controller
             'status' => $request->status
         ]);
 
+        return response()->json([
+            'result' => true,
+        ]);
+    }
+
+    /**
+     * 複数チャプターの公開/非公開API
+     *
+     * @param BulkPatchStatusRequest $request
+     * @return JsonResponse
+     */
+    public function bulkPatchStatus(BulkPatchStatusRequest $request): JsonResponse
+    {
         return response()->json([
             'result' => true,
         ]);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -183,7 +183,7 @@ class ChapterController extends Controller
             // 選択されたchapterを取得
             $chapters = Chapter::whereIn('id', $request->chapters)->with('course')->get();
 
-            $chapters->map(function ($chapter) use ($instructorId, $request) {
+            $chapters->each(function (Chapter $chapter) use ($instructorId, $request) {
                 // チャプターに紐づく講師でない場合は許可しない
                 if ((int) $instructorId !== $chapter->course->instructor_id) {
                     throw new ValidationErrorException('Invalid instructor_id.');
@@ -194,11 +194,8 @@ class ChapterController extends Controller
                 }
             });
 
-            // 該当するchaptersのidをコレクションで取得
-            $chapterIds = $chapters->pluck('id');
-
             // chaptersのstatusを一括で更新
-            Chapter::whereIn('id', $chapterIds)->update([
+            Chapter->update([
                 'status' => $request->status,
             ]);
 
@@ -206,7 +203,6 @@ class ChapterController extends Controller
                 'result' => true,
             ]);
         } catch (ValidationErrorException $e) {
-            Log::error($e);
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -183,7 +183,7 @@ class ChapterController extends Controller
             // 選択されたchapterを取得
             $chapters = Chapter::whereIn('id', $request->chapters)->with('course')->get();
 
-            $chapters->map(function($chapter) use ($instructorId) {
+            $chapters->map(function ($chapter) use ($instructorId) {
                 // チャプターに紐づく講師でない場合は許可しない
                 if ((int) $instructorId !== $chapter->course->instructor_id) {
                     throw new ValidationErrorException('Invalid instructor_id.');

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -196,7 +196,7 @@ class ChapterController extends Controller
 
         // $chaptersの中に$course_idと一致しないidが含まれている場合はエラーを返す
         $courseIdFlg = false;
-        $chapters->map(function($chapter) use ($request, &$courseIdFlg) {
+        $chapters->map(function ($chapter) use ($request, &$courseIdFlg) {
             if ($chapter->course_id !== intval($request->course_id)) {
                 $courseIdFlg = true;
             }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -189,13 +189,22 @@ class ChapterController extends Controller
     /**
      * 複数のチャプター公開/非公開API
      */
-    public function bulkPatchStatus(BulkPatchStatusRequest $request, $course_id)
+    public function bulkPatchStatus(BulkPatchStatusRequest $request)
     {
-        // 該当するchaptersを取得
-        $chapters = Chapter::where('course_id', $course_id)
-                           ->whereIn('id', $request->chapters);
+        // $chaptersの中に$course_idと一致しないidが含まれている場合はエラーを返す
+        foreach ($request->chapters as $chapter_id) {
+            $chapter = Chapter::findOrFail($chapter_id);
+            if ($chapter->course_id !== intval($request->course_id)) {
+                return response()->json([
+                    'result' => false,
+                ]);
+            }
+        }
 
-        // chaptersのstatusを更新
+        // 該当するchaptersを取得
+        $chapters = Chapter::whereIn('id', $request->chapters);
+
+        // chaptersのstatusを一括で更新
         $chapters->update([
             'status' => $request->status,
         ]);

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -19,7 +19,6 @@ use App\Http\Requests\Manager\ChapterDeleteRequest;
 use App\Http\Resources\Manager\ChapterShowResource;
 use App\Http\Requests\Manager\ChapterPutStatusRequest;
 use App\Http\Requests\Manager\ChapterPatchStatusRequest;
-use App\Http\Requests\Manager\BulkPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ChapterController extends Controller
@@ -183,40 +182,6 @@ class ChapterController extends Controller
         $chapter->delete();
         return response()->json([
             "result" => true
-        ]);
-    }
-
-    /**
-     * 複数のチャプター公開/非公開API
-     */
-    public function bulkPatchStatus(BulkPatchStatusRequest $request)
-    {
-        // 選択されたchapterを取得
-        $chapters = Chapter::whereIn('id', $request->chapters)->get();
-
-        // $chaptersの中に$course_idと一致しないidが含まれている場合はエラーを返す
-        $courseIdFlg = false;
-        $chapters->map(function ($chapter) use ($request, &$courseIdFlg) {
-            if ($chapter->course_id !== intval($request->course_id)) {
-                $courseIdFlg = true;
-            }
-        });
-        if ($courseIdFlg) {
-            return response()->json([
-                'result' => false,
-            ]);
-        }
-
-        // 該当するchaptersのidをコレクションで取得
-        $chapterIds = $chapters->pluck('id');
-
-        // chaptersのstatusを一括で更新
-        Chapter::whereIn('id', $chapterIds)->update([
-            'status' => $request->status,
-        ]);
-
-        return response()->json([
-            'result' => true,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -191,7 +191,18 @@ class ChapterController extends Controller
      */
     public function bulkPatchStatus(BulkPatchStatusRequest $request, $course_id)
     {
-        return response()->json([]);
+        // 該当するchaptersを取得
+        $chapters = Chapter::where('course_id', $course_id)
+                           ->whereIn('id', $request->chapters);
+
+        // chaptersのstatusを更新
+        $chapters->update([
+            'status' => $request->status,
+        ]);
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**

--- a/app/Http/Requests/Instructor/BulkPatchStatusRequest.php
+++ b/app/Http/Requests/Instructor/BulkPatchStatusRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\Manager;
+namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
 use App\Rules\ChapterStatusRule;

--- a/routes/api.php
+++ b/routes/api.php
@@ -78,6 +78,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::post('/', 'Api\Instructor\ChapterController@store');
                         Route::post('sort', 'Api\Instructor\ChapterController@sort');
                         Route::put('status', 'Api\Instructor\ChapterController@putStatus');
+                        Route::patch('status', 'Api\Instructor\ChapterController@bulkPatchStatus');
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', 'Api\Instructor\ChapterController@show');
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
@@ -173,7 +174,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('sort', 'Api\Manager\ChapterController@sort');
                             Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::put('status', 'Api\Manager\ChapterController@putStatus');
-                            Route::patch('status', 'Api\Manager\ChapterController@bulkPatchStatus');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');
                                 Route::patch('/', 'Api\Manager\ChapterController@update');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-932
- https://gut-familie.atlassian.net/browse/JKA-893

## 概要
- [講師側 チャプター作成画面 選択済チャプターを公開/非公開にするAPI作成](https://gut-familie.atlassian.net/browse/JKA-893)における、ロジックの作成。

## 動作確認手順
- Postmanにて確認
    - HTTTPメソッド：PATCH
    - URL：http://localhost:8080/api/v1/manager/course/:course_id/chapter/status
    - Headers
        - X-XSRF-TOKEN: {{XSRF-TOKEN}}
        - Referer: http://localhost:3000/
        - Origin: http://localhost:3000/
    - Body(row json形式)
        - status: "public" or "private"
        - chapters: [1, 2, 3]
    - Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```

## 考慮して欲しいこと
- 特になし。

## 確認して欲しいこと
- エラーが発生しないこと。
- statusが想定通りに更新されていること。
