### PR TITLE
JKA1016　マネージャー側 講師一覧画面 所有講座数の追加（たわらつみだ）

### DIFF
--- a/app/Http/Resources/Manager/InstructorIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorIndexResource.php
@@ -27,6 +27,7 @@ class InstructorIndexResource extends JsonResource
                     'email' => $instructor->email,
                     'profile_image' => $instructor->profile_image,
                     'created_at' => $instructor->created_at,
+                    'course_count' => $instructor->courses()->count(),
                 ];
             }),
             'pagination' => [

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
 
 /*
 |--------------------------------------------------------------------------

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
-
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## 概要
-  JKA1016 マネージャー側 講師一覧画面 所有講座数の追加（たわらつみだ）

## 動作確認
- Postmanにて確認
- URL: http://localhost:8080///api/v1/manager/instructor/index
- 講師側でログイン
email:test_instructor@example.com
password:password'
- GETリクエスト

- レスポンス
{
    "data": {
        "instructors": [
            {
                "instructor_id": 3,
                "nick_name": "Suzuki",
                "email": "test_instructor3@example.com",
                "profile_image": null,
                "created_at": "2024-08-18 20:25:02",
                "course_count": 2
            },
            {
                "instructor_id": 2,
                "nick_name": "Hanako",
                "email": "test_instructor2@example.com",
                "profile_image": null,
                "created_at": "2024-08-18 20:25:01",
                "course_count": 2
            },
            {
                "instructor_id": 1,
                "nick_name": "Yamada",
                "email": "test_instructor@example.com",
                "profile_image": "instructor/default.png",
                "created_at": "2024-08-18 20:25:01",
                "course_count": 2
            }
        ],
        "pagination": {
            "page": 1,
            "total": 3
        }
    }
}

### 考慮してほしいこと
なし

### 確認したいこと
１点目
所有講座数の追加ではなく講師がどれだけ講座を持っているかという確認のタスク内容になっているように見受けられますが問題ないのでしょうか。
２点目
データベースのCOURSEテーブルを確認したところinstructor_id:4が１つ講座を持っているようですがレスポンスで返ってきません。