### PR TITLE
空の配列を返すルーターとコントローラーの作成(松本)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,7 +245,8 @@ class ChapterController extends Controller
         }
     }
 
-    public function alldelete() {
+    public function alldelete()
+    {
         return response()->json([]);
     }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,6 +245,10 @@ class ChapterController extends Controller
         }
     }
 
+    public function alldelete() {
+        return response()->json([]);
+    }
+
     /**
      * チャプター並び替えAPI
      *

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,7 +245,8 @@ class ChapterController extends Controller
         }
     }
 
-    public function deleteAll() {
+    public function deleteAll()
+    {
         return response()->json([]);
     }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,7 +245,7 @@ class ChapterController extends Controller
         }
     }
 
-    public function alldelete() {
+    public function deleteAll() {
         return response()->json([]);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -178,7 +178,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::put('status', 'Api\Manager\ChapterController@putStatus');
                             Route::delete('/', 'Api\Manager\ChapterController@bulkDelete');
-                            Route::delete('all', 'Api\Manager\ChapterController@alldelete');
+                            Route::delete('all', 'Api\Manager\ChapterController@deleteAll');
                             Route::patch('status', 'Api\Manager\ChapterController@patchStatus');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -178,6 +178,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::put('status', 'Api\Manager\ChapterController@putStatus');
                             Route::delete('/', 'Api\Manager\ChapterController@bulkDelete');
+                            Route::delete('all', 'Api\Manager\ChapterController@alldelete');
                             Route::patch('status', 'Api\Manager\ChapterController@patchStatus');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');


### PR DESCRIPTION
## 概要
- マネージャー(講師側) チャプター作成画面 全チャプターを削除するAPI作成の
空の配列を返すルーターとコントローラーの作成

## 動作確認手順
- Postｍanにてhttp://localhost:8080/api/v1/manager/course/1/chapter/all
に送信。
空の配列が返ってくることを確認しました。