### PR TITLE
JKA-954マネージャー側（講師） 講師一覧APIの作成 1.空の配列を返すルーターとコントローラの作成 （たまやま）

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -46,6 +46,16 @@ class InstructorController extends Controller
     }
 
     /**
+     * 講師一覧取得API
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        return response()->json([]);
+    }
+    
+    /**
      * 講師更新API
      *
      * @param InstructorPatchRequest $request

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -54,7 +54,7 @@ class InstructorController extends Controller
     {
         return response()->json([]);
     }
-    
+
     /**
      * 講師更新API
      *

--- a/routes/api.php
+++ b/routes/api.php
@@ -146,6 +146,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('manager')->group(function () {
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {
+                    Route::get('index', 'Api\Manager\Instructor\InstructorController@index');
                     Route::prefix('{instructor_id}')->group(function () {
                         Route::get('/', 'Api\Manager\Instructor\InstructorController@show');
                         Route::post('/', 'Api\Manager\Instructor\InstructorController@update');


### PR DESCRIPTION
## タスク
- Closes #623
- https://gut-familie.atlassian.net/browse/JKA-954

## 概要
- **1.空の配列を返すルーターとコントローラの作成**

## 動作確認手順

**1. Postmanでマネージャー権限のあるinstructorでログイン**
- `database/seeds/InstructorSeeder.php`
`'type' => 'manager'`のinstructorを選ぶ

**2. Postmanにて下記を入力**
- URL
http://localhost:8080/api/v1/manager/instructor/index
- リクエスト
GET
- リクエストボディ
無し
- パラメーター
無し
- ヘッダー
キー→`Referer`　値→`http://localhost:3000`
キー→`Origin`　値→`http://localhost:3000`
- Pre-request Script にスクリプトを記述
- レスポンス
[] 
空の配列が返ってくることを確認
![スクリーンショット 2024-07-21 184259](https://github.com/user-attachments/assets/11dcb55f-344c-475f-980f-58aaeff3723a)


## 考慮して欲しいこと
- 1回目プルリク提出時は失礼しました。ファイル2つの変更のみを確認しました。
## 確認して欲しいこと
- 特になし