### PR TITLE
親-JKA989講師側 チャプター作成画面 チャプターに紐づく全レッスンを削除するAPI作成　子課題ロジック作成（たわらつみだ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -326,7 +326,7 @@ class ChapterController extends Controller
         }
     }
 
-    /**
+    /****
      * チャプターに紐づく全レッスンを削除するAPI
      *
      * @param DeleteAllLessonsRequest $request

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -327,10 +327,53 @@ class ChapterController extends Controller
     }
 
     /**
-    * チャプターに紐づく全レッスンを削除するAPI
-    */
-    public function deleteAllLessons() {
-        return response()->json([]);
+     * チャプターに紐づく全レッスンを削除するAPI
+     *
+     * @param DeleteAllLessonsRequest $request
+     * @return JsonResponse
+     */
+    public function deleteAllLessons(DeleteAllLessonsRequest $request): JsonResponse
+    {
+        DB::beginTransaction();
+
+        try {
+            // チャプターを取得
+            /** @var Chapter $chapter */
+            $chapter = Chapter::with('course.lessons')->findOrFail($request->chapter_id);
+
+            // 現在の講師がチャプターの講座の作成者であるか確認
+            if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Invalid instructor_id.'
+                ], 403);
+            }
+
+            // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
+            if ((int) $request->course_id !== $chapter->course->id) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Invalid course_id.',
+                ], 403);
+            }
+
+            // チャプターに紐づく全レッスンを削除
+            $chapter->lessons()->delete();
+
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+                'message' => 'All lessons deleted successfully.',
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to delete lessons.',
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -326,56 +326,7 @@ class ChapterController extends Controller
         }
     }
 
-    /****
-     * チャプターに紐づく全レッスンを削除するAPI
-     *
-     * @param DeleteAllLessonsRequest $request
-     * @return JsonResponse
-     */
-    public function deleteAllLessons(DeleteAllLessonsRequest $request): JsonResponse
-    {
-        DB::beginTransaction();
-
-        try {
-            // チャプターを取得
-            /** @var Chapter $chapter */
-            $chapter = Chapter::with('course.lessons')->findOrFail($request->chapter_id);
-
-            // 現在の講師がチャプターの講座の作成者であるか確認
-            if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid instructor_id.'
-                ], 403);
-            }
-
-            // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-            if ((int) $request->course_id !== $chapter->course->id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid course_id.',
-                ], 403);
-            }
-
-            // チャプターに紐づく全レッスンを削除
-            $chapter->lessons()->delete();
-
-            DB::commit();
-
-            return response()->json([
-                'result' => true,
-                'message' => 'All lessons deleted successfully.',
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to delete lessons.',
-            ], 500);
-        }
-    }
-
+   
     /**
      * チャプター並び替えAPI
      *

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -325,7 +325,6 @@ class ChapterController extends Controller
             ], 500);
         }
     }
-
    
     /**
      * チャプター並び替えAPI

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -325,7 +325,7 @@ class ChapterController extends Controller
             ], 500);
         }
     }
-   
+
     /**
      * チャプター並び替えAPI
      *

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -243,7 +243,7 @@ class LessonController extends Controller
     * @param DeleteAllLessonsRequest $request
     * @return JsonResponse
     */
-   public function deleteAllLessons(DeleteAllLessonsRequest $request): JsonResponse
+   public function dallDelete(DeleteAllLessonsRequest $request): JsonResponse
    {
        DB::beginTransaction();
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -324,13 +324,12 @@ class LessonController extends Controller
     */
     public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
-	
-	try {
 
+        try {
             // チャプターを取得
             /** @var Chapter $chapter */
             $chapter = Chapter::with('course')->findOrFail($chapter_id);
- 
+
             // 現在の講師がチャプターの講座の作成者であるか確認
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
                 return response()->json([
@@ -338,7 +337,7 @@ class LessonController extends Controller
                     'message' => 'Invalid instructor_id.'
                 ], 403);
             }
- 
+
             // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
             if ((int) $course_id !== $chapter->course->id) {
                 return response()->json([
@@ -346,28 +345,27 @@ class LessonController extends Controller
                     'message' => 'Invalid course_id.',
                 ], 403);
             }
- 
+
             // 認可チェックをパスした後にトランザクションを開始
             DB::beginTransaction();
 
             // チャプターに紐づく全レッスンを削除
             $chapter->lessons()->delete();
- 
+
             DB::commit();
- 
+
             return response()->json([
                 'result' => true,
             ]);
-	        } catch (Exception $e) {
+        } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
             return response()->json([
-                'result' => false,
-                'message' => 'Failed to delete lessons.',
+            'result' => false,
+            'message' => 'Failed to delete lessons.',
             ], 500);
-        
         }
