### PR TITLE
JKA-964講師側選択削除ロジックトランザクション(シンタロウ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -182,7 +182,6 @@ class LessonController extends Controller
         $lessonIds = $request->input('lessons');
 
         try {
-
             // レッスン情報を取得
             $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -178,7 +178,6 @@ class LessonController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
 
         try {
-
             //リクエストからデータを取得
             $courseId = $course_id;
 
@@ -215,7 +214,7 @@ class LessonController extends Controller
             Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
 
             Lesson::whereIn('id', $lessonIds)->delete();
-            
+
             //レッスン順序の更新
             Lesson::where('chapter_id', $chapterId)
                 ->orderBy('order')

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -174,33 +174,55 @@ class LessonController extends Controller
      */
     public function bulkDelete(Request $request, $course_id, $chapter_id)
     {
+        //ログイン中の講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
         try {
 
+            //リクエストからデータを取得
             $courseId = $course_id;
 
             $chapterId = $chapter_id;
 
             $lessonIds = $request->input('lessons');
 
+            //レッスン情報を取得
             $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
 
+            //レッスンデータの認可チェック
             $lessons->each(function (Lesson $lesson) use ($instructorId, $chapterId, $courseId) {
+                //自身の講座・チャプターに紐づくレッスンでない場合は許可しない
                 if ((int) $instructorId !== $lesson->chapter->course->instructor_id) {
                     throw new ValidationErrorException('Invalid instructor_id.');
                 }
+                //指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
                 if ((int) $chapterId !== $lesson->chapter_id) {
                     throw new ValidationErrorException('Invalid chapter.');
                 }
+                //指定したコースIDがレッスンのコースIDと一致しない場合は許可しない
                 if ((int) $courseId !== $lesson->chapter->course_id) {
                     throw new ValidationErrorException('Invalid course.');
+                }
+                //受講情報が登録されている場合は許可しない
+                if ($lesson->lessonAttendances->isNotEmpty()) {
+                    throw new ValidationErrorException('This lesson has attendance.');
                 }
             });
 
             DB::beginTransaction();
 
+            // 削除対象レッスンのorderカラムを0に設定する
+            Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
+
             Lesson::whereIn('id', $lessonIds)->delete();
+            
+            //レッスン順序の更新
+            Lesson::where('chapter_id', $chapterId)
+                ->orderBy('order')
+                ->get()
+                ->each(function (Lesson $lesson, int $index) {
+                    $lesson->update(['order' => $index + 1]);
+                });
 
             DB::commit();
 


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-897
- https://gut-familie.atlassian.net/browse/JKA-939
- https://gut-familie.atlassian.net/browse/JKA-964

## 概要
- 講師側 チャプター作成画面 選択済レッスンを削除するAPI作成の子タスク、ロジックの作成について、トランザクションの記述

## 動作確認手順
- postmanを使ってインストラクター(instructor_id = 2)でログイン後、http://localhost:8080/api/v1/instructor/course/2/chapter/4/lesson 
にアクセスし、trueが返って来たのを確認しました。
- HTTPメソッド: delete
- リクエストボディ　{
  "lessons": [7]
}

## 考慮して欲しい事
- 特になし

## 確認して欲しい事
- レッスン順序の更新処理を追加しましたが、レッスンテーブルのorderカラムの値が複数レコード間で重複する現象が起きます。ご確認願います。
