### PR TITLE
Topic/jka 884/topic/manager dashboard daily lessons completion

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -13,9 +13,9 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\Manager\AttendanceShowRequest;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
-use App\Http\Requests\Manager\AttendanceShowRequest;
 
 class AttendanceController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -12,7 +12,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-// use App\Http\Requests\Instructor\AttendanceShowRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -164,7 +164,7 @@ class AttendanceController extends Controller
         //自分と配下のnstructorのコースでなければエラー応答
         $course = Course::FindOrFail($request->course_id);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
-            // Error response 
+            // Error response
             return response()->json([
                 'result'  => false,
                 'message' => "Forbidden, not allowed to edit this course.",

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -152,27 +152,14 @@ class AttendanceController extends Controller
     {
         //変数にAttendanceのリレーションをロードし、course_idがリクエストのcourse_idと一致するものを取得
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
-        // dd($attendances);
-        //デバッグするため記述
-        // $attendances->each(function (Attendance $attendance) {
-        //     $attendance->lessonAttendances->each(function (LessonAttendance $lessonAttendance) {
-        //         if ($lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday()) {
-        //             dd($lessonAttendance);
-        //         }
-        //     });
-        // });
-
         // 今日完了したレッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
             $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
-                return $lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday();
+                return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $lessonAttendance->updated_at->isToday();
             });
-            //デバッグするため記述
-            // dd($compleatedLessonAttendances);
             return $compleatedLessonAttendances;
         });
         $completedLessonsCount = $completedLessonsCount->count();
-        //dd($completedLessonsCount);
         return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -146,7 +146,8 @@ class AttendanceController extends Controller
     /**
      * 本日のレッスン・チャプター完了数の取得API
      *
-     *
+     * @param AttendanceShowRequest $request
+     * @return \Illuminate\Http\JsonResponse
      */
     public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -150,8 +150,29 @@ class AttendanceController extends Controller
      */
     public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {
-        $attendancd = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
-        dd($attendancd);
-        // return response()->json([]);
+        //変数にAttendanceのリレーションをロードし、course_idがリクエストのcourse_idと一致するものを取得
+        $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+        // dd($attendances);
+        //デバッグするため記述
+        // $attendances->each(function (Attendance $attendance) {
+        //     $attendance->lessonAttendances->each(function (LessonAttendance $lessonAttendance) {
+        //         if ($lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday()) {
+        //             dd($lessonAttendance);
+        //         }
+        //     });
+        // });
+
+        // 今日完了したレッスンの個数を取得
+        $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
+            $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
+                return $lessonAttendance->status === 'completed_attendance' && $lessonAttendance->updated_at->isToday();
+            });
+            //デバッグするため記述
+            // dd($compleatedLessonAttendances);
+            return $compleatedLessonAttendances;
+        });
+        $completedLessonsCount = $completedLessonsCount->count();
+        //dd($completedLessonsCount);
+        return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
+use Composer\DependencyResolver\Request;
 
 class AttendanceController extends Controller
 {
@@ -140,5 +141,14 @@ class AttendanceController extends Controller
                 'result' => false,
             ], 500);
         }
+    }
+    /** 
+     * 完了済みレッスン数と完了済みチャプター数を取得するAPI
+     * 
+     * 
+     */
+    public function showStatus()
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -162,12 +162,12 @@ class AttendanceController extends Controller
         //instructorIdsにinstructor_idを追加
         $instructorIds[] = $instructorId;
         //自分と配下のnstructorのコースでなければエラー応答
-        $course = Course::FindOrFail($request->course_id);
+        $course = Course::findOrFail($request->course_id);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
             // Error response 
             return response()->json([
                 'result'  => false,
-                'message' => "Forbidden, not allowed to edit this course.",
+                'message' => "Forbidden, not allowed to access this course.",
             ], 403);
         }
 
