### PR TITLE
講師側 チャプター作成画面 チャプターに紐づく全レッスンを削除するAPI作成　子タスクフォームリクエストの作成（たわらつみだ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -23,7 +23,7 @@ use App\Http\Requests\Instructor\LessonPutStatusRequest;
 use App\Http\Requests\Instructor\LessonBulkDeleteRequest;
 use App\Http\Requests\Instructor\LessonPatchStatusRequest;
 use App\Http\Requests\Instructor\LessonUpdateTitleRequest;
-use Illuminate\Http\Request;
+use App\Http\Requests\Instructor\DeleteAllLessonsRequest;
 use App\Model\Chapter;
 
 class LessonController extends Controller
@@ -319,16 +319,16 @@ class LessonController extends Controller
     /**
     * チャプターに紐づく全レッスンを削除するAPI
     *
-    * @param Requestt $request
+    * @param RDeleteAllLessonsRequest $request
     * @return JsonResponse
     */
-    public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
+    public function deleteAll(DeleteAllLessonsRequest $request ): JsonResponse
     {
 
         try {
             // チャプターを取得
             /** @var Chapter $chapter */
-            $chapter = Chapter::with('course')->findOrFail($chapter_id);
+            $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
             // 現在の講師がチャプターの講座の作成者であるか確認
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
@@ -339,7 +339,7 @@ class LessonController extends Controller
             }
 
             // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-            if ((int) $course_id !== $chapter->course->id) {
+            if ((int) $request->course_id !== $chapter->course->id) {
                 return response()->json([
                     'result' => false,
                     'message' => 'Invalid course_id.',

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -23,7 +23,7 @@ use App\Http\Requests\Instructor\LessonPutStatusRequest;
 use App\Http\Requests\Instructor\LessonBulkDeleteRequest;
 use App\Http\Requests\Instructor\LessonPatchStatusRequest;
 use App\Http\Requests\Instructor\LessonUpdateTitleRequest;
-use App\Http\Requests\Instructor\DeleteAllLessonsRequest;
+use App\Http\Requests\Instructor\LessonsAllDeleteRequest;
 use App\Model\Chapter;
 
 class LessonController extends Controller
@@ -319,10 +319,10 @@ class LessonController extends Controller
     /**
     * チャプターに紐づく全レッスンを削除するAPI
     *
-    * @param RDeleteAllLessonsRequest $request
+    * @param LessonsAllDeleteRequest $request
     * @return JsonResponse
     */
-    public function deleteAll(DeleteAllLessonsRequest $request ): JsonResponse
+    public function deleteAll(LessonsAllDeleteRequest $request ): JsonResponse
     {
 
         try {

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -322,7 +322,7 @@ class LessonController extends Controller
     * @param LessonsAllDeleteRequest $request
     * @return JsonResponse
     */
-    public function deleteAll(LessonsAllDeleteRequest $request ): JsonResponse
+    public function deleteAll(LessonsAllDeleteRequest $request): JsonResponse
     {
 
         try {

--- a/app/Http/Requests/Instructor/DeleteAllLessonsRequest.php
+++ b/app/Http/Requests/Instructor/DeleteAllLessonsRequest.php
@@ -13,7 +13,7 @@ class DeleteAllLessonsRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true; // 認証チェックが必要であれば、適宜追加してください。
+        return true;
     }
 
     /**

--- a/app/Http/Requests/Instructor/DeleteAllLessonsRequest.php
+++ b/app/Http/Requests/Instructor/DeleteAllLessonsRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteAllLessonsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true; // 認証チェックが必要であれば、適宜追加してください。
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
+++ b/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class DeleteAllLessonsRequest extends FormRequest
+class LessonsAllDeleteRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -24,8 +24,8 @@ class DeleteAllLessonsRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id'],
-            'chapter_id' => ['required', 'integer', 'exists:chapters,id'],
+            'course_id' => ['required', 'integer', 'exists:courses,id','deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id','deleted_at,NULL'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
+++ b/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
@@ -37,4 +37,3 @@ class LessonsAllDeleteRequest extends FormRequest
         ];
     }
 }
-

--- a/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
+++ b/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
@@ -16,6 +16,14 @@ class LessonsAllDeleteRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -24,20 +32,9 @@ class LessonsAllDeleteRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id'],
-            'chapter_id' => ['required', 'integer', 'exists:chapters,id'],
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
         ];
-    }
-
-    /**
-     * バリデーション前にリクエストデータを加工する
-     */
-    protected function prepareForValidation(): void
-    {
-        $this->merge([
-            'course_id' => $this->route('course_id'),
-            'chapter_id' => $this->route('chapter_id'),
-        ]);
     }
 }
 

--- a/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
+++ b/app/Http/Requests/Instructor/LessonsAllDeleteRequest.php
@@ -24,8 +24,20 @@ class LessonsAllDeleteRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id','deleted_at,NULL'],
-            'chapter_id' => ['required', 'integer', 'exists:chapters,id','deleted_at,NULL'],
+            'course_id' => ['required', 'integer', 'exists:courses,id'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id'],
         ];
     }
+
+    /**
+     * バリデーション前にリクエストデータを加工する
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
 }
+


### PR DESCRIPTION
## 概要
-  JJKA989フォームリクエストの作成（たわらつみだ）

## 動作確認
Postmanにて確認

- http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id/lesson/all

### チャプターに紐づく全レッスンを削除の場合
- 講師側でログイン
email:test_instructor@example.com
password:Hash::make('password')

- DELETEリクエスト

- パラメータ
couse_id:1
chapter_id:2

- ボディ
なし

- レスポンス
{
    "result": true,
}

### 指定された course_id がチャプターに関連付けられている course_id と一致するか確認の場合

- 講師側でログイン
email:test_instructor@example.com
password:Hash::make('password')

- DELETEリクエスト

- パラメータ
couse_id:1
chapter_id:4

- ボディ
なし

- レスポンス
{
    "result": false,
    "message": "Invalid instructor_id."
}

### 現在の講師がチャプターの講座の作成者であるか確認の場合
- 講師側でログイン
email:test_instructor2@example.com
password:password'

- DELETEリクエスト

- パラメータ
couse_id:1
chapter_id:2

- ボディ
なし

- レスポンス
{
    "result": false,
    "message": "Invalid instructor_id."
}

### 考慮してほしいこと
なし
