### PR TITLE
JKA-977  マネージャー側（講師側） チャプター作成画面 選択済レッスンを削除するAPI作成のロジック作成(Tokeshi)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -361,13 +361,11 @@ class LessonController extends Controller
 
         //レッスン情報を取得
         /** @var Lesson $lesson */
-        $lesson = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
-        //アテンダンス情報を取得
-        $attendedLessons = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id')->toArray();
+        $lesson = Lesson::with('chapter.course', 'attendances')->whereIn('id', $lessonIds)->get();
         //認可チェック
         try {
             //レッスンデータの認可チェック
-            $lesson->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId, $attendedLessons) {
+            $lesson->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
                 //自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない
                 if (!in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
                     throw new ValidationErrorException('Invalid instructor_id.');
@@ -381,7 +379,7 @@ class LessonController extends Controller
                     throw new ValidationErrorException('Invalid chapter_id.');
                 }
                 //受講情報が登録されている場合は許可しない
-                if (in_array($lesson->id, $attendedLessons)) {
+                if ($lesson->attendances->isNotEmpty()) {
                     throw new ValidationErrorException('This lesson has attendance.');
                 }
             });

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -20,6 +20,7 @@ use App\Http\Requests\Manager\LessonStoreRequest;
 use App\Http\Requests\Manager\LessonDeleteRequest;
 use App\Http\Requests\Manager\LessonUpdateRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
+use Illuminate\Http\Request;
 
 class LessonController extends Controller
 {
@@ -336,14 +337,84 @@ class LessonController extends Controller
             'result' => true,
         ]);
     }
+
     /**
-     * 選択ずみレッスン削除API
+     * 選択済みレッスン削除API
      *
      * @param 
      * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete()
+    public function bulkDelete(Request $request, $course_id, $chapter_id): JsonResponse
     {
-        return response()->json([]);
+        //ログイン中の講師IDを取得
+        $managerId = Auth::guard('instructor')->user()->id;
+
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($managerId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        //リクエストからデータを取得
+        $lessonIds = $request->input('lessons');
+        $chapterId = $chapter_id;
+        $courseId =  $course_id;
+
+        //レッスン情報を取得
+        /** @var Lesson $lesson */
+        $lesson = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
+        //認可チェック
+        try {
+            //レッスンデータの認可チェック
+            $lesson->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
+                //自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない
+                if (!in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
+                    throw new ValidationErrorException('Invalid instructor_id.');
+                }
+                //指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
+                if ((int) $courseId !== $lesson->chapter->course->id) {
+                    throw new ValidationErrorException('Invalid course_id.');
+                }
+                //指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
+                if ((int) $chapterId !== $lesson->chapter->id) {
+                    throw new ValidationErrorException('Invalid chapter_id.');
+                }
+                //受講情報が登録されている場合は許可しない
+                if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
+                    throw new ValidationErrorException('This lesson has attendance.');
+                }
+            });
+
+            DB::beginTransaction();
+
+            //対象レッスンの削除処理
+            $lesson->update(['order' => 0]);
+            $lesson->delete();
+            //レッスン順序の更新
+            Lesson::where('chapter_id', $lesson->chapter_id)
+                ->orderBy('order')
+                ->get()
+                ->each(function ($lesson, $index) {
+                    $lesson->update(['order' => $index + 1]);
+                });
+
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (ValidationErrorException $e) {
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ], 403);
+            //
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to delete lesson.',
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -361,7 +361,7 @@ class LessonController extends Controller
 
         //レッスン情報を取得
         /** @var Lesson $lesson */
-        $lesson = Lesson::with('chapter.course', 'attendances')->whereIn('id', $lessonIds)->get();
+        $lesson = Lesson::with('chapter.course', 'lessonAttendances')->whereIn('id', $lessonIds)->get();
         //認可チェック
         try {
             //レッスンデータの認可チェック
@@ -379,7 +379,7 @@ class LessonController extends Controller
                     throw new ValidationErrorException('Invalid chapter_id.');
                 }
                 //受講情報が登録されている場合は許可しない
