### PR TITLE
JKA-984講師側選択削除フォームリクエストの作成(シンタロウ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -18,12 +18,11 @@ use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Instructor\LessonSortRequest;
 use App\Http\Requests\Instructor\LessonStoreRequest;
 use App\Http\Requests\Instructor\LessonDeleteRequest;
-use App\Http\Requests\Instructor\LessonBulkDeleteRequest;
 use App\Http\Requests\Instructor\LessonUpdateRequest;
+use App\Http\Requests\Instructor\LessonPutStatusRequest;
+use App\Http\Requests\Instructor\LessonBulkDeleteRequest;
 use App\Http\Requests\Instructor\LessonPatchStatusRequest;
 use App\Http\Requests\Instructor\LessonUpdateTitleRequest;
-use App\Http\Requests\Instructor\LessonPutStatusRequest;
-use Illuminate\Http\Request;
 
 class LessonController extends Controller
 {
@@ -165,6 +164,7 @@ class LessonController extends Controller
             ], 500);
         }
     }
+
     /**
      * 複数のレッスン削除API
      *

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -18,6 +18,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Instructor\LessonSortRequest;
 use App\Http\Requests\Instructor\LessonStoreRequest;
 use App\Http\Requests\Instructor\LessonDeleteRequest;
+use App\Http\Requests\Instructor\LessonBulkDeleteRequest;
 use App\Http\Requests\Instructor\LessonUpdateRequest;
 use App\Http\Requests\Instructor\LessonPatchStatusRequest;
 use App\Http\Requests\Instructor\LessonUpdateTitleRequest;
@@ -167,18 +168,16 @@ class LessonController extends Controller
     /**
      * 複数のレッスン削除API
      *
-     * @param Request $request
-     * @param $course_id
-     * @param $chapter_id
+     * @param LessonBulkDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete(Request $request, $course_id, $chapter_id)
+    public function bulkDelete(LessonBulkDeleteRequest $request)
     {
         // ログイン中の講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
         // リクエストからデータを取得
-        $courseId = $course_id;
-        $chapterId = $chapter_id;
+        $courseId = $request->input('course_id');
+        $chapterId = $request->input('chapter_id');
         $lessonIds = $request->input('lessons');
 
         try {

--- a/app/Http/Requests/Instructor/LessonBulkDeleteRequest.php
+++ b/app/Http/Requests/Instructor/LessonBulkDeleteRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonBulkDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'lessons' => ['required', 'array'],
+            'lessons.*' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-897
- https://gut-familie.atlassian.net/browse/JKA-984

## 概要
- 講師側 チャプター作成画面 選択済レッスンを削除するAPI作成タスクの子タスク、フォームリクエストの作成

## 動作確認手順
- postmanを使ってインストラクター(instructor_id = 2)でログイン後、http://localhost:8080/api/v1/instructor/course/2/chapter/4/lesson
にアクセスし、trueが返って来たのを確認しました。
- HTTPメソッド: delete
- リクエストボディ　{
"lessons": [7]
}

## 考慮して欲しい事
- 特になし

## 確認して欲しい事
- 特になし