### PR TITLE
JKA1016 マネージャー側 講師一覧画面 所有講座数の追加ログインマネジャーID除外（たわらつみだ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -66,7 +66,7 @@ class InstructorController extends Controller
 
         /** @var Instructor $manager */
         $manager = $queryService->getManagerWithManagings($managerId);
-    
+
         // 管理する講師のIDを取得
         $instructorIds = $manager->managings->pluck('id')->toArray();
 

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -64,13 +64,13 @@ class InstructorController extends Controller
 
         $managerId = Auth::guard('instructor')->user()->id;
 
-         /** @var Instructor $manager */
+        //** @var Instructor $manager */
         $manager = $queryService->getManagerWithManagings($managerId);
     
         // 管理する講師のIDを取得
         $instructorIds = $manager->managings->pluck('id')->toArray();
 
-        // マネージャー自身のIDを除外
+        // 講師情報を取得
         $instructors = $queryService->getPaginatedInstructors($instructorIds, $sortBy, $order, $perPage, $page);
 
         return new InstructorIndexResource($instructors);

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -64,12 +64,13 @@ class InstructorController extends Controller
 
         $managerId = Auth::guard('instructor')->user()->id;
 
-        /** @var Instructor $manager */
+         /** @var Instructor $manager */
         $manager = $queryService->getManagerWithManagings($managerId);
+    
+        // 管理する講師のIDを取得
         $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
 
-        // 講師情報を取得
+        // マネージャー自身のIDを除外
         $instructors = $queryService->getPaginatedInstructors($instructorIds, $sortBy, $order, $perPage, $page);
 
         return new InstructorIndexResource($instructors);

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -64,7 +64,7 @@ class InstructorController extends Controller
 
         $managerId = Auth::guard('instructor')->user()->id;
 
-        //** @var Instructor $manager */
+        /** @var Instructor $manager */
         $manager = $queryService->getManagerWithManagings($managerId);
     
         // 管理する講師のIDを取得


### PR DESCRIPTION
## 概要
-  JKA1016 マネージャー側 講師一覧画面 所有講座数の追加ログインマネジャーID除外（たわらつみだ）

## 動作確認
- Postmanにて確認
- URL: http://localhost:8080///api/v1/manager/instructor/index
- 講師側でログイン
email:test_instructor1@example.com
password:password'
- GETリクエスト

- レスポンス
{
    "data": {
        "instructors": [
            {
                "instructor_id": 3,
                "nick_name": "Suzuki",
                "email": "test_instructor3@example.com",
                "profile_image": null,
                "created_at": "2024-08-18 20:25:02",
                "course_count": 2
            },
            {
                "instructor_id": 2,
                "nick_name": "Hanako",
                "email": "test_instructor2@example.com",
                "profile_image": null,
                "created_at": "2024-08-18 20:25:01",
                "course_count": 2
            }
        ],
        "pagination": {
            "page": 1,
            "total": 2
        }
    }

### 考慮してほしいこと
なし

### 確認したいこと
全体実装のルールはほぼ無視して記載しております。問題ありませんでしょうか。