### PR TITLE
マネージャー(講師側) チャプター作成画面 全チャプターを削除するAPI作成(topicブランチからdevelopへのプルリク)　松本

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,7 +245,8 @@ class ChapterController extends Controller
         }
     }
 
-    public function alldelete() {
+    public function alldelete()
+    {
         return response()->json([]);
     }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,6 +245,10 @@ class ChapterController extends Controller
         }
     }
 
+    public function alldelete() {
+        return response()->json([]);
+    }
+
     /**
      * チャプター並び替えAPI
      *

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -267,14 +267,10 @@ class ChapterController extends Controller
             // course_id に紐づくすべてのチャプターを取得
             $chapters = Chapter::where('course_id', $courseId)->get();
 
-            $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
-                //インストラクターIDのバリデーション
+            $chapters->each(function (Chapter $chapter) use ($instructorIds) {
+                // 自分、または配下の講師の講座のチャプターでなければエラー応答
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     throw new ValidationErrorException('Invalid instructor_id.');
-                }
-                //コースIDのバリデーション
-                if ((int) $courseId !== $chapter->course_id) {
-                    throw new ValidationErrorException('Invalid course.');
                 }
             });
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -296,7 +296,7 @@ class ChapterController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-            
+
             return response()->json([
                 'result' => false,
                 'message' => 'Failed to delete chapters.',

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -21,6 +21,7 @@ use App\Http\Requests\Manager\ChapterDeleteRequest;
 use App\Http\Resources\Manager\ChapterShowResource;
 use App\Http\Requests\Manager\ChapterPutStatusRequest;
 use App\Http\Requests\Manager\ChapterBulkDeleteRequest;
+use App\Http\Requests\Manager\ChapterDeleteAllRequest;
 use App\Http\Requests\Manager\ChapterPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\Requests\Manager\ChaptersPatchStatusRequest;
@@ -245,9 +246,62 @@ class ChapterController extends Controller
         }
     }
 
-    public function deleteAll()
+    /**
+     * 全チャプター削除API
+     *
+     * @param ChapterDeleteAllRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function deleteAll(ChapterDeleteAllRequest $request)
     {
-        return response()->json([]);
+        //現在のユーザーを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        // マネージャーが管理する講師を取得
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        try {
+            // リクエストから course_id を取得
+            $courseId = $request->input('course_id');
+            // course_id に紐づくすべてのチャプターを取得
+            $chapters = Chapter::where('course_id', $courseId)->get();
+
+            $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
+                //インストラクターIDのバリデーション
+                if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+                    throw new ValidationErrorException('Invalid instructor_id.');
+                }
+                //コースIDのバリデーション
+                if ((int) $courseId !== $chapter->course_id) {
+                    throw new ValidationErrorException('Invalid course.');
+                }
+            });
+
+            DB::beginTransaction();
+            //course_idに関連する全てのチャプターを削除
+            Chapter::where('course_id', $courseId)->delete();
+            //全て成功した場合にコミット
+            DB::commit();
+            //成功した場合のレスポンス
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (ValidationErrorException $e) {
+            //バリデーションエラーが発生した場合の処理
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ], 403);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to delete chapters.',
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,7 +245,8 @@ class ChapterController extends Controller
         }
     }
 
-    public function deleteAll() {
+    public function deleteAll()
+    {
         return response()->json([]);
     }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -245,7 +245,7 @@ class ChapterController extends Controller
         }
     }
 
-    public function alldelete() {
+    public function deleteAll() {
         return response()->json([]);
     }
 

--- a/app/Http/Requests/Manager/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Manager/ChapterDeleteAllRequest.php
@@ -25,8 +25,6 @@ class ChapterDeleteAllRequest extends FormRequest
     {
         return [
            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
-           'chapters' => ['required', 'array'],
-           'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
         ];
     }
 

--- a/app/Http/Requests/Manager/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Manager/ChapterDeleteAllRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChapterDeleteAllRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+           'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+           'chapters' => ['required', 'array'],
+           'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -178,7 +178,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::put('status', 'Api\Manager\ChapterController@putStatus');
                             Route::delete('/', 'Api\Manager\ChapterController@bulkDelete');
-                            Route::delete('all', 'Api\Manager\ChapterController@alldelete');
+                            Route::delete('all', 'Api\Manager\ChapterController@deleteAll');
                             Route::patch('status', 'Api\Manager\ChapterController@patchStatus');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -178,6 +178,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::post('/', 'Api\Manager\ChapterController@store');
                             Route::put('status', 'Api\Manager\ChapterController@putStatus');
                             Route::delete('/', 'Api\Manager\ChapterController@bulkDelete');
+                            Route::delete('all', 'Api\Manager\ChapterController@alldelete');
                             Route::patch('status', 'Api\Manager\ChapterController@patchStatus');
                             Route::prefix('{chapter_id}')->group(function () {
                                 Route::get('/', 'Api\Manager\ChapterController@show');


### PR DESCRIPTION
## 概要
- マネージャー(講師側) チャプター作成画面 全チャプターを削除するAPI作成(topicブランチからdevelopへのプルリク)

## 動作確認
- 全チャプターが削除されることを確認 
Postmanにて
http://localhost:8080/api/v1/manager/course/2/chapter/all
に送信。trueが返ってくることを確認
AdminerにてチャプターIDの4,5がdeleted_atになっていることを確認。

- バリデーションエラーが正しく機能しているか確認
http://localhost:8080/api/v1/manager/course/{course_id}/chapter/all
コースIDが整数ではない場合、存在しないコース番号、指定したコースがdelete_atになっている場合
それぞれバリデーションエラーになることを確認

- 認可のチェック
Postmanにて
担当ではない別のマネージャーへログイン後
http://localhost:8080/api/v1/manager/course/2/chapter/all
に送信。Invalid instructor_id
が返ってくることを確認