-}
+    }
 
     /**
      * レッスン並び替えAPI

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -237,7 +237,58 @@ class LessonController extends Controller
                 'message' => 'Failed to delete lessons.',
             ], 500);
         }
-    }
+    } /****
+    * チャプターに紐づく全レッスンを削除するAPI
+    *
+    * @param DeleteAllLessonsRequest $request
+    * @return JsonResponse
+    */
+   public function deleteAllLessons(DeleteAllLessonsRequest $request): JsonResponse
+   {
+       DB::beginTransaction();
+
+       try {
+           // チャプターを取得
+           /** @var Chapter $chapter */
+           $chapter = Chapter::with('course.lessons')->findOrFail($request->chapter_id);
+
+           // 現在の講師がチャプターの講座の作成者であるか確認
+           if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
+               return response()->json([
+                   'result' => false,
+                   'message' => 'Invalid instructor_id.'
+               ], 403);
+           }
+
+           // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
+           if ((int) $request->course_id !== $chapter->course->id) {
+               return response()->json([
+                   'result' => false,
+                   'message' => 'Invalid course_id.',
+               ], 403);
+           }
+
+           // チャプターに紐づく全レッスンを削除
+           $chapter->lessons()->delete();
+
+           DB::commit();
+
+           return response()->json([
+               'result' => true,
+               'message' => 'All lessons deleted successfully.',
+           ]);
+       } catch (Exception $e) {
+           DB::rollBack();
+           Log::error($e);
+           return response()->json([
+               'result' => false,
+               'message' => 'Failed to delete lessons.',
+           ], 500);
+       }
+   }
+
+
+
 
     /**
      * レッスンステータス更新API

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -322,7 +322,7 @@ class LessonController extends Controller
     * @param Requestt $request
     * @return JsonResponse
     */
-    public function allDelete(Request $request, int $course_id, int $chapter_id): JsonResponse
+    public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
         DB::beginTransaction();
 	
@@ -355,7 +355,6 @@ class LessonController extends Controller
  
             return response()->json([
                 'result' => true,
-                'message' => 'All lessons deleted successfully.',
             ]);
 	} catch (Exception $e) {
             DB::rollBack();

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -325,8 +325,7 @@ class LessonController extends Controller
     public function allDelete(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
         DB::beginTransaction();
- 
-        try {
+
             // チャプターを取得
             /** @var Chapter $chapter */
             $chapter = Chapter::with('course.lessons')->findOrFail($request->chapter_id);
@@ -355,15 +354,14 @@ class LessonController extends Controller
             return response()->json([
                 'result' => true,
                 'message' => 'All lessons deleted successfully.',
-            ]);
-        } catch (Exception $e) {
+            ]);        
             DB::rollBack();
             Log::error($e);
             return response()->json([
                 'result' => false,
                 'message' => 'Failed to delete lessons.',
             ], 500);
-        }
+        
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -24,6 +24,7 @@ use App\Http\Requests\Instructor\LessonBulkDeleteRequest;
 use App\Http\Requests\Instructor\LessonPatchStatusRequest;
 use App\Http\Requests\Instructor\LessonUpdateTitleRequest;
 use Illuminate\Http\Request;
+use App\Model\Chapter;
 
 class LessonController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -324,7 +324,6 @@ class LessonController extends Controller
     */
     public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
-        DB::beginTransaction();
 	
 	try {
 
@@ -348,6 +347,9 @@ class LessonController extends Controller
                 ], 403);
             }
  
