### PR TITLE
JKA990空の配列を返すルーターとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -396,7 +396,7 @@ class LessonController extends Controller
         }
     }
 
-    public function allDelete() {
+    public function deleteAll() {
         return response()->json([]);
     }
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -395,4 +395,9 @@ class LessonController extends Controller
             ], 403);
         }
     }
+
+    public function allDelete() {
+        return response()->json([]);
+    }
+
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -396,8 +396,8 @@ class LessonController extends Controller
         }
     }
 
-    public function allDelete() {
+    public function allDelete()
+    {
         return response()->json([]);
     }
-
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -189,6 +189,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
                                     Route::put('status', 'Api\Manager\LessonController@putStatus');
+                                    Route::delete('all', 'Api\Manager\LessonController@allDelete');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -189,7 +189,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::post('/', 'Api\Manager\LessonController@store');
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
                                     Route::put('status', 'Api\Manager\LessonController@putStatus');
-                                    Route::delete('all', 'Api\Manager\LessonController@allDelete');
+                                    Route::delete('all', 'Api\Manager\LessonController@deleteAll');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');


### PR DESCRIPTION

## 概要
- 子JKA1002　JKA990空の配列を返すルーターとコントローラの作成

## 動作確認手順
-Postmanにて確認
http://localhost:8080/api/v1/manager/course/:course_id/chapter/:chapter_id/lesson/all

- 講師側でログイン

DELETEリクエスト

ヘッダー
X-XSRF-TOKEN　{{XSRF-TOKEN}}
Referer　http://localhost:3000/
Origin　http://localhost:3000/

ボディ
[ ]

スクリプト
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
url: 'http://localhost:8080/sanctum/csrf-cookie',
method: 'GET'
}, function (error, response, { cookies }) {
let xsrfCookie = cookies.one('XSRF-TOKEN');
if (xsrfCookie) {
let xsrfToken = decodeURIComponent(xsrfCookie['value']);
console.log(xsrfToken);
pm.request.headers.upsert({
key: 'X-XSRF-TOKEN',
value: xsrfToken,
});
pm.environment.set('XSRF-TOKEN', xsrfToken);
}
})

レスポンス
[　]