### PR TITLE
親-マネージャー側 チャプター作成画面 チャプターに紐づく全レッスンを削除するAPI作成 のロジック作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -449,7 +449,6 @@ class LessonController extends Controller
                 ], 403);
             }
 
-    
             // チャプターに紐づく全レッスンを削除
             $chapter->lessons()->delete();
     

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -431,12 +431,11 @@ class LessonController extends Controller
                 ], 403);
             }
     
-            // マネージャーがチャプターのコース作成者かを確認
-            if ($instructorId !== $chapter->course->instructor_id) {
+            if ((int) $course_id !== $chapter->course_id) {
                 return response()->json([
                     'result' => false,
-                    'message' => 'Invalid instructor_id.'
-                ], 403); // 認可エラー
+                    'message' => 'Invalid course_id.',
+                ], 403);
             }
     
             // チャプターに紐づく全レッスンを削除

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Manager;
 
 use Exception;
 use App\Model\Course;
+use App\Model\Chapter;
 use App\Model\Lesson;
 use App\Model\Attendance;
 use App\Model\Instructor;
@@ -22,6 +23,7 @@ use App\Http\Requests\Manager\LessonUpdateRequest;
 use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Manager\LessonPutStatusRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
+use Illuminate\Http\Request;
 
 class LessonController extends Controller
 {
@@ -396,8 +398,68 @@ class LessonController extends Controller
         }
     }
 
-    public function deleteAll()
+    /**
+     * チャプターに紐づく全レッスンを削除する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
-        return response()->json([]);
+        DB::beginTransaction(); // トランザクションの開始
+    
+        try {
+            // チャプターを取得し、関連するコースも取得
+            /** @var Chapter $chapter */
+            $chapter = Chapter::with('course')->findOrFail($chapter_id);
+    
+            // 現在ログイン中のインストラクターのID取得
+            $instructorId = Auth::guard('instructor')->user()->id;
+            $manager = Instructor::with('managings')->find($instructorId);
+    
+            // 管理しているインストラクターIDリストを取得
+            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructorId; // 自分自身のIDをリストに追加
+    
+            // コースを取得し、認可チェック（自分または管理しているインストラクターのコースかどうか）
+            $course = Course::findOrFail($course_id);
+            if (!in_array($course->instructor_id, $instructorIds, true)) {
+                // 認可されていない場合はエラーを返す
+                return response()->json([
+                    'result'  => false,
+                    'message' => "Forbidden, not allowed to edit this course.",
+                ], 403);
+            }
+    
+            // マネージャーがチャプターのコース作成者かを確認
+            if ($instructorId !== $chapter->course->instructor_id) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Invalid instructor_id.'
+                ], 403); // 認可エラー
+            }
+    
+            // チャプターに紐づく全レッスンを削除
+            $chapter->lessons()->delete();
+    
+            // トランザクションをコミットして変更を確定
+            DB::commit();
+    
+            // 成功レスポンスを返す
+            return response()->json([
+                'result' => true,
+            ]);
+    
+        } catch (Exception $e) {
+            // エラーが発生したらトランザクションをロールバック
+            DB::rollBack();
+            Log::error($e); // エラーをログに記録
+    
+            // エラーレスポンスを返す
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to delete lessons.',
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -437,6 +437,17 @@ class LessonController extends Controller
                     'message' => 'Invalid course_id.',
                 ], 403);
             }
+            
+            // 学生が登録しているか、コース/章で進歩しているかどうかを確認します
+            $hasAttendance = Attendance::where('course_id', $course_id)->exists();
+
+            if ($hasAttendance) {
+            // 学生が登録している場合、または進歩している場合はエラーを返します
+                return response()->json([
+                    'result' => false,
+                    'message' => 'This course has attendance.',
+                ], 403);
+            }
     
             // チャプターに紐づく全レッスンを削除
             $chapter->lessons()->delete();

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -427,7 +427,7 @@ class LessonController extends Controller
                 // 認可されていない場合はエラーを返す
                 return response()->json([
                     'result'  => false,
-                    'message' => "Forbidden, not allowed to edit this course.",
+                    'message' => "Invalid instructor_id.",
                 ], 403);
             }
     

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -438,16 +438,17 @@ class LessonController extends Controller
                 ], 403);
             }
             
-            // 学生が登録しているか、コース/章で進歩しているかどうかを確認します
-            $hasAttendance = Attendance::where('course_id', $course_id)->exists();
-
-            if ($hasAttendance) {
-            // 学生が登録している場合、または進歩している場合はエラーを返します
+            // チャプターに紐づく全レッスンIDを取得
+            $lessonIds = $chapter->lessons->pluck('id');
+            $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
+            if ($attendedLessonIds->isNotEmpty()) {
+            // 出席のあるレッスンがあれば削除を許可しない
                 return response()->json([
                     'result' => false,
-                    'message' => 'This course has attendance.',
+                    'message' => 'This lessons contains attendance.'
                 ], 403);
             }
+
     
             // チャプターに紐づく全レッスンを削除
             $chapter->lessons()->delete();


### PR DESCRIPTION
JKA1003-ロジック作成

## issue
- https://gut-familie.atlassian.net/browse/JKA-1003

## 概要
- チャプターに紐づく全レッスンを削除するAPI作成のロジック作成

## 動作確認手順
-　postomanにて講師側でログインする

-　DELETEメソットで

-　http://localhost:8080/api/v1/manager/course/:course_id/chapter/:chapter_id/lesson/all
このURLにてsend する

　

## 確認してほしいこと

適したcourse_idとchapter_idであればtrueが返ってくるのかどうかの確認
