### PR TITLE
JKA-983 ChapterのQueryServiceをManager/ChapterControllerに適用（共通化）（鍵野）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use App\Services\Chapter\QueryService;
 use App\Exceptions\ValidationErrorException;
 use App\Http\Requests\Manager\ChapterShowRequest;
 use App\Http\Requests\Manager\ChapterSortRequest;
@@ -33,7 +34,7 @@ class ChapterController extends Controller
      * @param ChapterShowRequest $request
      * @return ChapterShowResource|JsonResponse
      */
-    public function show(ChapterShowRequest $request)
+    public function show(ChapterShowRequest $request, QueryService $queryService)
     {
         // ユーザーID取得
         $userId = $request->user()->id;
@@ -44,7 +45,9 @@ class ChapterController extends Controller
         $instructorIds[] = $manager->id;
 
         // chapter_idから属するlassons含めてデータ取得
-        $chapter = Chapter::with(['lessons','course'])->findOrFail($request->chapter_id);
+        //$chapter = Chapter::with(['lessons','course'])->findOrFail($request->chapter_id);
+        // QueryServiceにてチャプターを取得
+        $chapter = $queryService->getChapter($request->chapter_id);
 
         // 自身もしくは配下のinstructorでない場合はエラー応答
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -84,7 +84,6 @@ class ChapterController extends Controller
         }
 
         try {
-
             $order =  $course->chapters->count();
             $newOrder = $order + 1;
             Chapter::create([

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -45,7 +45,6 @@ class ChapterController extends Controller
         $instructorIds[] = $manager->id;
 
         // chapter_idから属するlassons含めてデータ取得
-        //$chapter = Chapter::with(['lessons','course'])->findOrFail($request->chapter_id);
         // QueryServiceにてチャプターを取得
         $chapter = $queryService->getChapter($request->chapter_id);
 


### PR DESCRIPTION
## issue
・https://gut-familie.atlassian.net/browse/JKA-983

## 概要
・ChapterのQueryServiceをManager/ChapterControllerに適用（共通化）

## 動作確認手順
・postmanを使ってインストラクターでログイン
・http://localhost:8080/api/v1/manager/course/1/chapter/1
・GETリクエスト
・ヘッダー
　X-XSRF-TOKEN　{{XSRF-TOKEN}}
　Referer　http://localhost:3000
　Origin　http://localhost:3000
　course_id　1
　chapter_id  1

・レスポンス
　"chapter_id": 1の"title"、"status"
　"lesson_id": 1の"title"、"url"、"remarks"、"status"
　が表示される

