### PR TITLE
(辻/G2)受講生側 StundentControllerでのQueryServiceの作成→適用（共通化)<親-JKA-981-講師・マネージャー・受講生側Student..>

### DIFF
--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use App\Model\StudentAuthorization;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
@@ -32,11 +33,16 @@ class StudentController extends Controller
      * 生徒情報取得API
      *
      * @param Request $request
+     * @param QueryService $queryService
      * @return StudentShowResource
      */
     public function show(Request $request, QueryService $queryService)
     {
-        $student = $queryService->get($request->student_id);
+        // ユーザーID取得(認証済みのユーザーを取得)
+        $studentId = $request->user()->id;
+        // 生徒情報を取得 (getStudent メソッドを使用)
+        $student = $queryService->getStudent($studentId);
+        // 生徒の詳細情報をリソース形式で返す
         return new StudentShowResource($student);
     }
 

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
+use App\Services\Student\QueryService;
 use App\Mail\AuthenticationConfirmationMail;
 use App\Http\Requests\Student\StudentPostRequest;
 use App\Http\Requests\Student\StudentPatchRequest;
@@ -33,9 +34,9 @@ class StudentController extends Controller
      * @param Request $request
      * @return StudentShowResource
      */
-    public function show(Request $request)
+    public function show(Request $request, QueryService $queryService)
     {
-        $student = Student::findOrFail($request->user()->id);
+        $student = $queryService->get($request->student_id);
         return new StudentShowResource($student);
     }
 

--- a/app/Services/Student/QueryService.php
+++ b/app/Services/Student/QueryService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\Student;
+
+use App\Model\Student;
+use Illuminate\Database\Eloquent\Collection;
+
+class QueryService
+{
+    /**
+     * 選択された生徒の情報を取得
+     *
+     * @param int $studentId
+     * @return Student
+     */
+    public function get(int $studentId): Student
+    {
+        return Student::
+    }
+
+    /**
+     * 選択された生徒情報一覧を取得
+     *
+     * @param int $studentId
+     * @return Collection<Student>
+     */
+    public function get(int $studentId): Collection
+    {
+        return Student::where('student_id', $studentId)->get();
+    }
+}

--- a/app/Services/Student/QueryService.php
+++ b/app/Services/Student/QueryService.php
@@ -3,7 +3,6 @@
 namespace App\Services\Student;
 
 use App\Model\Student;
-use Illuminate\Database\Eloquent\Collection;
 
 class QueryService
 {
@@ -13,19 +12,8 @@ class QueryService
      * @param int $studentId
      * @return Student
      */
-    public function get(int $studentId): Student
+    public function getStudent(int $studentId):Student
     {
-        return Student::
-    }
-
-    /**
-     * 選択された生徒情報一覧を取得
-     *
-     * @param int $studentId
-     * @return Collection<Student>
-     */
-    public function get(int $studentId): Collection
-    {
-        return Student::where('student_id', $studentId)->get();
+        return Student::find($studentId);
     }
 }

--- a/app/Services/Student/QueryService.php
+++ b/app/Services/Student/QueryService.php
@@ -12,7 +12,7 @@ class QueryService
      * @param int $studentId
      * @return Student
      */
-    public function getStudent(int $studentId):Student
+    public function getStudent(int $studentId): Student
     {
         return Student::find($studentId);
     }


### PR DESCRIPTION
## 概要
- 受講生側からStudentController.phpを作成。showメソッド(生徒情報取得API)のみ訂正

## 動作確認
- 生徒情報の取得を確認。
   Postmanの以下のURLで動作確認完了。
   (http://localhost:8080/api/v1/student)
   受講生をtest_student_2にして、動作確認実行。
   
   結果、Jsonにて、
  {
    "data": {
        "student_id": 2,
        "nick_name": "生徒ニックネーム2",
        "last_name": "生徒",
        "first_name": "テスト2",
        "email": "test_student_2@example.com",
        "occupation": "フロントエンジニア",
        "purpose": "サーバーサイド知識を理解したい",
        "birth_date": "2024/08/20",
        "gender": "woman",
        "address": "大阪府",
        "profile_image": "/student/image2.jpg"
    }
}
が出力された。

## 考慮してほしいこと
- Querymethodで関数名を違うもの<getStudent関係>にしても(Queryservice.php, StudentController.php)
   動作確認を行っても、上手くいきませんでした。同じものにしたら、動作確認が上手くいきました。
   9月20日作業会のアドバイスと異なっていることをしているのをご了承ください。

 - Studentcontroller.php(44行目)
   $student = $queryService->getStudent($studentId);

 - Queryservice.php(15行目)
    public function getStudent(int $studentId):Student
 
## 確認してほしいこと
特になし