@@ -207,7 +207,6 @@ class AttendanceController extends Controller
             ->count();
 
         return response()->json([
-            'coures' => $course,
             'completed_lessons_conut' => $completedLessonsCount,
             'completed_chapters_count' => $completedChaptersCount
         ]);

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -152,6 +152,25 @@ class AttendanceController extends Controller
     {
         //変数にAttendanceのリレーションをロードし、course_idがリクエストのcourse_idと一致するものを取得
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+
+        //変数にAuthのguardを使用して現在ログインしているinstructorのidを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        //instructor_idをキーにしてmanagingsリレーションをロードし、instructor_idが一致するものを取得
+        $manager = Instructor::with('managings')->find($instructorId);
+        //managingsリレーションのidを取得
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        //instructorIdsにinstructor_idを追加
+        $instructorIds[] = $instructorId;
+        //自分と配下のnstructorのコースでなければエラー応答
+        $course = Course::FindOrFail($request->course_id);
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
+            // Error response 
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to edit this course.",
+            ], 403);
+        }
+
         // 今日完了したレッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) {
             $compleatedLessonAttendances = $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) {
@@ -188,6 +207,7 @@ class AttendanceController extends Controller
             ->count();
 
         return response()->json([
+            'coures' => $course,
             'completed_lessons_conut' => $completedLessonsCount,
             'completed_chapters_count' => $completedChaptersCount
         ]);

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -174,9 +174,7 @@ class AttendanceController extends Controller
                     ->whereIn('lesson_id', $allLessonsId)
                     ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
                     ->count();
-                // dd($compleatedLessonsCount);ここで、最新レッスンの完了済みを取得できているか確認
                 return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $compleatedLessonsCount;
-                // dd($compleatedLessonsCount);ここで更新日時が表であるかどうか確認
             })
             //ユニークなチャプターID取得と出席のIDを取得
             ->map(function (LessonAttendance $lessonAttendance) {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -142,10 +142,10 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
-    /** 
+    /**
      * 完了済みレッスン数と完了済みチャプター数を取得するAPI
-     * 
-     * 
+     *
+     *
      */
     public function showStatus()
     {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -15,7 +15,6 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
-use Composer\DependencyResolver\Request;
 
 class AttendanceController extends Controller
 {
@@ -142,12 +141,13 @@ class AttendanceController extends Controller
             ], 500);
         }
     }
+
     /** 
-     * 完了済みレッスン数と完了済みチャプター数を取得するAPI
+     * 本日のレッスン・チャプター完了数の取得API
      * 
      * 
      */
-    public function showStatus()
+    public function showStatusToday()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -142,10 +142,10 @@ class AttendanceController extends Controller
         }
     }
 
-    /** 
+    /**
      * 本日のレッスン・チャプター完了数の取得API
-     * 
-     * 
+     *
+     *
      */
     public function showStatusToday()
     {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -17,7 +17,6 @@ use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
 use App\Http\Requests\Manager\AttendanceShowRequest;
 
-
 class AttendanceController extends Controller
 {
     /**

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -12,10 +12,12 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\AttendanceShowRequest;
+// use App\Http\Requests\Instructor\AttendanceShowRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
+use App\Http\Requests\Manager\AttendanceShowRequest;
+
 
 class AttendanceController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\AttendanceShowRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
@@ -147,8 +148,10 @@ class AttendanceController extends Controller
      *
      *
      */
-    public function showStatusToday()
+    public function showStatusToday(AttendanceShowRequest $request): JsonResponse
     {
-        return response()->json([]);
+        $attendancd = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+        dd($attendancd);
+        // return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -158,37 +158,8 @@ class AttendanceController extends Controller
                 return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $lessonAttendance->updated_at->isToday();
             });
             return $compleatedLessonAttendances;
-        })->count();
-
-        //今日完了したチャプターの個数を取得
-        $completedChaptersCount = $attendances->flatMap(function (Attendance $attendance) {
-            return $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
-            dd($completedChaptersCount);
         })
