### PR TITLE
JKA-938講師側レッスン選択削除空配列を返すルータ、コントローラの作成(シンタロウ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -164,7 +164,8 @@ class LessonController extends Controller
         }
     }
 
-    public function bulkDelete(){
+    public function bulkDelete()
+    {
         return response()->json([]);
     }
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -164,6 +164,10 @@ class LessonController extends Controller
         }
     }
 
+    public function bulkDelete(){
+        return response()->json([]);
+    }
+
     /**
      * レッスンステータス更新API
      *

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,7 +83,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
                             Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                             Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                            Route::delete('lessons', 'Api\Instructor\LessonController@bulkDelete');
+                            Route::delete('lesson', 'Api\Instructor\LessonController@bulkDelete');
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,6 +83,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
                             Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                             Route::delete('/', 'Api\Instructor\ChapterController@delete');
+                            Route::delete('lessons', 'Api\Instructor\LessonController@bulkDelete');
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,12 +83,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
                             Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                             Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                            Route::delete('lesson', 'Api\Instructor\LessonController@bulkDelete');
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::put('status', 'Api\Instructor\LessonController@putStatus');
+                                Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-897
- https://gut-familie.atlassian.net/browse/JKA-938

## 概要
- 講師側 チャプター作成画面 選択済レッスンを削除するAPI作成タスクの子タスク、空の配列を返すルーターとコントローラーの作成しました。

## 動作確認手順
- postmanを使ってインストラクターでログイン後http://localhost:8080/api/v1/instructor/course/1/chapter/1/lessons
にアクセスし、空の配列が返って来たのを確認しました。