-                if ($lesson->attendances->isNotEmpty()) {
+                if ($lesson->lessonAttendances->isNotEmpty()) {
                     throw new ValidationErrorException('This lesson has attendance.');
                 }
             });
@@ -405,7 +405,6 @@ class LessonController extends Controller
                 'result' => false,
                 'message' => $e->getMessage(),
             ], 403);
-            //
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -387,16 +387,18 @@ class LessonController extends Controller
             DB::beginTransaction();
 
             //対象レッスンの削除処理
-            $lesson->update(['order' => 0]);
-            $lesson->delete();
+            // $lesson->update(['order' => 0]);
+            // $lesson->delete();
+
+            Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
+            Lesson::whereIn('id', $lessonIds)->delete();
             //レッスン順序の更新
-            Lesson::where('chapter_id', $lesson->chapter_id)
+            Lesson::where('chapter_id', $chapterId)
                 ->orderBy('order')
                 ->get()
                 ->each(function ($lesson, $index) {
                     $lesson->update(['order' => $index + 1]);
                 });
-
             DB::commit();
 
             return response()->json([

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -340,7 +340,7 @@ class LessonController extends Controller
      * 選択ずみレッスン削除API
      *
      * @param 
-     * @return JsonResponse
+     * @return \Illuminate\Http\JsonResponse
      */
     public function bulkDelete()
     {

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -341,7 +341,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスン削除API
      *
-     * @param 
+     * @param
      * @return \Illuminate\Http\JsonResponse
      */
     public function bulkDelete(Request $request, $course_id, $chapter_id): JsonResponse


### PR DESCRIPTION
## Issue
- JKA-898 マネージャー側（講師側） チャプター作成画面 選択済レッスンを削除するAPI作成(親)
- https://gut-familie.atlassian.net/browse/JKA-977
## 動作確認手順
- Postmanにて確認
- HTTTPメソッド：DELETE
- URL：[http://localhost:8080//api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson](http://localhost:8080//api/v1/manager/course/%7Bcourse_id%7D/chapter/%7Bchapter_id%7D/lesson)
- Headers
   X-XSRF-TOKEN: {{XSRF-TOKEN}}
   Referer: http://localhost:3000/
   Origin: http://localhost:3000/
- Body(row json形式) 
   lessons: [1, 2, 3]
- Pre-request Script
```
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
```
## 考慮してほしいこと
- 特になし

## 確認してほしいとこ
- 認可のところでうまくいってないです。受講状況のどこを変更すると正しい値が返ってくるのか理解ができたません。
　一旦、考えたコードを提出しますのでどこがおかしいかご教授いただきたいです。
- 受講状況のロジックがおかしいようですが、どの値を変更すると良いのかわかっておりません。

<img width="1405" alt="Screenshot 2024-08-08 at 12 14 55" src="https://github.com/user-attachments/assets/e57d3e65-4970-4b7a-8e4f-bb6209daa820">

<img width="1146" alt="Screenshot 2024-08-08 at 12 09 36" src="https://github.com/user-attachments/assets/aad38040-9a6a-441b-a0c2-7b2b3091e2cd">
<img width="1144" alt="Screenshot 2024-08-08 at 12 09 53" src="https://github.com/user-attachments/assets/256096a4-3d8f-4ff7-bfbb-b6c75a38f85b">
<img width="1144" alt="Screenshot 2024-08-08 at 12 09 53" src="https://github.com/user-attachments/assets/1be9fb5e-31c0-490e-a13a-91f181991973">
<img width="1140" alt="Screenshot 2024-08-08 at 12 12 10" src="https://github.com/user-attachments/assets/5fcd2cb9-d5e5-4939-987b-4abe6c7b67e7">