-
-            ->filter(function (LessonAttendance $lessonAttendance) {
-                //チャプターに含まれているレッスンが完了されているかつ、最新のレッスンの完了済みステータスへの更新日が当日の日時で絞り込む
-                $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
-                $totalLessonsCount = $allLessonsId->count();
-                $completedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
-                    ->whereIn('lesson_id', $allLessonsId)
-                    ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
-                    ->count();
-                return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $completedLessonsCount;
-            })
-            ->map(function (LessonAttendance $lessonAttendance) {
-                //chapter_idとattendance_idをkeyにもつ配列を作成
-                return [
-                    'chapter_id' => $lessonAttendance->lesson->chapter->id,
-                    'attendance_id' => $lessonAttendance->attendance_id
-                ];
-            })
-            ->unique()
             ->count();
-        // $completedLessonsCount = $completedLessonsCount->count();
-        return response()->json([
-            'completed_lessons_conut' => $completedLessonsCount,
-            'completed_chapters_count' => $completedChaptersCount
-        ]);
+        return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -158,8 +158,37 @@ class AttendanceController extends Controller
                 return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $lessonAttendance->updated_at->isToday();
             });
             return $compleatedLessonAttendances;
-        });
-        $completedLessonsCount = $completedLessonsCount->count();
-        return response()->json(['completed_lessons_conut' => $completedLessonsCount]);
+        })->count();
+
+        //今日完了したチャプターの個数を取得
+        $completedChaptersCount = $attendances->flatMap(function (Attendance $attendance) {
+            return $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE);
+            dd($completedChaptersCount);
+        })
+
+            ->filter(function (LessonAttendance $lessonAttendance) {
+                //チャプターに含まれているレッスンが完了されているかつ、最新のレッスンの完了済みステータスへの更新日が当日の日時で絞り込む
+                $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
+                $totalLessonsCount = $allLessonsId->count();
+                $completedLessonsCount = $lessonAttendance->where('attendance_id', $lessonAttendance->attendance_id)
+                    ->whereIn('lesson_id', $allLessonsId)
+                    ->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE)
+                    ->count();
+                return $lessonAttendance->updated_at->isToday() && $totalLessonsCount === $completedLessonsCount;
+            })
+            ->map(function (LessonAttendance $lessonAttendance) {
+                //chapter_idとattendance_idをkeyにもつ配列を作成
+                return [
+                    'chapter_id' => $lessonAttendance->lesson->chapter->id,
+                    'attendance_id' => $lessonAttendance->attendance_id
+                ];
+            })
+            ->unique()
+            ->count();
+        // $completedLessonsCount = $completedLessonsCount->count();
+        return response()->json([
+            'completed_lessons_conut' => $completedLessonsCount,
+            'completed_chapters_count' => $completedChaptersCount
+        ]);
     }
 }

--- a/app/Http/Requests/Manager/AttendanceShowRequest.php
+++ b/app/Http/Requests/Manager/AttendanceShowRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -195,11 +195,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         });
 
                         //マネージャー生徒学習状況
-                        Route::prefix('attendance')->group(
-                            function () {
-                                Route::get('status/{period}', 'Api\Manager\AttendanceController@showStatus');
-                            }
-                        );
+                        Route::prefix('attendance/status')->group(function () {
+                            Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                        });
                     });
                     // マネージャー-受講
                     Route::prefix('attendance')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -193,7 +193,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('notification')->group(function () {
                             Route::post('/', 'Api\Manager\NotificationController@store');
                         });
-
                         //マネージャー生徒学習状況
                         Route::prefix('attendance/status')->group(function () {
                             Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');

--- a/routes/api.php
+++ b/routes/api.php
@@ -194,8 +194,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('/', 'Api\Manager\NotificationController@store');
                         });
                         //マネージャー生徒学習状況
