### PR TITLE
JKA-965 空の配列を返すルーターとコントローラの作成（ゆうへい）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -220,6 +220,16 @@ class ChapterController extends Controller
     }
 
     /**
+     * 選択済チャプターの削除API
+     *
+     * @return JsonResponse
+     */
+    public function bulkDelete(): JsonResponse
+    {
+        return response()->json([]);
+    }
+
+    /**
      * チャプター削除API
      *
      * @param ChapterDeleteRequest $request

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::post('sort', 'Api\Instructor\ChapterController@sort');
                         Route::put('status', 'Api\Instructor\ChapterController@putStatus');
                         Route::patch('status', 'Api\Instructor\ChapterController@bulkPatchStatus');
+                        Route::delete('/', 'Api\Instructor\ChapterController@bulkDelete');
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', 'Api\Instructor\ChapterController@show');
                             Route::patch('/', 'Api\Instructor\ChapterController@update');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-965
- https://gut-familie.atlassian.net/browse/JKA-895

## 概要
- [講師側 チャプター作成画面 選択済チャプターを削除するAPI作成](https://gut-familie.atlassian.net/browse/JKA-895)における、空の配列を返すルーターとコントローラの作成。

## 動作確認手順
- Postmanにて確認
    - HTTTPメソッド：DELETE
    - URL：http://localhost:8080/api/v1/instructor/course/:course_id/chapter
    - Headers
        - X-XSRF-TOKEN: {{XSRF-TOKEN}}
        - Referer: http://localhost:3000/
        - Origin: http://localhost:3000/
    - Body(row json形式)
        - chapters: [1, 2, 3]
    - Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```

## 考慮して欲しいこと
- 特になし。

## 確認して欲しいこと
- エラーが発生しないこと。
- 空配列が返ること。
