### PR TITLE
JKA-815 講師側（マネージャー側）受講生詳細画面の学習状況API レスポンス整形のリソースファイル作成(とさか)

### DIFF
--- a/app/Http/Resources/Instructor/AttendanceStatusResource.php
+++ b/app/Http/Resources/Instructor/AttendanceStatusResource.php
@@ -21,17 +21,15 @@ class AttendanceStatusResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'data' => [
-                'attendance_id' => $this->resource->id,
-                'progress' => $this->resource->progress,
-                'course' => [
-                    'course_id' => $this->resource->course->id,
-                    'title' => $this->resource->course->title,
-                    'status' => $this->resource->course->status,
-                    'image' => $this->resource->course->image,
-                    'chapters' => $this->mapChapters($this->resource->course->chapters),
+            'progress' => $this->resource->progress,
+            'attendance_id' => $this->resource->id,
+            'course_id' => $this->resource->course->id,
+            'course' => [
+                'status' => $this->resource->course->status,
+                'image' => $this->resource->course->image,
+                'chapters' => $this->mapChapters($this->resource->course->chapters),
+                'title' => $this->resource->course->title,
                 ],
-            ],
         ];
     }
 

--- a/app/Http/Resources/Instructor/AttendanceStatusResource.php
+++ b/app/Http/Resources/Instructor/AttendanceStatusResource.php
@@ -21,15 +21,15 @@ class AttendanceStatusResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'progress' => $this->resource->progress,
             'attendance_id' => $this->resource->id,
-            'course_id' => $this->resource->course->id,
+            'progress' => $this->resource->progress,
             'course' => [
+                'course_id' => $this->resource->course->id,
                 'status' => $this->resource->course->status,
                 'image' => $this->resource->course->image,
                 'chapters' => $this->mapChapters($this->resource->course->chapters),
                 'title' => $this->resource->course->title,
-                ],
+            ],
         ];
     }
 

--- a/app/Http/Resources/Manager/AttendanceStatusResource.php
+++ b/app/Http/Resources/Manager/AttendanceStatusResource.php
@@ -25,10 +25,10 @@ class AttendanceStatusResource extends JsonResource
             'progress' => $this->resource->progress,
             'course' => [
                 'course_id' => $this->resource->course->id,
-                'title' => $this->resource->course->title,
                 'status' => $this->resource->course->status,
                 'image' => $this->resource->course->image,
                 'chapters' => $this->mapChapters($this->resource->course->chapters),
+                'title' => $this->resource->course->title,
             ],
         ];
     }

--- a/app/Http/Resources/Manager/AttendanceStatusResource.php
+++ b/app/Http/Resources/Manager/AttendanceStatusResource.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use App\Model\Chapter;
+use App\Model\Attendance;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AttendanceStatusResource extends JsonResource
+{
+    /** @var Attendance */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'data' => [
+                'attendance_id' => $this->resource->id,
+                'progress' => $this->resource->progress,
+                'course' => [
+                    'course_id' => $this->resource->course->id,
+                    'title' => $this->resource->course->title,
+                    'status' => $this->resource->course->status,
+                    'image' => $this->resource->course->image,
+                    'chapters' => $this->mapChapters($this->resource->course->chapters),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Calculate chapter progress
+     *
+     * @param Collection $chapters
+     * @return array
+     */
+    private function mapChapters(Collection $chapters)
+    {
+        return $chapters->map(function (Chapter $chapter) {
+            $chapterProgress = $chapter->calculateChapterProgress($this->resource);
+            return [
+                'chapter_id' => $chapter->id,
+                'title' => $chapter->title,
+                'status' => $chapter->status,
+                'progress' => $chapterProgress,
+            ];
+        })
+        ->toArray();
+    }
+}

--- a/app/Http/Resources/Manager/AttendanceStatusResource.php
+++ b/app/Http/Resources/Manager/AttendanceStatusResource.php
@@ -21,16 +21,14 @@ class AttendanceStatusResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'data' => [
-                'attendance_id' => $this->resource->id,
-                'progress' => $this->resource->progress,
-                'course' => [
-                    'course_id' => $this->resource->course->id,
-                    'title' => $this->resource->course->title,
-                    'status' => $this->resource->course->status,
-                    'image' => $this->resource->course->image,
-                    'chapters' => $this->mapChapters($this->resource->course->chapters),
-                ],
+            'attendance_id' => $this->resource->id,
+            'progress' => $this->resource->progress,
+            'course' => [
+                'course_id' => $this->resource->course->id,
+                'title' => $this->resource->course->title,
+                'status' => $this->resource->course->status,
+                'image' => $this->resource->course->image,
+                'chapters' => $this->mapChapters($this->resource->course->chapters),
             ],
         ];
     }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-946

## 概要
- 講師側（マネージャー側）受講生詳細画面の学習状況を取得するAPIを作成　子課題
 4.レスポンス整形のリソースファイル作成

## 動作確認手順
- ポストマンのGETリクエストで/api/v1/instructor/attendance/{attendance_id}/statusを実行
{attendance_id}　に1を入れると下記が返る
manajerも同じレスポンスが返ることを確認済み

レスポンス
```
{
    "data": {
        "attendance_id": 1,
        "progress": 10,
        "course": {
            "course_id": 1,
            "title": "PHP入門講座",
            "status": "public",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "chapters": [
                {
                    "chapter_id": 1,
                    "title": "PHPとは？",
                    "status": "public",
                    "progress": 100
                },
                {
                    "chapter_id": 2,
                    "title": "PHPの基礎を学ぼう",
                    "status": "public",
                    "progress": 25
                },
                {
                    "chapter_id": 3,
                    "title": "PHPの応用にチャレンジしよう",
                    "status": "public",
                    "progress": 0
                }
            ]
        }
    }
}
```

{attendance_id}　に存在しない50やnを入れても、instructor、manajerも同じレスポンスが返ることを確認済み


## 考慮してほしいこと
- 今回は特にありません。

## 確認してほしいこと
- 今回は特にありません。