-                        Route::prefix('attendance/status')->group(function () {
-                            Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                        Route::prefix('attendance')->group(function () {
+                            Route::prefix('status')->group(function () {
+                                Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                            });
                         });
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -193,50 +193,57 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('notification')->group(function () {
                             Route::post('/', 'Api\Manager\NotificationController@store');
                         });
+
+                        //マネージャー生徒学習状況
+                        Route::prefix('attendance')->group(
+                            function () {
+                                Route::get('status/{period}', 'Api\Manager\AttendanceController@showStatus');
+                            }
+                        );
                     });
-                });
-                // マネージャー-受講
-                Route::prefix('attendance')->group(function () {
-                    Route::post('/', 'Api\Manager\AttendanceController@store');
-                    Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
-                });
-                Route::prefix('instructor')->group(function () {
-                });
-                // マネージャー-生徒
-                Route::prefix('student')->group(function () {
-                    Route::get('{student_id}', 'Api\Manager\StudentController@show');
-                    Route::post('/', 'Api\Manager\StudentController@store');
-                });
-                // マネージャー-お知らせ
-                Route::prefix('notification')->group(function () {
-                    Route::get('index', 'Api\Manager\NotificationController@index');
-                    Route::prefix('{notification_id}')->group(function () {
-                        Route::get('/', 'Api\Manager\NotificationController@show');
-                        Route::patch('/', 'Api\Manager\NotificationController@update');
-                        Route::delete('/', 'Api\Manager\NotificationController@delete');
+                    // マネージャー-受講
+                    Route::prefix('attendance')->group(function () {
+                        Route::post('/', 'Api\Manager\AttendanceController@store');
+                        Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
                     });
-                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
+                    Route::prefix('instructor')->group(function () {
+                    });
+                    // マネージャー-生徒
+                    Route::prefix('student')->group(function () {
+                        Route::get('{student_id}', 'Api\Manager\StudentController@show');
+                        Route::post('/', 'Api\Manager\StudentController@store');
+                    });
+                    // マネージャー-お知らせ
+                    Route::prefix('notification')->group(function () {
+                        Route::get('index', 'Api\Manager\NotificationController@index');
+                        Route::prefix('{notification_id}')->group(function () {
+                            Route::get('/', 'Api\Manager\NotificationController@show');
+                            Route::patch('/', 'Api\Manager\NotificationController@update');
+                            Route::delete('/', 'Api\Manager\NotificationController@delete');
+                        });
+                        Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
+                    });
                 });
             });
         });
     });
-});
 