+            // 認可チェックをパスした後にトランザクションを開始
+            DB::beginTransaction();
+
             // チャプターに紐づく全レッスンを削除
             $chapter->lessons()->delete();
  
@@ -356,7 +358,7 @@ class LessonController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-	} catch (Exception $e) {
+	        } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -328,7 +328,7 @@ class LessonController extends Controller
 
             // チャプターを取得
             /** @var Chapter $chapter */
-            $chapter = Chapter::with('course.lessons')->findOrFail($request->chapter_id);
+            $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
  
             // 現在の講師がチャプターの講座の作成者であるか確認
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
@@ -354,7 +354,7 @@ class LessonController extends Controller
             return response()->json([
                 'result' => true,
                 'message' => 'All lessons deleted successfully.',
-            ]);        
+            ]);
             DB::rollBack();
             Log::error($e);
             return response()->json([

--- a/routes/api.php
+++ b/routes/api.php
@@ -92,6 +92,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::put('status', 'Api\Instructor\LessonController@putStatus');
                                 Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
+                                Route::delete('all', 'Api\Instructor\ChapterController@allDelete');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,7 +55,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('{notification_id}', 'Api\Student\NotificationController@show');
         });
     });
-
+    
     // 講師側API
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         });
     });
 
+    
     // 講師側API
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,7 +56,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         });
     });
 
-
     // 講師側API
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述
@@ -85,14 +84,13 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::patch('/', 'Api\Instructor\ChapterController@update');
                             Route::patch('status', 'Api\Instructor\ChapterController@updateStatus');
                             Route::delete('/', 'Api\Instructor\ChapterController@delete');
-                            Route::delete('lessons/all', 'Api\Instructor\ChapterController@deleteAllLessons');
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', 'Api\Instructor\LessonController@store');
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::put('status', 'Api\Instructor\LessonController@putStatus');
                                 Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
-                                Route::delete('all', 'Api\Instructor\ChapterController@allDelete');
+                                Route::delete('all', 'Api\Instructor\LessonController@allDelete');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,7 +91,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::post('sort', 'Api\Instructor\LessonController@sort');
                                 Route::put('status', 'Api\Instructor\LessonController@putStatus');
                                 Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
-                                Route::delete('all', 'Api\Instructor\LessonController@allDelete');
+                                Route::delete('all', 'Api\Instructor\LessonController@deleteAll');
                                 Route::prefix('{lesson_id}')->group(function () {
                                     Route::put('/', 'Api\Instructor\LessonController@update');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,7 +55,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('{notification_id}', 'Api\Student\NotificationController@show');
         });
     });
-
     
     // 講師側API
     Route::middleware('instructor')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,7 +55,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('{notification_id}', 'Api\Student\NotificationController@show');
         });
     });
-    
+
+
     // 講師側API
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,7 +55,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('{notification_id}', 'Api\Student\NotificationController@show');
         });
     });
-    
+
     // 講師側API
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述


### PR DESCRIPTION
## 概要
-  JJKA989ロジックの作成（たわらつみだ）

## 動作確認
Postmanにて確認

- http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id/lesson/all

### チャプターに紐づく全レッスンを削除の場合
- 講師側でログイン
email:test_instructor@example.com
password:Hash::make('password')

- DELETEリクエスト

- パラメータ
couse_id:1
chapter_id:2

- レスポンス
{
    "result": true,
}

### 指定された course_id がチャプターに関連付けられている course_id と一致するか確認の場合

- 講師側でログイン
email:test_instructor@example.com
password:Hash::make('password')

- DELETEリクエスト

- パラメータ
couse_id:1
chapter_id:4

- レスポンス
{
    "result": false,
    "message": "Invalid instructor_id."
}

### 現在の講師がチャプターの講座の作成者であるか確認の場合
- 講師側でログイン
email:test_instructor2@example.com
password:password'

- DELETEリクエスト

- パラメータ
couse_id:1
chapter_id:2

- レスポンス
{
    "result": false,
    "message": "Invalid instructor_id."
}

### 考慮してほしいこと
なし

### 確認したいこと
今回は、api.phpは変更しておりませんがFiles changedに変更履歴があります。問題ないのでしょうか。
