### PR TITLE
jka-967 ロジックの作成(あちょこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -392,7 +392,7 @@ class ChapterController extends Controller
     /**
      * 選択済みチャプターを公開/非公開にするAPI
      *
-     * @param PatchStatusRequest $request
+     * @param 
      * @return JsonResponse
      */
     public function patchStatus(Request $request, $course_id): JsonResponse

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -392,28 +392,28 @@ class ChapterController extends Controller
     /**
      * 選択済みチャプターを公開/非公開にするAPI
      *
-     * @param 
+     * @param
      * @return JsonResponse
      */
     public function patchStatus(Request $request, $course_id): JsonResponse
     {
         //ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
-         
+
         // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
-        
+
         //リクエストから必要なデータを取得
         $chapterIds =  $request->input('chapters');
         $courseId = $course_id;
         $status = $request->input('status');
-        
+
         //チャプターデータの取得
         $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
-        
+
         //認可チェックとデータ更新
         try {
             //チャプターデータの認可チェック


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-967

## 概要
- マネージャー側（講師側） チャプター作成画面 選択済チャプターを公開/非公開にするAPI作成のロジックの作成

## 動作確認手順
- HTTPメソッド: PATCH

- URL:``http://localhost:8080/api/v1/manager/course/1/chapter/status``

- Headers
``X-XSRF-TOKEN:{{XSRF-TOKEN}}``
``Referer:http://localhost :3000/``
``Origin:http://localhost :3000/``

- Body
status:`` "public" or "private"``
chapters:``[1,2,3,4,5]``

- Pre-request Script
``pm.environment.set("variable_key", "variable_value"); pm.sendRequest({ url: 'http://localhost:8080/sanctum/csrf-cookie', method: 'GET' }, function (error, response, { cookies }) { let xsrfCookie = cookies.one('XSRF-TOKEN'); if (xsrfCookie) { let xsrfToken = decodeURIComponent(xsrfCookie['value']); console.log(xsrfToken); pm.request.headers.upsert({ key: 'X-XSRF-TOKEN', value: xsrfToken, });                 pm.environment.set('XSRF-TOKEN', xsrfToken); } })``

- 正しい値が返ってくる

## 考慮して欲しいこと
- 特に無し

## 確認して欲しいこと
- 特に無し