-Route::prefix('v1')->group(function () {
-    Route::prefix('student')->group(function () {
-        Route::post('/', 'Api\Student\StudentController@store');
-        Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
+    Route::prefix('v1')->group(function () {
+        Route::prefix('student')->group(function () {
+            Route::post('/', 'Api\Student\StudentController@store');
+            Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
+        });
     });
-});
 
-// 講師側API
-Route::prefix('v1')->group(function () {
-    Route::prefix('instructor')->group(function () {
-        Route::prefix('notification')->group(function () {
-            Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
-            Route::prefix('{notification_id}')->group(function () {
-                Route::get('/', 'Api\Instructor\NotificationController@show');
-                Route::patch('/', 'Api\Instructor\NotificationController@update');
+    // 講師側API
+    Route::prefix('v1')->group(function () {
+        Route::prefix('instructor')->group(function () {
+            Route::prefix('notification')->group(function () {
+                Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
+                Route::prefix('{notification_id}')->group(function () {
+                    Route::get('/', 'Api\Instructor\NotificationController@show');
+                    Route::patch('/', 'Api\Instructor\NotificationController@update');
+                });
             });
         });
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -198,49 +198,49 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
                         });
                     });
-                    // マネージャー-受講
-                    Route::prefix('attendance')->group(function () {
-                        Route::post('/', 'Api\Manager\AttendanceController@store');
-                        Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
+                });
+                // マネージャー-受講
+                Route::prefix('attendance')->group(function () {
+                    Route::post('/', 'Api\Manager\AttendanceController@store');
+                    Route::delete('{attendance_id}', 'Api\Manager\AttendanceController@delete');
+                });
+                Route::prefix('instructor')->group(function () {
+                });
+                // マネージャー-生徒
+                Route::prefix('student')->group(function () {
+                    Route::get('{student_id}', 'Api\Manager\StudentController@show');
+                    Route::post('/', 'Api\Manager\StudentController@store');
+                });
+                // マネージャー-お知らせ
+                Route::prefix('notification')->group(function () {
+                    Route::get('index', 'Api\Manager\NotificationController@index');
+                    Route::prefix('{notification_id}')->group(function () {
+                        Route::get('/', 'Api\Manager\NotificationController@show');
+                        Route::patch('/', 'Api\Manager\NotificationController@update');
+                        Route::delete('/', 'Api\Manager\NotificationController@delete');
                     });
-                    Route::prefix('instructor')->group(function () {
-                    });
-                    // マネージャー-生徒
-                    Route::prefix('student')->group(function () {
-                        Route::get('{student_id}', 'Api\Manager\StudentController@show');
-                        Route::post('/', 'Api\Manager\StudentController@store');
-                    });
-                    // マネージャー-お知らせ
-                    Route::prefix('notification')->group(function () {
-                        Route::get('index', 'Api\Manager\NotificationController@index');
-                        Route::prefix('{notification_id}')->group(function () {
-                            Route::get('/', 'Api\Manager\NotificationController@show');
-                            Route::patch('/', 'Api\Manager\NotificationController@update');
-                            Route::delete('/', 'Api\Manager\NotificationController@delete');
-                        });
-                        Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
-                    });
+                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
                 });
             });
         });
     });
+});
 
-    Route::prefix('v1')->group(function () {
-        Route::prefix('student')->group(function () {
-            Route::post('/', 'Api\Student\StudentController@store');
-            Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
-        });
+Route::prefix('v1')->group(function () {
+    Route::prefix('student')->group(function () {
+        Route::post('/', 'Api\Student\StudentController@store');
+        Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
     });
+});
 
-    // 講師側API
-    Route::prefix('v1')->group(function () {
-        Route::prefix('instructor')->group(function () {
-            Route::prefix('notification')->group(function () {
-                Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
-                Route::prefix('{notification_id}')->group(function () {
-                    Route::get('/', 'Api\Instructor\NotificationController@show');
-                    Route::patch('/', 'Api\Instructor\NotificationController@update');
-                });
+// 講師側API
+Route::prefix('v1')->group(function () {
+    Route::prefix('instructor')->group(function () {
+        Route::prefix('notification')->group(function () {
+            Route::put('type/{notification_type}', 'Api\Instructor\NotificationController@updateType');
+            Route::prefix('{notification_id}')->group(function () {
+                Route::get('/', 'Api\Instructor\NotificationController@show');
+                Route::patch('/', 'Api\Instructor\NotificationController@update');
             });
         });
     });


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-884

## 概要
- マネージャー側 ダッシュボード 本日のレッスン・チャプター完了数 取得API

## 動作確認手順
1.Postmanでマネージャー権限のあるinstructorでログイン

2.Postmanで下記を入力
```URL```
[http://localhot:8080//api/v1/manager/course/{course_id}/attendance/status/today](http://localhot:8080//api/v1/manager/course/%7Bcourse_id%7D/attendance/status/today)
リクエスト
```GET```

Headers
```Key``` Referer, Origin
```Value``` http://localhost:3000/
3.Postmanにデータが返ってくるを確認しました

子タスクを全てマージした上で、正しい値が返ってくることを確認(コンフリクト解消後も確認済み)

## 考慮して欲しいこと


## 確認して欲しい事
コンフリクトが起きたので、修正してみたが解消されず、、、
なので、元のプルリクを停止し
新たにこのプルリクを作成しましたが、問題なかったでしょうか？
