### PR TITLE
JKA-976 空の配列を返すルーターとコントローラの作成(Tokeshi)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -339,7 +339,7 @@ class LessonController extends Controller
     /**
      * 選択ずみレッスン削除API
      *
-     * @param 
+     * @param
      * @return JsonResponse
      */
     public function bulkDelete()

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -336,4 +336,14 @@ class LessonController extends Controller
             'result' => true,
         ]);
     }
+    /**
+     * 選択ずみレッスン削除API
+     *
+     * @param 
+     * @return JsonResponse
+     */
+    public function bulkDelete()
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -337,7 +337,7 @@ class LessonController extends Controller
         ]);
     }
     /**
-     * 選択ずみレッスン削除API
+     * 選択済みレッスン削除API
      *
      * @param 
      * @return JsonResponse

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -337,7 +337,7 @@ class LessonController extends Controller
         ]);
     }
     /**
-     * 選択済みレッスン削除API
+     * 選択済みレッスンの削除API
      *
      * @param
      * @return JsonResponse

--- a/routes/api.php
+++ b/routes/api.php
@@ -184,6 +184,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
+                                    Route::delete('/', 'Api\Manager\LessonController@bulkDelete');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');


### PR DESCRIPTION
##Issue
-  JKA-898 マネージャー側（講師側） チャプター作成画面 選択済レッスンを削除するAPI作成の子タスク 空の配列を返すルーターとコントローラの作成 https://gut-familie.atlassian.net/browse/JKA-976

## 動作確認手順
- Postmanにて確認
- HTTTPメソッド：```DELETE```
- URL：http://localhost:8080//api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson     
- Headers
   X-XSRF-TOKEN: ```{{XSRF-TOKEN}}```
   Referer: http://localhost:3000/
   Origin: http://localhost:3000/
- Body(row json形式)
   lessons: [1, 2, 3]
- Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```
## 考慮して欲しいこと
- 特になし
## 確認して欲しいこと
- 空配列が返ること
- エラーがないかどうか