### PR TITLE
JKA-950 マネージャー側（講師側） チャプター作成画面 選択済レッスンを公開/非公開にするAPI作成のロジック作成（Tokeshi）

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -342,7 +342,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスンステータス一括更新API
      *
-     * @param LessonUpdateStatusRequest $request
+     * @param 
      * @return JsonResponse
      */
     public function putStatus(Request $request, $course_id, $chapter_id): JsonResponse
@@ -383,7 +383,7 @@ class LessonController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-            //エラーハンドリング、認可に失敗した場合エラーを返す
+        //エラーハンドリング、認可に失敗した場合エラーを返す　
         } catch (AuthorizationException $e) {
             return response()->json([
                 'result' => false,

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -20,6 +20,7 @@ use App\Http\Requests\Manager\LessonStoreRequest;
 use App\Http\Requests\Manager\LessonDeleteRequest;
 use App\Http\Requests\Manager\LessonUpdateRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
+use Illuminate\Http\Request;
 
 class LessonController extends Controller
 {
@@ -340,11 +341,23 @@ class LessonController extends Controller
     /**
      * 選択済みレッスンステータス一括更新API
      *
-     * @param
+     * @param LessonUpdateStatusRequest $request
      * @return JsonResponse
      */
-    public function updateStatus()
+    public function updateStatus(Request $request): JsonResponse
     {
+        $managerId = Auth::guard('instructor')->user()->id;
+        // 配下の講師情報を取得
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($managerId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+        dd($instructorIds);
+
+        // ログイン中の講師IDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        //
+
         return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -342,7 +342,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスンステータス一括更新API
      *
-     * @param 
+     * @param
      * @return JsonResponse
      */
     public function putStatus(Request $request, $course_id, $chapter_id): JsonResponse

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -364,9 +364,9 @@ class LessonController extends Controller
         //認可チェックとデータ更新
         try {
             //レッスンデータの認可チェック
-            $lessons->each(function (Lesson $lesson) use ($managerId, $chapterId, $courseId) {
-                //講座に紐づく講師でない場合は許可しない 
-                if ($managerId !== $lesson->chapter->course->instructor_id) {
+            $lessons->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
+                //講座に紐づく講師でない場合は許可しない(自分、または配下であればOK)    
+                if (!in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
                     throw new AuthorizationException('Invalid instructor_id.');
                 }
                 //指定した講座IDがレッスンの講座IDと一致しない場合は許可しない

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -357,14 +357,10 @@ class LessonController extends Controller
         //リクエストから必要なデータを取得
         $lessonIds =  $request->input('lessons');
         $chapterId = $chapter_id;
-        // dd($chapter_id);
         $courseId = $course_id;
-        // dd($courseId);
         $status = $request->input('status');
-        // dd($status);
         //レッスンデータの取得
         $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
-        // dd($lessons);
         //認可チェックとデータ更新
         try {
             //レッスンデータの認可チェック

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -365,7 +365,7 @@ class LessonController extends Controller
         try {
             //レッスンデータの認可チェック
             $lessons->each(function (Lesson $lesson) use ($managerId, $chapterId, $courseId) {
-                //講座に紐づく講師でない場合は許可しない 
+                //講座に紐づく講師でない場合は許可しない
                 if ($managerId !== $lesson->chapter->course->instructor_id) {
                     throw new AuthorizationException('Invalid instructor_id.');
                 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -365,7 +365,7 @@ class LessonController extends Controller
         try {
             //レッスンデータの認可チェック
             $lessons->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
-                //講座に紐づく講師でない場合は許可しない(自分、または配下であればOK)    
+                //講座に紐づく講師でない場合は許可しない(自分、または配下であればOK)
                 if (!in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
                     throw new AuthorizationException('Invalid instructor_id.');
                 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -183,7 +183,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
-                                    Route::put('status', 'Api\Manager\LessonController@updateStatus');
+                                    Route::put('status', 'Api\Manager\LessonController@putStatus');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-950

## 概要
- [ マネージャー側（講師側） チャプター作成画面 選択済レッスンを公開/非公開にするAPI作成](https://gut-familie.atlassian.net/browse/JKA-892)のロジック作成


## 動作確認手順
- Postmanにて確認
- HTTPメソッド: ```PUT``` 
- URL:```/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/status```
- Headers
   X-XSRF-TOKEN:```{{XSRF-TOKEN}}```
   Referer:```http://localhost :3000/```
   Origin:```http://localhost :3000/```
- Body
  status: "public" or "private"
  lessons:[1,2,3,4,5]
- Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```

## 考慮して欲しいこと
- 特になし

## 確認して欲しい事
- エラーが発生しないこと
- 選択済みレッスンのステータスが変更できるかどうか
- マネージャーの配下（instructor）のレッスンのステータスが変更できるかどうか


