### PR TITLE
JKA989親-講師側 チャプター作成画面 チャプターに紐づく全レッスンを削除するAPI作成 子JKA995　JKA989リクエスト実装・空配列作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -327,13 +327,6 @@ class ChapterController extends Controller
     }
 
     /**
-    * チャプターに紐づく全レッスンを削除するAPI
-    */
-    public function deleteAllLessons() {
-        return response()->json([]);
-    }
-
-    /**
      * チャプター並び替えAPI
      *
      * @param ChapterSortRequest $request

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -327,6 +327,13 @@ class ChapterController extends Controller
     }
 
     /**
+    * チャプターに紐づく全レッスンを削除するAPI
+    */
+    public function deleteAllLessons() {
+        return response()->json([]);
+    }
+
+    /**
      * チャプター並び替えAPI
      *
      * @param ChapterSortRequest $request

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -315,6 +315,13 @@ class LessonController extends Controller
     }
 
     /**
+    * チャプターに紐づく全レッスンを削除するAPI
+    */
+    public function allDelete() {
+        return response()->json([]);
+    }
+
+    /**
      * レッスン並び替えAPI
      *
      * @param LessonSortRequest $request

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -317,7 +317,8 @@ class LessonController extends Controller
     /**
     * チャプターに紐づく全レッスンを削除するAPI
     */
-    public function allDelete() {
+    public function allDelete()
+    {
         return response()->json([]);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,7 +91,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::put('status', 'Api\Instructor\LessonController@putStatus');
                                 Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
-                                Route::delete('all', 'Api\Instructor\ChapterController@dallDelete');
+                                Route::delete('all', 'Api\Instructor\ChapterController@allDelete');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,7 +91,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::put('status', 'Api\Instructor\LessonController@putStatus');
                                 Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
-                                Route::delete('all', 'Api\Instructor\ChapterController@allDelete');
+                                Route::delete('all', 'Api\Instructor\LessonController@allDelete');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -85,6 +85,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
                             Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                             Route::delete('/', 'Api\Instructor\ChapterController@delete');
+                            Route::delete('lessons/all', 'Api\Instructor\ChapterController@deleteAllLessons');
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -85,13 +85,13 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
                             Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                             Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                            Route::delete('lessons/all', 'Api\Instructor\ChapterController@deleteAllLessons');
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::put('status', 'Api\Instructor\LessonController@putStatus');
                                 Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
+                                Route::delete('all', 'Api\Instructor\ChapterController@dallDelete');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');


### PR DESCRIPTION
## 概要
- 子JKA995　JKA989リクエスト実装・空配列作成（たわらつみだ）

## 動作確認
Postmanにて確認

- http://localhost:8080/api/v1/instructor/course/{course_id}/chapter/{chapter_id}/lessons/all

- 講師側でログイン

- DELETEリクエスト

- ヘッダー
X-XSRF-TOKEN　{{XSRF-TOKEN}}
Referer　http://localhost:3000
Origin　http://localhost:3000

- ボディ
`[
]`

- スクリプト
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})

レスポンス
[　]

- 考慮してほしいこと
プルリクエストの記載内容（issueの内容）

- 確認してほしいこと
レスポンス内容がエラーなく
[　]が返ってきましたがこれでよろしいのでしょうか。

- 修正内容
apiのURL変更、メソッド変更、ChapterControllerへ空配列を削除し、LessonControllerへ記述しております。