### PR TITLE
Manager/CourseControllerにQueryServiceの適用（共通化）(シンタロウ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -52,11 +52,11 @@ class CourseController extends Controller
      *
      * @param CourseShowRequest $request
      * @param QueryService $queryService
-     * @return CourseShowResource|\Illuminate\Http\JsonResponse
+     * @return CourseShowResource|JsonResponse
      */
-    public function show(CourseShowRequest $request, QueryService $queryService): CourseShowResource
+    public function show(CourseShowRequest $request, QueryService $queryService)
     {
-        // ユーザID取得
+        // ログイン中の講師IDを取得
         $userId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\Manager\Instructor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\InstructorCourseIndexRequest;
 use App\Http\Resources\Manager\InstructorCourseIndexResource;
-use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Support\Facades\Auth;
 use App\Services\Course\QueryService;
@@ -37,7 +36,7 @@ class CourseController extends Controller
             ], 403);
         }
 
-        $courses = $queryService->getCoursesByManagerInstructorId($request->instructor_id);
+        $courses = $queryService->getPaginatedCoursesByInstructorId($request->instructor_id, 5);
             
         return new InstructorCourseIndexResource($courses);
     }

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -28,7 +28,7 @@ class CourseController extends Controller
         $manager = Instructor::with('managings')->findOrFail($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
-
+        
         // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
         if (!in_array((int)$request->instructor_id, $instructorIds, true)) {
             return response()->json([
@@ -37,7 +37,7 @@ class CourseController extends Controller
             ], 403);
         }
 
-        $courses = $queryService->getCoursesByManagerInstructorId($request->instructor_id);
+        $courses = $queryService->getCoursesByInstructorId($request->instructor_id);
             
         return new InstructorCourseIndexResource($courses);
     }

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -8,6 +8,7 @@ use App\Http\Resources\Manager\InstructorCourseIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Support\Facades\Auth;
+use App\Services\Course\QueryService;
 
 class CourseController extends Controller
 {
@@ -15,9 +16,10 @@ class CourseController extends Controller
      * 講師-講座情報一覧取得API
      *
      * @param InstructorCourseIndexRequest $request
+     * @param QueryService $queryService
      * @return InstructorCourseIndexResource|\Illuminate\Http\JsonResponse
      */
-    public function index(InstructorCourseIndexRequest $request)
+    public function index(InstructorCourseIndexRequest $request, QueryService $queryService): InstructorCourseIndexResource
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -35,9 +37,8 @@ class CourseController extends Controller
             ], 403);
         }
 
-        $courses = Course::where('instructor_id', $request->instructor_id)
-            ->paginate(5);
-
+        $courses = $queryService->getCoursesByManagerInstructorId($request->instructor_id);
+            
         return new InstructorCourseIndexResource($courses);
     }
 }

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -8,6 +8,7 @@ use App\Http\Resources\Manager\InstructorCourseIndexResource;
 use App\Model\Instructor;
 use Illuminate\Support\Facades\Auth;
 use App\Services\Course\QueryService;
+use Illuminate\Http\JsonResponse;
 
 class CourseController extends Controller
 {
@@ -16,9 +17,9 @@ class CourseController extends Controller
      *
      * @param InstructorCourseIndexRequest $request
      * @param QueryService $queryService
-     * @return InstructorCourseIndexResource|\Illuminate\Http\JsonResponse
+     * @return InstructorCourseIndexResource|JsonResponse
      */
-    public function index(InstructorCourseIndexRequest $request, QueryService $queryService): InstructorCourseIndexResource
+    public function index(InstructorCourseIndexRequest $request, QueryService $queryService)
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -27,7 +28,7 @@ class CourseController extends Controller
         $manager = Instructor::with('managings')->findOrFail($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
-        
+
         // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
         if (!in_array((int)$request->instructor_id, $instructorIds, true)) {
             return response()->json([
@@ -37,7 +38,7 @@ class CourseController extends Controller
         }
 
         $courses = $queryService->getPaginatedCoursesByInstructorId($request->instructor_id, 5);
-            
+
         return new InstructorCourseIndexResource($courses);
     }
 }

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -37,7 +37,7 @@ class CourseController extends Controller
             ], 403);
         }
 
-        $courses = $queryService->getCoursesByInstructorId($request->instructor_id);
+        $courses = $queryService->getCoursesByManagerInstructorId($request->instructor_id);
             
         return new InstructorCourseIndexResource($courses);
     }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -47,10 +47,11 @@ class QueryService
      * ログイン中のマネージャー及び配下の講師の所有するコースリストを個別指定して取得
      *
      * @param int $instructorId
+     * @param int $perPage
      * @return LengthAwarePaginator
      */
