### PR TITLE
JKA-949 空の配列を返すルーターとコントローラの作成(Tokeshi)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -340,7 +340,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスンステータス一括更新API
      * 
-     * @param 
+     * @param LssonUpdateStatusRequest $request
      * @return JsonResponse
      */
     public function updateStatus()

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -339,11 +339,11 @@ class LessonController extends Controller
 
     /**
      * 選択済みレッスンステータス一括更新API
-     * 
-     * @param 
+     *
+     * @param LessonUpdateStatusRequest $request
      * @return JsonResponse
      */
-    public function updateStatus()
+    public function putStatus(): JsonResponse
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -339,8 +339,8 @@ class LessonController extends Controller
 
     /**
      * 選択済みレッスンステータス一括更新API
-     * 
-     * @param 
+     *
+     * @param
      * @return JsonResponse
      */
     public function updateStatus()

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -340,11 +340,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスンステータス一括更新API
      *
-<<<<<<< HEAD
-     * @param LessonUpdateStatusRequest $request
-=======
      * @param
->>>>>>> c91a9bd19e7769ce54a47f5a1da83ce7af9fae7c
      * @return JsonResponse
      */
     public function putStatus(): JsonResponse

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -340,7 +340,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスンステータス一括更新API
      * 
-     * @param LssonUpdateStatusRequest $request
+     * @param 
      * @return JsonResponse
      */
     public function updateStatus()

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -336,4 +336,15 @@ class LessonController extends Controller
             'result' => true,
         ]);
     }
+
+    /**
+     * 選択済みレッスンステータス一括更新API
+     * 
+     * @param 
+     * @return JsonResponse
+     */
+    public function updateStatus()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -183,6 +183,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
+                                    //my task
+                                    Route::patch('status', 'Api\Manager\LessonController@updateStatus');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -183,7 +183,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
-                                    Route::put('status', 'Api\Manager\LessonController@updateStatus');
+                                    Route::put('status', 'Api\Manager\LessonController@putStatus');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -183,7 +183,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
-                                    Route::patch('status', 'Api\Manager\LessonController@updateStatus');
+                                    Route::put('status', 'Api\Manager\LessonController@updateStatus');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -183,7 +183,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
-                                    //my task
                                     Route::patch('status', 'Api\Manager\LessonController@updateStatus');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-949

##概要
-JKA-949 空の配列を返すルーターとコントローラの作成
-
-

## 動作確認手順
- Postmanにて確認
- HTTPメソッド: ```PUT ```
- URL:```/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/status```
- Headers
X-XSRF-TOKEN:```{{XSRF-TOKEN}}```
Referer:```http://localhost :3000/```
Origin:```http://localhost :3000/```
- Body
status: "public" or "private"
lessons:[1,2,3,4,5]
- Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```


## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- Postmanに記述するコード類が正しいものであるかどうか