### PR TITLE
🈞🈞🈞JKA-924 マネージャー(講師側) チャプター作成画面 選択済チャプターを削除するAPI作成4.フォームリクエストの作成（たまやま）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -210,20 +210,20 @@ class ChapterController extends Controller
             // リクエストから削除するチャプターIDのリストを取得
             $chapterIds = $request->input('chapters', []);
 
-            // リクエストからcourse_idを取得
-            $course_id = $request->input('course_id');
+            // リクエストからcourseIdを取得
+            $courseId = $request->input('course_id');
 
             // 削除対象のチャプターを一度に取得
             $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
 
             // 各チャプターの認可処理
-            $chapters->each(function (Chapter $chapter) use ($instructorIds, $course_id) {
+            $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
                 // 認証された講師（マネージャー）のIDとチャプターに紐づく講師IDが一致しない場合は許可しない
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     throw new ValidationErrorException('Invalid instructor_id.');
                 }
                 // 指定した講座IDがチャプターの講座IDと一致しない場合は許可しない
-                if ((int) $course_id !== $chapter->course_id) {
+                if ((int) $courseId !== $chapter->course_id) {
                     throw new ValidationErrorException('Invalid course.');
                 }
             });

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -6,7 +6,6 @@ use Exception;
 use App\Model\Course;
 use App\Model\Chapter;
 use App\Model\Instructor;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -196,61 +195,47 @@ class ChapterController extends Controller
      */
     public function bulkDelete(ChapterBulkDeleteRequest $request)
     {
-        // 現在認証されている講師（マネージャー）のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
-        // 現在認証されている講師（マネージャー）の情報を取得し、その講師が管理する配下の講師の情報も取得
         $manager = Instructor::with('managings')->find($instructorId);
 
-        // 配下の講師のIDリストを取得し、現在の講師（マネージャー）自身のIDも含める
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
         try {
-            // リクエストから削除するチャプターIDのリストを取得
             $chapterIds = $request->input('chapters', []);
 
-            // リクエストからcourseIdを取得
             $courseId = $request->input('course_id');
 
-            // 削除対象のチャプターを一度に取得
             $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
 
-            // 各チャプターの認可処理
             $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
-                // 認証された講師（マネージャー）のIDとチャプターに紐づく講師IDが一致しない場合は許可しない
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     throw new ValidationErrorException('Invalid instructor_id.');
                 }
-                // 指定した講座IDがチャプターの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $chapter->course_id) {
                     throw new ValidationErrorException('Invalid course.');
                 }
             });
 
-            // トランザクションを開始
             DB::beginTransaction();
-            // バルクデリートを実行
+
             Chapter::whereIn('id', $chapterIds)->delete();
-            // トランザクションをコミット
+
             DB::commit();
