### PR TITLE
JKA-945 マネージャーと配下のinstructorの講座情報のみにアクセスできるロジックの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -176,7 +176,6 @@ class AttendanceController extends Controller
                 'message' => "Forbidden, not allowed to access this course.",
             ], 403);
         }
- 
 
         // 今月完了したレッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -157,7 +157,7 @@ class AttendanceController extends Controller
     public function showStatusThisMonth(Request $request): JsonResponse
     {
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
-         
+
         //現在ログインしているinstructorのidを取得
         $instructorId = Auth::guard('instructor')->user()->id;
         //ログインしているインストラクターとその管理しているインストラクターを取得
@@ -165,11 +165,10 @@ class AttendanceController extends Controller
         //管理しているインストラクターのIDを配列として取得し、自分自身のIDも追加
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
-        
+
         //自分と配下のinstructorのコースでなければエラー応答
         $course = Course::findOrFail($request->course_id);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
-            
             // エラー応答
             return response()->json([
                 'result'  => false,


### PR DESCRIPTION
## task
- jka-945
## 概要
- マネージャーと配下のinstructorの講座情報のみにアクセスできるロジックの作成
## 動作確認手順
- Postmanでマネージャー権限のあるinstructorでログイン
- Postmanで下記を入力
URL
[http://localhot:8080/api/v1/manager/course/{course_id}/attendance/status/this-month]
リクエスト
GET
Headers
Key→Referer, Origin
Value→http://localhost:3000/
- Postmanに正しいデータが返ってくることを確認
## 確認して欲しいこと
- 一つ前のタスクでインデントの修正をしていない箇所があったのでこちらで修正しています