### PR TITLE
子-ロジックの作成<親-新権限マネージャー設立による> (辻/G2)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -339,57 +339,6 @@ class LessonController extends Controller
         ]);
     }
 
-
-    /**
-     * レッスンステータス更新API
-     *
-     * @param LessonPatchStatusRequest $request
-     * @return LessonPatchResource
-     */
-    public function updateStatus(LessonPatchStatusRequest $request): JsonResponse
-    {
-        $instructorId = Auth::guard('instructor')->user()->id;
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $instructorId;
-
-        //自分と配下のinstructorのレッスンでなければエラー応答
-        $lesson = Lesson::FindOrFail($request->lesson_id);
-        if (!in_array($lesson->instructor_id, $instructorIds, true)) {
-            // エラー応答
-            return response()->json([
-                'result'  => false,
-                'message' => "Forbidden, not allowed to update this lesson.",
-            ], 403);
-        }
-        return response()->json($course);
-
-        $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
-
-        if (Auth::guard('instructor')->user()->id !== $lesson->chapter->course->instructor_id) {
-            return response()->json([
-                'result' => false,
-                "message" => 'invalid instructor_id.'
-            ], 403);
-        }
-
-        if ((int) $request->chapter_id !== $lesson->chapter->id) {
-            // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は更新を許可しない
-            return response()->json([
-                'result'  => false,
-                'message' => 'Invalid chapter_id.',
-            ], 403);
-        }
-
-        $lesson->update([
-            'status' => $request->status
-        ]);
-
-        return response()->json([
-            'result' => true,
-        ]);
-    }
-
     /**
      * レッスンタイトル変更API
      *

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -298,7 +298,6 @@ class LessonController extends Controller
      */
     public function updateStatus(LessonPatchStatusRequest $request): JsonResponse
     {
-        
         $managerId = Auth::guard('instructor')->user()->id;
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($managerId);


### PR DESCRIPTION
## 概要
ロジック作成

## 動作確認
Postmanにて
インストラクター側にログイン後
http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/status
などに送信。trueが返ってくることを確認。
<instructor_id 1>

instructor_id 2,3は"Forbidden, not allowed to use manager api"
instructor_id 4は、"invalid instructor_id"と返ってきました。

-HTTPメソッド: patch
-"raw"(Body)にて、
{
"status": "public"
}

## 考慮してほしい所
base: topic/jka-985/manager_new_instructor_status_update
compare: feature/tsuji_g2/JKA-993/new_manager_make_logic のブランチが勝手にmergeされてしまったので、
"base", "compare"のブランチを逆にし、マージを行いました。

## 確認してほしいこと
Postmanでinstructor_id 1~4でログインを行い、patchステータスで
URL(http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/status)の送信をお願いします。
