### PR TITLE
親-講師側/マネージャー側 チャプター選択削除時に受講中のチャプターは削除できないように変更　松本

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -251,7 +251,8 @@ class ChapterController extends Controller
                     throw new ValidationErrorException('Invalid course_id.');
                 }
                 $lessonIds = $chapter->lessons->pluck('id');
-                $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->where('status', LessonAttendance::STATUS_IN_ATTENDANCE)->pluck('lesson_id');
+                $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
+                // 出席情報が存在する場合エラー応答
                 if ($attendedLessonIds->isNotEmpty()) {
                     throw new ValidationErrorException('This lesson has attendance.');
                 }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -223,8 +223,9 @@ class ChapterController extends Controller
                     throw new ValidationErrorException('Invalid course.');
                 }
                 $lessonIds = $chapter->lessons->pluck('id');
-                $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->where('status', LessonAttendance::STATUS_IN_ATTENDANCE)->pluck('lesson_id');
+                $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
                 if ($attendedLessonIds->isNotEmpty()) {
+                    // 出席情報が存在する場合エラー応答
                     throw new ValidationErrorException('This lesson has attendance.');
                 }
             });

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -209,10 +209,10 @@ class ChapterController extends Controller
 
         $chapterIds = $request->input('chapters', []);
         $courseId = $request->input('course_id');
-        
+
         DB::beginTransaction();
         try {
-            $chapters = Chapter::with('course','lessons')->whereIn('id', $chapterIds)->get();
+            $chapters = Chapter::with('course', 'lessons')->whereIn('id', $chapterIds)->get();
             $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     // 自分、または配下の講師の講座のチャプターでなければエラー応答


### PR DESCRIPTION
## 概要
- 親-講師側/マネージャー側 チャプター選択削除時に受講中のチャプターは削除できないように変更

## 動作確認
- マネージャー側
マネージャーでログイン後、Postmanにて
http://localhost:8080/api/v1/manager/course/1/chapter
メソッド：delete
ボディ:
{
    "course_id": 1,
    "chapters": [1,2,3]
}
を送信。
{
    "result": false,
    "message": "This lesson has attendance."
}
出席情報があるためfalseで返ってくることを確認。

※出席情報がない場合はtrueでチャプターが消えることを確認。

- インストラクター側
インストラクターでログイン後Postmanにて
http://localhost:8080/api/v1/instructor/course/1/chapter
メソッド：delete
ボディ:
{
    "course_id": 1,
    "chapters": [1,2,3]
}
を送信。
{
    "result": false,
    "message": "This lesson has attendance."
}
出席情報があるためfalseで返ってくることを確認。

※出席情報がない場合はtrueでチャプターが消えることを確認。