### PR TITLE
Instructor/CourseControllerにQueryServiceの作成→適用（共通化）(シンタロウ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -33,7 +33,7 @@ class CourseController extends Controller
     public function index(QueryService $queryService): CourseIndexResource
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $courses = $queryService->getCourses($instructorId);
+        $courses = $queryService->getCoursesByInstructorId($instructorId);
 
         return new CourseIndexResource($courses);
     }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use App\Services\Course\QueryService;
 use App\Http\Requests\Instructor\CourseShowRequest;
 use App\Http\Requests\Instructor\CourseStoreRequest;
 use App\Http\Requests\Instructor\CourseDeleteRequest;
@@ -28,10 +29,10 @@ class CourseController extends Controller
      *
      * @return CourseIndexResource
      */
-    public function index(): CourseIndexResource
+    public function index(QueryService $queryService): CourseIndexResource
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $courses = Course::where('instructor_id', $instructorId)->get();
+        $courses = $queryService->getCourses($instructorId);
 
         return new CourseIndexResource($courses);
     }
@@ -42,10 +43,9 @@ class CourseController extends Controller
      * @param CourseShowRequest $request
      * @return CourseShowResource
      */
-    public function show(CourseShowRequest $request): CourseShowResource
+    public function show(CourseShowRequest $request, QueryService $queryService): CourseShowResource
     {
-        $course = Course::with(['chapters.lessons'])
-            ->findOrFail($request->course_id);
+        $course = $queryService->getCourse($request->course_id);
         return new CourseShowResource($course);
     }
 

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -26,7 +26,8 @@ class CourseController extends Controller
 {
     /**
      * 講座一覧取得API
-     *
+     * 
+     * @param QueryService $queryService
      * @return CourseIndexResource
      */
     public function index(QueryService $queryService): CourseIndexResource
@@ -41,6 +42,7 @@ class CourseController extends Controller
      * 講座取得API
      *
      * @param CourseShowRequest $request
+     * @param QueryService $queryService
      * @return CourseShowResource
      */
     public function show(CourseShowRequest $request, QueryService $queryService): CourseShowResource

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -12,8 +12,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Storage;
 use App\Services\Course\QueryService;
+use Illuminate\Support\Facades\Storage;
 use App\Http\Requests\Instructor\CourseShowRequest;
 use App\Http\Requests\Instructor\CourseStoreRequest;
 use App\Http\Requests\Instructor\CourseDeleteRequest;
@@ -66,7 +66,7 @@ class CourseController extends Controller
         $filePath = Storage::putFileAs('puiblic/course', $file, $filename);
         $filePath = Course::convertImagePath($filePath);
 
-        $course = Course::create([
+        Course::create([
             'instructor_id' => $instructorId,
             'title' => $request->title,
             'image' => $filePath,

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -26,7 +26,7 @@ class CourseController extends Controller
 {
     /**
      * 講座一覧取得API
-     * 
+     *
      * @param QueryService $queryService
      * @return CourseIndexResource
      */

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -19,7 +19,7 @@ class QueryService
     }
 
     /**
-     * 選択されたコースリストを取得
+     * ログイン中のインストラクターの所有するコースリストを取得
      *
      * @param int $instructorId
      * @return Collection<Course>

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -24,8 +24,8 @@ class QueryService
      * @param array<int> $courseIds
      * @return Collection<Course>
      */
-    public function getCourses(array $courseIds): Collection
+    public function getCourses(int $instructorId): Collection
     {
-        return Course::with('instructor_id')->whereIn('id', $courseIds)->get();
+        return Course::where('instructor_id', $instructorId)->get();
     }
 }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\Course;
+
+use App\Model\Course;
+use Illuminate\Database\Eloquent\Collection;
+
+class QueryService
+{
+    /**
+     * 選択されたコースを取得
+     *
+     * @param int $courseId
+     * @return Course
+     */
+    public function getCourse(int $courseId): Course
+    {
+        return Course::with(['chapters.lessons'])->findOrFail($courseId);
+    }
+
+    /**
+     * 選択されたコースリストを取得
+     *
+     * @param array<int> $courseIds
+     * @return Collection<Course>
+     */
+    public function getCourses(array $courseIds): Collection
+    {
+        return Course::with('instructor_id')->whereIn('id', $courseIds)->get();
+    }
+}

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -21,10 +21,10 @@ class QueryService
     /**
      * 選択されたコースリストを取得
      *
-     * @param array<int> $courseIds
+     * @param int $instructorId
      * @return Collection<Course>
      */
-    public function getCourses(int $instructorId): Collection
+    public function getCoursesByInstructorId(int $instructorId): Collection
     {
         return Course::where('instructor_id', $instructorId)->get();
     }


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-988

## 概要
- Instructor/CourseControllerにQueryServiceの作成→適用（共通化）

## 動作確認手順
- postmanを使ってインストラクター(instructor_id = 2)でログイン後、HTTPメソッド: get でhttp://localhost:8080/api/v1/instructor/course/index
にアクセスし、コース一覧が表示されるのを確認（indexメソッド）
- postmanを使ってインストラクター(instructor_id = 2)でログイン後、HTTPメソッド: get  、リクエストボディ:{
    "course":[2]
}で
http://localhost:8080/api/v1/instructor/course/2
にアクセスし、コース（course_id=2）の内容が表示されるのを確認（showメソッド）
