### PR TITLE
子-空の配列を返すルーターとコントローラの作成<親-新権限マネージャー設立による...>(辻/G2)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -287,6 +287,10 @@ class LessonController extends Controller
         }
     }
 
+    public function updateStatus(){
+        return response()->json([]);
+    }
+    
     /**
      * レッスンタイトル変更API
      *

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -287,10 +287,11 @@ class LessonController extends Controller
         }
     }
 
-    public function updateStatus(){
+    public function updateStatus()
+    {
         return response()->json([]);
     }
-    
+
     /**
      * レッスンタイトル変更API
      *

--- a/routes/api.php
+++ b/routes/api.php
@@ -186,6 +186,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
+                                    Route::patch('status', 'Api\Manager\LessonController@updateStatus');
                                     Route::put('status', 'Api\Manager\LessonController@putStatus');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');


### PR DESCRIPTION
## 概要
<確認> 空の配列を返すルーターとコントローラの作成

## 動作確認
Postmanにて
インストラクター側にログイン後
http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1/status
に送信。trueが返ってくることを確認。
※画像にて別途、送信。

-HTTPメソッド：patch
-"raw"(Body)にて、
 {
  "status": "public"
 }
 
 ## 考慮してほしいこと
 特になし
 
 ## 確認してほしいこと
 特になし