### PR TITLE
JKA-973 フォームリクエストの作成（ゆうへい）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Exceptions\ValidationErrorException;
+use App\Http\Requests\Instructor\BulkDeleteRequest;
 use App\Http\Requests\Instructor\ChapterShowRequest;
 use App\Http\Requests\Instructor\ChapterSortRequest;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
@@ -224,19 +225,17 @@ class ChapterController extends Controller
      *
      * @return JsonResponse
      */
-    public function bulkDelete(): JsonResponse
+    public function bulkDelete(BulkDeleteRequest $request): JsonResponse
     {
         try {
             // 認証ユーザー情報取得
             $instructorId = Auth::guard('instructor')->user()->id;
 
             // リクエストから講座IDを取得
-            // TODO：1 → $request->course_id
-            $courseId = 1;
+            $courseId = $request->course_id;
 
             // 選択されたチャプターを取得
-            // TODO：[1, 2, 3] → $request->chapters
-            $chapters = Chapter::whereIn('id', [1, 2, 3])->with('course')->get();
+            $chapters = Chapter::whereIn('id', $request->chapters)->with('course')->get();
 
             $chapters->each(function (Chapter $chapter) use ($instructorId, $courseId) {
                 // チャプターに紐づく講師でない場合は許可しない

--- a/app/Http/Requests/Instructor/BulkDeleteRequest.php
+++ b/app/Http/Requests/Instructor/BulkDeleteRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BulkDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapters' => ['required', 'array'],
+            'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-973
- https://gut-familie.atlassian.net/browse/JKA-895

## 概要
- [講師側 チャプター作成画面 選択済チャプターを削除するAPI作成](https://gut-familie.atlassian.net/browse/JKA-895)における、フォームリクエストの作成。

## 動作確認手順
- Postmanにて確認
    - HTTTPメソッド：DELETE
    - URL：http://localhost:8080/api/v1/instructor/course/:course_id/chapter
    - Headers
        - X-XSRF-TOKEN: {{XSRF-TOKEN}}
        - Referer: http://localhost:3000/
        - Origin: http://localhost:3000/
    - Body(row json形式)
        - chapters: [1, 2, 3]
    - Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```

## 考慮して欲しいこと
- 特になし。

## 確認して欲しいこと
- エラーが発生しないこと。
- 複数チャプターの論理削除が一括で行われること。
- Postmanのリクエストボディで指定したchapter_idのみ削除されること。
