### PR TITLE
JKA-963 講師側選択削除ロジック認可処理(シンタロウ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use Exception;
 use App\Model\Lesson;
+use App\Model\Chapter;
 use App\Model\Attendance;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
@@ -182,11 +183,14 @@ class LessonController extends Controller
 
         $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
 
-        $lessons->each(function (Lesson $lesson) use ($instructorId, $chapterId) {
-            if (!in_array($lesson->chapter->course->instructor_id, $instructorId, true)) {
+        $lessons->each(function (Lesson $lesson) use ($instructorId, $chapterId, $courseId) {
+            if ($lesson->chapter->course->instructor_id !== $instructorId) {
                 throw new ValidationErrorException('Invalid instructor_id.');
             }
             if ((int) $chapterId !== $lesson->chapter_id) {
+                throw new ValidationErrorException('Invalid chapter.');
+            }
+            if ((int) $courseId !== $lesson->chapter->course_id) {
                 throw new ValidationErrorException('Invalid course.');
             }
         });

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -167,7 +167,7 @@ class LessonController extends Controller
         }
     }
     /**
-     * 複数のチャプター削除API
+     * 複数のレッスン削除API
      *
      * @param lessonBulkDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use Exception;
 use App\Model\Lesson;
 use App\Model\Chapter;
+use App\Model\Course;
 use App\Model\Attendance;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
@@ -184,7 +185,7 @@ class LessonController extends Controller
         $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
 
         $lessons->each(function (Lesson $lesson) use ($instructorId, $chapterId, $courseId) {
-            if ($lesson->chapter->course->instructor_id !== $instructorId) {
+            if ((int) $instructorId !== $lesson->chapter->course->instructor_id) {
                 throw new ValidationErrorException('Invalid instructor_id.');
             }
             if ((int) $chapterId !== $lesson->chapter_id) {

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -182,6 +182,15 @@ class LessonController extends Controller
 
         $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
 
+        $lessons->each(function (Lesson $lesson) use ($instructorId, $chapterId) {
+            if (!in_array($lesson->chapter->course->instructor_id, $instructorId, true)) {
+                throw new ValidationErrorException('Invalid instructor_id.');
+            }
+            if ((int) $chapterId !== $lesson->chapter_id) {
+                throw new ValidationErrorException('Invalid course.');
+            }
+        });
+
         Lesson::whereIn('id', $lessonIds)->delete();
 
         return response()->json([


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-897
- https://gut-familie.atlassian.net/browse/JKA-939
- https://gut-familie.atlassian.net/browse/JKA-963

## 概要
- 講師側 チャプター作成画面 選択済レッスンを削除するAPI作成の子タスク、ロジックの作成について、認可処理の記述

## 動作確認手順
- postmanを使ってインストラクターでログイン後http://localhost:8080/api/v1/instructor/course/1/chapter/1/lessons
にアクセスし、trueが返って来たのを確認しました。

## 確認してほしい事
- trueが返ってきた事が認可処理機能の確認になるのか