-            // 成功レスポンスを返す
+
             return response()->json([
                 'result' => true,
             ]);
         } catch (ValidationErrorException $e) {
-            // バリデーションエラーの場合の処理
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),
             ], 403);
         } catch (Exception $e) {
-            // 一般的なエラーの場合の処理
-            // 例外発生時はトランザクションをロールバックし、エラーログを記録
             DB::rollBack();
             Log::error($e);
 
-            // エラーレスポンスを返す
             return response()->json([
                 'result' => false,
                 'message' => 'Failed to delete chapters.',

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -20,6 +20,7 @@ use App\Http\Requests\Manager\ChapterStoreRequest;
 use App\Http\Requests\Manager\ChapterDeleteRequest;
 use App\Http\Resources\Manager\ChapterShowResource;
 use App\Http\Requests\Manager\ChapterPutStatusRequest;
+use App\Http\Requests\Manager\ChapterbulkDeleteRequest;
 use App\Http\Requests\Manager\ChapterPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -190,11 +191,11 @@ class ChapterController extends Controller
     /**
      * 複数のチャプター削除API
      *
-     * @param Request $request
+     * @param ChapterbulkDeleteRequest $request
      * @param int $course_id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete(Request $request, $course_id)
+    public function bulkDelete(ChapterbulkDeleteRequest $request, $course_id)
     {
         // 現在認証されている講師（マネージャー）のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -214,16 +215,16 @@ class ChapterController extends Controller
             $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
 
             // 各チャプターの認可処理
-                $chapters->each(function (Chapter $chapter) use ($instructorIds, $course_id, $chapterIds) {
+            $chapters->each(function (Chapter $chapter) use ($instructorIds, $course_id, $chapterIds) {
                 // 認証された講師（マネージャー）のIDとチャプターに紐づく講師IDが一致しない場合は許可しない
-                    if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
-                        throw new ValidationErrorException('Invalid instructor_id.');
-                    }
+                if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+                    throw new ValidationErrorException('Invalid instructor_id.');
+                }
                 // 指定した講座IDがチャプターの講座IDと一致しない場合は許可しない
-                    if ((int) $course_id !== $chapter->course_id) {
-                        throw new ValidationErrorException('Invalid course.');
-                    }
-                });
+                if ((int) $course_id !== $chapter->course_id) {
+                    throw new ValidationErrorException('Invalid course.');
+                }
+            });
 
             // トランザクションを開始
             DB::beginTransaction();

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -20,7 +20,7 @@ use App\Http\Requests\Manager\ChapterStoreRequest;
 use App\Http\Requests\Manager\ChapterDeleteRequest;
 use App\Http\Resources\Manager\ChapterShowResource;
 use App\Http\Requests\Manager\ChapterPutStatusRequest;
-use App\Http\Requests\Manager\ChapterbulkDeleteRequest;
+use App\Http\Requests\Manager\ChapterBulkDeleteRequest;
 use App\Http\Requests\Manager\ChapterPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -191,11 +191,10 @@ class ChapterController extends Controller
     /**
      * 複数のチャプター削除API
      *
-     * @param ChapterbulkDeleteRequest $request
-     * @param int $course_id
+     * @param ChapterBulkDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete(ChapterbulkDeleteRequest $request)
+    public function bulkDelete(ChapterBulkDeleteRequest $request)
     {
         // 現在認証されている講師（マネージャー）のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -211,11 +210,14 @@ class ChapterController extends Controller
             // リクエストから削除するチャプターIDのリストを取得
             $chapterIds = $request->input('chapters', []);
 
+            // リクエストからcourse_idを取得
+            $course_id = $request->input('course_id');
+
             // 削除対象のチャプターを一度に取得
             $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
 
             // 各チャプターの認可処理
-            $chapters->each(function (Chapter $chapter) use ($instructorIds, $course_id, $chapterIds) {
+            $chapters->each(function (Chapter $chapter) use ($instructorIds, $course_id) {
                 // 認証された講師（マネージャー）のIDとチャプターに紐づく講師IDが一致しない場合は許可しない
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     throw new ValidationErrorException('Invalid instructor_id.');

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -195,7 +195,7 @@ class ChapterController extends Controller
      * @param int $course_id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete(ChapterbulkDeleteRequest $request, $course_id)
+    public function bulkDelete(ChapterbulkDeleteRequest $request)
     {
         // 現在認証されている講師（マネージャー）のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Requests/Manager/ChapterBulkDeleteRequest.php
+++ b/app/Http/Requests/Manager/ChapterBulkDeleteRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\Manager;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class ChapterbulkDeleteRequest extends FormRequest
+class ChapterBulkDeleteRequest extends FormRequest
 {
     public function authorize()
     {

--- a/app/Http/Requests/Manager/ChapterBulkDeleteRequest.php
+++ b/app/Http/Requests/Manager/ChapterBulkDeleteRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChapterbulkDeleteRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapters' => ['required', 'array'],
+            'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}


### PR DESCRIPTION
## タスク
- Closes #609

## 概要
- **4.フォームリクエストの作成**
- **※3.ロジックの作成を一部修正**
ゆきひろさん指摘のインデントを一部修正しております。
`app/Http/Controllers/Api/Manager/ChapterController.php`
218行目～227行目

## 動作確認手順

**1. Postmanでマネージャー権限のあるinstructorでログイン**
- `database/seeds/InstructorSeeder.php`
`'type' => 'manager'`のinstructorを選ぶ

**2. Postmanにて下記を入力**
- URL
`http://localhost:8080/api/v1/manager/course/:{course_id}/chapter`

- リクエスト
`DELETE`

- リクエストボディ
RAW　JSON
```
{
    "chapters": [1, 2, 3]
}
```
- パラメーター
`{course_id}`の値をテスト的に入力（下記スクリーンショット参照）

- レスポンス（{course_id}が999の時）
![スクリーンショット 2024-07-14 232821](https://github.com/user-attachments/assets/78d99380-41e4-468c-ae0c-def667f157a9)
- レスポンス（{course_id}がaの時）
![スクリーンショット 2024-07-14 230235](https://github.com/user-attachments/assets/b852b913-73d2-4ae9-83c7-2545c47764d6)
- レスポンス（{course_id}が1でありdeleted_at が NULLでない時）
![スクリーンショット 2024-07-14 234257](https://github.com/user-attachments/assets/02478a4f-eef4-47dd-891a-1e3e9610c9f0)
![スクリーンショット 2024-07-14 234454](https://github.com/user-attachments/assets/ac9b3ea0-7309-4a81-907c-e7b2a89e728c)

削除テストの為、途中`php artisan migrate:fresh --seed`を入力しテスト実施。
期待するレスポンスがそれぞれ返ってくることを確認

## 考慮して欲しいこと
- 特になし
## 確認して欲しいこと
- 特になし