### PR TITLE
JKA-971 ロジックの作成（ゆうへい）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -249,7 +249,7 @@ class ChapterController extends Controller
                 }
             });
 
-            // チャプターの状態を一括で削除
+            // チャプターを一括で削除
             Chapter::whereIn('id', $chapters->pluck('id'))->delete();
 
             return response()->json([
@@ -267,8 +267,6 @@ class ChapterController extends Controller
                 'message' => $e->getMessage(),
             ]);
         }
-
-        return response()->json([]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -226,6 +226,48 @@ class ChapterController extends Controller
      */
     public function bulkDelete(): JsonResponse
     {
+        try {
+            // 認証ユーザー情報取得
+            $instructorId = Auth::guard('instructor')->user()->id;
+
+            // リクエストから講座IDを取得
+            // TODO：1 → $request->course_id
+            $courseId = 1;
+
+            // 選択されたチャプターを取得
+            // TODO：[1, 2, 3] → $request->chapters
+            $chapters = Chapter::whereIn('id', [1, 2, 3])->with('course')->get();
+
+            $chapters->each(function (Chapter $chapter) use ($instructorId, $courseId) {
+                // チャプターに紐づく講師でない場合は許可しない
+                if ((int) $instructorId !== $chapter->course->instructor_id) {
+                    throw new ValidationErrorException('Invalid instructor_id.');
+                }
+                // チャプターに紐づく講座IDがリクエストの講座IDと一致しない場合は許可しない
+                if ((int) $courseId !== $chapter->course_id) {
+                    throw new ValidationErrorException('Invalid course_id.');
+                }
+            });
+
+            // チャプターの状態を一括で削除
+            Chapter::whereIn('id', $chapters->pluck('id'))->delete();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (ValidationErrorException $e) {
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ]);
+        } catch (Exception $e) {
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
+
         return response()->json([]);
     }
 


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-971
- https://gut-familie.atlassian.net/browse/JKA-895

## 概要
- [講師側 チャプター作成画面 選択済チャプターを削除するAPI作成](https://gut-familie.atlassian.net/browse/JKA-895)における、ロジックの作成。

## 動作確認手順
- Postmanにて確認
    - HTTTPメソッド：DELETE
    - URL：http://localhost:8080/api/v1/instructor/course/:course_id/chapter
    - Headers
        - X-XSRF-TOKEN: {{XSRF-TOKEN}}
        - Referer: http://localhost:3000/
        - Origin: http://localhost:3000/
    - Body(row json形式)
        - chapters: [1, 2, 3]
    - Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```

## 考慮して欲しいこと
- フォームリクエストは未実装のため、固定の値を利用して実装。

## 確認して欲しいこと
- エラーが発生しないこと。
- 複数チャプターの論理削除が一括で行われること。

## 動作確認結果
Postmanにて動作確認を行なった。
<img width="718" alt="スクリーンショット 2024-07-29 14 14 17" src="https://github.com/user-attachments/assets/3c17b99f-b57b-4cf5-ad6e-64390c1cdfd1">

### Before
<img width="1067" alt="スクリーンショット 2024-07-29 13 57 08" src="https://github.com/user-attachments/assets/3eee66c9-54ac-48e8-bcda-460729d24049">

### After
<img width="1067" alt="スクリーンショット 2024-07-29 13 57 29" src="https://github.com/user-attachments/assets/ad0c1d5d-7d80-43f4-afbc-d84d1bc1cb33">
