### PR TITLE
JKA-968 フォームリクエストの作成（あちょこ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -399,21 +399,21 @@ class ChapterController extends Controller
     {
         //ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
-         
+
         // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
-        
+
         //リクエストから必要なデータを取得
         $chapterIds =  $request->input('chapters');
         $courseId = $course_id;
         $status = $request->input('status');
-        
+
         //チャプターデータの取得
         $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
-        
+
         //認可チェックとデータ更新
         try {
             //チャプターデータの認可チェック

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -430,7 +430,6 @@ class ChapterController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-
         } catch (AuthorizationException $e) {
             return response()->json([
                 'result' => false,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -16,13 +16,13 @@ use App\Http\Requests\Manager\ChapterShowRequest;
 use App\Http\Requests\Manager\ChapterSortRequest;
 use App\Http\Requests\Manager\ChapterPatchRequest;
 use App\Http\Requests\Manager\ChapterStoreRequest;
+use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Manager\ChapterDeleteRequest;
 use App\Http\Resources\Manager\ChapterShowResource;
 use App\Http\Requests\Manager\ChapterPutStatusRequest;
 use App\Http\Requests\Manager\ChapterBulkDeleteRequest;
 use App\Http\Requests\Manager\ChapterPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Manager\ChaptersPatchStatusRequest;
 
 class ChapterController extends Controller
@@ -46,8 +46,8 @@ class ChapterController extends Controller
         // chapter_idから属するlassons含めてデータ取得
         $chapter = Chapter::with(['lessons','course'])->findOrFail($request->chapter_id);
 
-        // 自身もしくは配下のinstructorでない場合はエラー応答
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+            // 自分、または配下の講師の講座でなければエラー応答
             return response()->json([
                 'result' => false,
                 'message' => "Forbidden, not allowed to this course.",
@@ -123,9 +123,8 @@ class ChapterController extends Controller
         // チャプターを取得
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
-        // マネージャー自身が作成したチャプターか、または配下の講師が作成したチャプターなら更新を許可
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
-            // 失敗結果を返す
+            // 自分、または配下の講師の講座のチャプターでなければエラー応答
             return response()->json([
                 'result'  => false,
                 'message' => "Forbidden, not allowed to this chapter.",
@@ -266,9 +265,8 @@ class ChapterController extends Controller
             $instructorIds = $manager->managings->pluck('id')->toArray();
             $instructorIds[] = $manager->id;
 
-            // マネージャー自身または配下の講師が担当する講座なら更新を許可
             if (!in_array($course->instructor_id, $instructorIds, true)) {
-                // 失敗結果を返す
+                // 自分、または配下の講師の講座でなければエラー応答
                 return response()->json([
                     'result'  => false,
                     'message' => "Forbidden, not allowed to this course.",
@@ -311,7 +309,7 @@ class ChapterController extends Controller
      */
     public function updateStatus(ChapterPatchStatusRequest $request)
     {
-        // 現在のユーザーを取得（講師の場合）
+        // 現在のユーザーを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // マネージャーが管理する講師を取得
@@ -322,16 +320,16 @@ class ChapterController extends Controller
         // 指定されたチャプターを取得
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
-        // 自分、または配下の講師の講座のチャプターでなければエラー応答
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+            // 自分、または配下の講師の講座のチャプターでなければエラー応答
             return response()->json([
                 'result' => false,
                 'message' => 'Unauthorized access to update chapter status.'
             ], 403);
         }
 
-        // リクエストのcourse_idとチャプターのcourse_idが一致するか確認
         if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
             return response()->json([
                 'result'  => false,
                 'message' => 'Invalid course_id.',
@@ -397,33 +395,31 @@ class ChapterController extends Controller
      */
     public function patchStatus(ChaptersPatchStatusRequest $request): JsonResponse
     {
-        //ログイン中の講師IDを取得
+        // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
 
-        //配下の講師情報を取得
+        // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        //リクエストから必要なデータを取得
+        // リクエストから必要なデータを取得
         $chapterIds =  $request->input('chapters');
         $courseId = $request->input('course_id');
         $status = $request->input('status');
 
-        //チャプターデータの取得
+        // チャプターデータの取得
         $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
 
-        //認可チェックとデータ更新
         try {
-            //チャプターデータの認可チェック
             $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
-                //講座に紐づく講師でない場合は許可しない(自分、または配下であればOK)
+                // 講座に紐づく講師でない場合は許可しない
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     throw new AuthorizationException('Invalid instructor_id.');
                 }
 
-                //指定した講座IDがチャプターの講座IDと一致しない場合は許可しない
+                // 指定した講座IDがチャプターの講座IDと一致しない場合は許可しない
                 if ((int)$courseId !== $chapter->course->id) {
                     throw new AuthorizationException('Invalid course_id.');
                 }
@@ -435,7 +431,6 @@ class ChapterController extends Controller
                 'result' => true,
             ]);
 
-        //エラーハンドリング、認可に失敗した場合エラーを返す　
         } catch (AuthorizationException $e) {
             return response()->json([
                 'result' => false,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -23,7 +23,7 @@ use App\Http\Requests\Manager\ChapterBulkDeleteRequest;
 use App\Http\Requests\Manager\ChapterPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Http\Request;
+use App\Http\Requests\Manager\ChaptersPatchStatusRequest;
 
 class ChapterController extends Controller
 {
@@ -392,15 +392,15 @@ class ChapterController extends Controller
     /**
      * 選択済みチャプターを公開/非公開にするAPI
      *
-     * @param PatchStatusRequest $request
+     * @param ChaptersPatchStatusRequest $request
      * @return JsonResponse
      */
-    public function patchStatus(Request $request, $course_id): JsonResponse
+    public function patchStatus(ChaptersPatchStatusRequest $request): JsonResponse
     {
         //ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
 
-        // 配下の講師情報を取得
+        //配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
@@ -408,7 +408,7 @@ class ChapterController extends Controller
 
         //リクエストから必要なデータを取得
         $chapterIds =  $request->input('chapters');
-        $courseId = $course_id;
+        $courseId = $request->input('course_id');
         $status = $request->input('status');
 
         //チャプターデータの取得
@@ -429,7 +429,7 @@ class ChapterController extends Controller
                 }
             });
 
-            //チャプターデータのステータス一括更新
+            //チャプターのステータスを一括更新
             Chapter::whereIn('id', $chapterIds)->update(['status' => $status]);
             return response()->json([
                 'result' => true,

--- a/app/Http/Requests/Manager/ChaptersPatchStatusRequest.php
+++ b/app/Http/Requests/Manager/ChaptersPatchStatusRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use App\Rules\ChapterStatusRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChaptersPatchStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapters' => ['required', 'array'],
+            'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'status' => ['required', 'string', new ChapterStatusRule()],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-968

## 概要
- マネージャー側（講師側） チャプター作成画面 選択済チャプターを公開/非公開にするAPI作成のフォームリクエストの作成

## 動作確認手順
- HTTPメソッド: PATCH

``URL:http://localhost:8080/api/v1/manager/course/1/chapter/status``

- Headers
X-XSRF-TOKEN:``{{XSRF-TOKEN}}``
Referer:``http://localhost :3000/``
Origin:``http://localhost :3000/``

- Body
status:`` "public" or "private"``
chapters:``[1,2,3,4,5]``

- Pre-request Script
``pm.environment.set("variable_key", "variable_value"); pm.sendRequest({ url: 'http://localhost:8080/sanctum/csrf-cookie', method: 'GET' }, function (error, response, { cookies }) { let xsrfCookie = cookies.one('XSRF-TOKEN'); if (xsrfCookie) { let xsrfToken = decodeURIComponent(xsrfCookie['value']); console.log(xsrfToken); pm.request.headers.upsert({ key: 'X-XSRF-TOKEN', value: xsrfToken, });                 pm.environment.set('XSRF-TOKEN', xsrfToken); } })``

- 正しい値が返ってくる

## 考慮して欲しいこと
- 特に無し

## 確認して欲しいこと
- 特に無し