-    public function getCoursesByManagerInstructorId(int $instructorId): LengthAwarePaginator
+    public function getPaginatedCoursesByInstructorId(int $instructorId, int $perPage): LengthAwarePaginator
     {
-        return Course::where('instructor_id', $instructorId)->paginate(5);
+        return Course::where('instructor_id', $instructorId)->paginate($perPage);
     }
 }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -50,6 +50,6 @@ class QueryService
      */
     public function getCoursesByManagerInstructorId(int $instructorId): Collection
     {
-        return Course::where('instructor_id', $instructorId)->get();
+        return Course::where('instructor_id', $instructorId)->paginate(5);
     }
 }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -4,6 +4,7 @@ namespace App\Services\Course;
 
 use App\Model\Course;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class QueryService
 {
@@ -46,10 +47,10 @@ class QueryService
      * ログイン中のマネージャー及び配下の講師の所有するコースリストを個別指定して取得
      *
      * @param int $instructorId
-     * @return Collection<Course>
+     * @return LengthAwarePaginator
      */
-    public function getCoursesByManagerInstructorId(int $instructorId): Collection
+    public function getCoursesByManagerInstructorId(int $instructorId): LengthAwarePaginator
     {
-        return Course::where('instructor_id', $instructorId)->get();
+        return Course::where('instructor_id', $instructorId)->paginate(5);
     }
 }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -50,6 +50,6 @@ class QueryService
      */
     public function getCoursesByManagerInstructorId(int $instructorId): Collection
     {
-        return Course::where('instructor_id', $instructorId)->paginate(5);
+        return Course::where('instructor_id', $instructorId)->get();
     }
 }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -19,7 +19,7 @@ class QueryService
     }
 
     /**
-     * ログイン中のインストラクターの所有するコースリストを取得
+     * ログイン中の講師の所有するコースリストを取得
      *
      * @param int $instructorId
      * @return Collection<Course>
@@ -27,5 +27,18 @@ class QueryService
     public function getCoursesByInstructorId(int $instructorId): Collection
     {
         return Course::where('instructor_id', $instructorId)->get();
+    }
+
+    /**
+     * ログイン中のマネージャーの所有するコースリストと配下の講師の所有するコースリストを取得
+     *
+     * @param array<int> $instructorIds
+     * @return Collection<Course>
+     */
+    public function getCoursesByInstructorIds(array $instructorIds): Collection
+    {
+        return Course::with('instructor')
+        ->whereIn('instructor_id', $instructorIds)
+        ->get();
     }
 }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -4,7 +4,7 @@ namespace App\Services\Course;
 
 use App\Model\Course;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 class QueryService
 {
@@ -31,7 +31,7 @@ class QueryService
     }
 
     /**
-     * ログイン中のマネージャーの所有するコースリストと配下の講師の所有するコースリストを取得
+     * 講師IDのリストから講座情報を取得
      *
      * @param array<int> $instructorIds
      * @return Collection<Course>
@@ -44,7 +44,7 @@ class QueryService
     }
 
     /**
-     * ログイン中のマネージャー及び配下の講師の所有するコースリストを個別指定して取得
+     * 講師IDから講座情報を取得（ページネーション）
      *
      * @param int $instructorId
      * @param int $perPage

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -41,4 +41,15 @@ class QueryService
         ->whereIn('instructor_id', $instructorIds)
         ->get();
     }
+
+    /**
+     * ログイン中のマネージャー及び配下の講師の所有するコースリストを個別指定して取得
+     *
+     * @param int $instructorId
+     * @return Collection<Course>
+     */
+    public function getCoursesByManagerInstructorId(int $instructorId): Collection
+    {
+        return Course::where('instructor_id', $instructorId)->get();
+    }
 }

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -4,12 +4,12 @@ namespace App\Services\Course;
 
 use App\Model\Course;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 class QueryService
 {
     /**
-     * 選択されたコースを取得
+     * 講座情報を取得
      *
      * @param int $courseId
      * @return Course
@@ -20,7 +20,7 @@ class QueryService
     }
 
     /**
-     * ログイン中の講師の所有するコースリストを取得
+     * 講師IDから講座情報を取得
      *
      * @param int $instructorId
      * @return Collection<Course>
@@ -31,7 +31,7 @@ class QueryService
     }
 
     /**
-     * ログイン中のマネージャーの所有するコースリストと配下の講師の所有するコースリストを取得
+     * 講師IDのリストから講座情報を取得
      *
      * @param array<int> $instructorIds
      * @return Collection<Course>
@@ -44,7 +44,7 @@ class QueryService
     }
 
     /**
-     * ログイン中のマネージャー及び配下の講師の所有するコースリストを個別指定して取得
+     * 講師IDから講座情報を取得（ページネーション）
      *
      * @param int $instructorId
      * @param int $perPage


### PR DESCRIPTION
## issue
- https://gut-familie.atlassian.net/browse/JKA-1001

## 概要
- Manager/CourseControllerにQueryServiceの適用（共通化）

## 動作確認手順
- postmanを使ってマネージャー権限のあるインストラクター(instructor_id = 1)でログイン後、HTTPメソッド: get でhttp://localhost:8080/api/v1/manager/course/index
にアクセスし、コース一覧が表示されるのを確認（indexメソッド）
- postmanを使ってマネージャー権限のあるインストラクター(instructor_id = 1)でログイン後、HTTPメソッド: get で
http://localhost:8080/api/v1/manager/course/1
にアクセスし、コース（course_id=1）の内容が表示されるのを確認（showメソッド）
- postmanを使ってマネージャー権限のあるインストラクター(instructor_id = 1)でログイン後、HTTPメソッド: get で
http://localhost:8080/api/v1/manager/instructor/1/course/index
にアクセスし、ルーティングで指定したマネージャー自身、もしくは配下の講師のそれぞれ固有のコース一覧が表示されるのを確認（Manager/Instructor/CourseController内のindexメソッド）
