### PR TITLE
-親-<JKA-1019>マネージャー側 チャプター全削除時に受講中のチャプターは削除できないように変更(辻/G2)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -310,7 +310,6 @@ class ChapterController extends Controller
         }
     }
 
-
     /**
      * チャプター並び替えAPI
      *

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -274,7 +274,6 @@ class ChapterController extends Controller
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     throw new ValidationErrorException('Invalid instructor_id.');
                 }
-<<<<<<< HEAD
             });
             // チャプターに紐づく全レッスンIDを取得
             $lessonIds = $chapters->pluck('lessons')->flatten()->pluck('id')->toArray();
@@ -284,16 +283,6 @@ class ChapterController extends Controller
                 // 受講中のレッスンがあれば、エラー応答
                 throw new ValidationErrorException('This lesson has attendance.');
             }
-=======
-                // 受講中の講座があれば、エラー応答
-                if (LessonAttendance::where('course_id', $chapter->course->id)->exists()) {
-                    return response()->json([
-                         'result' => false,
-                         'message' => 'This lesson has attendance.'
-                    ], 403);
-                }
-            });
->>>>>>> be2f2620c9bb2e38ec82637acbd242c63615f677
 
             // チャプターを削除
             Chapter::where('course_id', $courseId)->delete();

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -269,8 +269,6 @@ class ChapterController extends Controller
 
             // チャプターを取得
             $chapters = Chapter::with(['course', 'lessons'])->where('course_id', $courseId)->get();
-            $lessonIds = $chapters->pluck('lessons')->flatten()->pluck('id')->toArray();
-            \Log::debug($lessonIds);
             $chapters->each(function (Chapter $chapter) use ($instructorIds) {
                 // 自分、または配下の講師の講座のチャプターでなければエラー応答
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
@@ -279,6 +277,7 @@ class ChapterController extends Controller
             });
             // チャプターに紐づく全レッスンIDを取得
             $lessonIds = $chapters->pluck('lessons')->flatten()->pluck('id')->toArray();
+            \Log::debug($lessonIds);
             // whereIn で複数の lesson_id があるかどうかを確認
             $attendedLessonExists = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('id')->isNotEmpty();
             if ($attendedLessonExists) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -278,12 +278,11 @@ class ChapterController extends Controller
             // チャプターに紐づく全レッスンIDを取得
             $lessonIds = $chapters->pluck('lessons')->flatten()->pluck('id')->toArray();
             // whereIn で複数の lesson_id があるかどうかを確認
-            $attendedLessonExists = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('id')->isNotEmpty();
-            if ($attendedLessonExists) {
+            $hasAttendedLessons = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('id')->isNotEmpty();
+            if ($hasAttendedLessons) {
                 // 受講中のレッスンがあれば、エラー応答
                 throw new ValidationErrorException('This lesson has attendance.');
             }
-
             // チャプターを削除
             Chapter::where('course_id', $courseId)->delete();
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -276,14 +276,14 @@ class ChapterController extends Controller
                     throw new ValidationErrorException('Invalid instructor_id.');
                 }
                 // 受講中の講座があれば、エラー応答
-                if (LessonAttendance::where('course_id', $chapter->course->id)->exists()){
+                if (LessonAttendance::where('course_id', $chapter->course->id)->exists()) {
                     return response()->json([
                          'result' => false,
-                         'message' => 'This lesson has attendance.'    
+                         'message' => 'This lesson has attendance.'
                     ], 403);
                 }
             });
-                
+
             // チャプターを削除
             Chapter::where('course_id', $courseId)->delete();
 
@@ -308,7 +308,7 @@ class ChapterController extends Controller
                 'result' => false,
                 'message' => 'Failed to delete chapters.',
             ], 500);
-        } 
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -230,6 +230,7 @@ class ChapterController extends Controller
                 'result' => true,
             ]);
         } catch (ValidationErrorException $e) {
+            DB::rollBack();
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),
@@ -275,11 +276,10 @@ class ChapterController extends Controller
                     throw new ValidationErrorException('Invalid instructor_id.');
                 }
             });
+
             // チャプターに紐づく全レッスンIDを取得
             $lessonIds = $chapters->pluck('lessons')->flatten()->pluck('id')->toArray();
-            // whereIn で複数の lesson_id があるかどうかを確認
-            $hasAttendedLessons = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('id')->isNotEmpty();
-            if ($hasAttendedLessons) {
+            if (LessonAttendance::whereIn('lesson_id', $lessonIds)->exists()) {
                 // 受講中のレッスンがあれば、エラー応答
                 throw new ValidationErrorException('This lesson has attendance.');
             }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -6,6 +6,7 @@ use Exception;
 use App\Model\Course;
 use App\Model\Chapter;
 use App\Model\Instructor;
+use App\Model\LessonAttendance;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -274,8 +275,15 @@ class ChapterController extends Controller
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     throw new ValidationErrorException('Invalid instructor_id.');
                 }
+                // 受講中の講座があれば、エラー応答
+                if (LessonAttendance::where('course_id', $chapter->course->id)->exists()){
+                    return response()->json([
+                         'result' => false,
+                         'message' => 'This lesson has attendance.'    
+                    ], 403);
+                }
             });
-
+                
             // チャプターを削除
             Chapter::where('course_id', $courseId)->delete();
 
@@ -300,7 +308,7 @@ class ChapterController extends Controller
                 'result' => false,
                 'message' => 'Failed to delete chapters.',
             ], 500);
-        }
+        } 
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -277,7 +277,6 @@ class ChapterController extends Controller
             });
             // チャプターに紐づく全レッスンIDを取得
             $lessonIds = $chapters->pluck('lessons')->flatten()->pluck('id')->toArray();
-            \Log::debug($lessonIds);
             // whereIn で複数の lesson_id があるかどうかを確認
             $attendedLessonExists = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('id')->isNotEmpty();
             if ($attendedLessonExists) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -246,11 +246,11 @@ class ChapterController extends Controller
     }
 
     /**
-    * 全チャプター削除API
-    *
-    * @param ChapterDeleteAllRequest $request
-    * @return JsonResponse
-    */
+     * 全チャプター削除API
+     *
+     * @param ChapterDeleteAllRequest $request
+     * @return JsonResponse
+     */
     public function deleteAll(ChapterDeleteAllRequest $request)
     {
         // ログイン中の講師IDを取得


### PR DESCRIPTION
## Issue
- マネージャー側 チャプター全削除時に受講中のチャプターは削除できないように変更

## 動作確認
- Postmanで動作確認を行い、<DELETEメソッド使用>
  URL(http://localhost:8080/api/v1/manager/course/:course_id/chapter/all)
  にて、
  Pathパラメーターのcourse_idを"1"に設定。(Attendanceseeder.phpのcourse_idを参照)
  <レッスン受講ありの状態>
  結果、
 {
    "result": false,
    "message": "This lesson has attendance."
  }
   
   が返ってきました。
   
- また、PostmanでPathパラメーターのcourse_idを"2"に設定し、同じURLで動作確認を行った結果、
   <レッスン受講なしの状態>
  {
    "result": true
   }
   と返ってきました。
   
 ## 確認してほしいこと
   現時点では、特にありません。
     
 ## 考慮してほしいこと
   特にありません。
    