### PR TITLE
ide-helper導入(大川)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+
+# ide-helper関連
+/_ide_helper.php
+/.phpstorm.meta.php
+/_ide_helper_models.php

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -7,18 +7,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 
-/**
- * @property int $id
- * @property int $course_id
- * @property int $student_id
- * @property int $progress
- * @property Carbon $created_at
- * @property Carbon $updated_at
- * @property string|null $deleted_at
- * @property Student $student
- * @property Course $course
- * @property Collection<LessonAttendance> $lessonAttendances
- */
 class Attendance extends Model
 {
     use SoftDeletes;

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -6,19 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
 
-/**
- * @property int $id
- * @property int $course_id
- * @property int $order
- * @property string $title
- * @property 'public'|'private' $status
- * @property string $created_at
- * @property string $updated_at
- * @property string $deleted_at
- * @property int $completed_count
- * @property Course $course
- * @property Collection<Lesson> $lessons
- */
 class Chapter extends Model
 {
     use SoftDeletes;

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -6,19 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
 
-/**
- * @property int $id
- * @property int $instructor_id
- * @property string $title
- * @property string $image
- * @property 'public'|'private' $status
- * @property string $created_at
- * @property string $updated_at
- * @property string|null $deleted_at
- * @property Instructor $instructor
- * @property Collection<Chapter> $chapters
- * @property Collection<Attendance> $attendances
- */
 class Course extends Model
 {
     use SoftDeletes;

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -5,21 +5,6 @@ namespace App\Model;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\Collection;
 
-/**
- * @property int $id
- * @property string $nick_name
- * @property string $last_name
- * @property string $first_name
- * @property string $email
- * @property string $password
- * @property string|null $profile_image
- * @property 'manager'|'instructor' $type
- * @property string $created_at
- * @property string $updated_at
- * @property string|null $deleted_at
- * @property Collection<Course> $courses
- * @property Collection<Instructor> $managings
- */
 class Instructor extends Authenticatable
 {
     /**

--- a/app/Model/Lesson.php
+++ b/app/Model/Lesson.php
@@ -6,21 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
 
-/**
- * @property int $id
- * @property int $chapter_id
- * @property string $title
- * @property string $url
- * @property string $remarks
- * @property 'public'|'private' $status
- * @property string $created_at
- * @property string $updated_at
- * @property string $deleted_at
- * @property int $order
- * @property-read int $total_lessons_count
- * @property Chapter $chapter
- * @property Collection<LessonAttendance> $lessonAttendances
- */
 class Lesson extends Model
 {
     use SoftDeletes;

--- a/app/Model/LessonAttendance.php
+++ b/app/Model/LessonAttendance.php
@@ -6,18 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
-/**
- * @property int $id
- * @property int $lesson_id
- * @property int $attendance_id
- * @property 'before_attendance'|'in_attendance'|'completed_attendance' $status
- * @property 'today'|'month' $period
- * @property Carbon $created_at
- * @property Carbon $updated_at
- * @property string|null $deleted_at
- * @property Lesson $lesson
- * @property Attendance $attendance
- */
 class LessonAttendance extends Model
 {
     use SoftDeletes;

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -6,21 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Collection;
 
-/**
- * @property int $id
- * @property int $course_id
- * @property int $instructor_id
- * @property string $title
- * @property 'always'|'once' $type
- * @property string $start_date
- * @property string $end_date
- * @property string $content
- * @property string $created_at
- * @property string $updated_at
- * @property string|null $deleted_at
- * @property Course $course
- * @property Collection<Student> $students
- */
 class Notification extends Model
 {
     use SoftDeletes;

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -7,29 +7,6 @@ use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
-/**
- * @property int $id
- * @property string $given_name_by_instructor
- * @property string $nick_name
- * @property string $last_name
- * @property string $first_name
- * @property string $occupation
- * @property string $email
- * @property string $password
- * @property string $purpose
- * @property Carbon $birth_date
- * @property int $gender
- * @property string $address
- * @property Carbon $created_at
- * @property Carbon $updated_at
- * @property Carbon $last_login_at
- * @property string $email_verified_at
- * @property string $profile_image
- * @property string $full_name
- * @property Collection<Course> $courses
- * @property Collection<Notification> $notifications
- * @property Collection<Attendance> $attendances
- */
 class Student extends Authenticatable
 {
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        if ($this->app->environment() !== 'production') {
+            $this->app->register(IdeHelperServiceProvider::class);
+        }
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -14,9 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->environment() !== 'production') {
-            $this->app->register(IdeHelperServiceProvider::class);
-        }
+        //
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laravel/tinker": "^2.5"
     },
     "require-dev": {
+        "barryvdh/laravel-ide-helper": "^2.0",
         "facade/ignition": "^1.16.15",
         "fakerphp/faker": "^1.9.1",
         "larastan/larastan": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18cef13bb716e71487c27d619d0c9236",
+    "content-hash": "5e7f1faad77b60812fd58b257687d120",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -3939,6 +3939,144 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-ide-helper",
+            "version": "v2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-ide-helper.git",
+                "reference": "5515cabea39b9cf55f98980d0f269dc9d85cfcca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/5515cabea39b9cf55f98980d0f269dc9d85cfcca",
+                "reference": "5515cabea39b9cf55f98980d0f269dc9d85cfcca",
+                "shasum": ""
+            },
+            "require": {
+                "barryvdh/reflection-docblock": "^2.0.6",
+                "composer/composer": "^1.6 || ^2",
+                "doctrine/dbal": "~2.3",
+                "ext-json": "*",
+                "illuminate/console": "^6 || ^7 || ^8",
+                "illuminate/filesystem": "^6 || ^7 || ^8",
+                "illuminate/support": "^6 || ^7 || ^8",
+                "php": ">=7.2",
+                "phpdocumentor/type-resolver": "^1.1.0"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite": "*",
+                "friendsofphp/php-cs-fixer": "^2",
+                "illuminate/config": "^6 || ^7 || ^8",
+                "illuminate/view": "^6 || ^7 || ^8",
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench": "^4 || ^5 || ^6",
+                "phpunit/phpunit": "^8.5 || ^9",
+                "spatie/phpunit-snapshot-assertions": "^1.4 || ^2.2 || ^3 || ^4",
+                "vimeo/psalm": "^3.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\LaravelIdeHelper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Laravel IDE Helper, generates correct PHPDocs for all Facade classes, to improve auto-completion.",
+            "keywords": [
+                "autocomplete",
+                "codeintel",
+                "helper",
+                "ide",
+                "laravel",
+                "netbeans",
+                "phpdoc",
+                "phpstorm",
+                "sublime"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-ide-helper/issues",
+                "source": "https://github.com/barryvdh/laravel-ide-helper/tree/v2.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-06T08:55:05+00:00"
+        },
+        {
+            "name": "barryvdh/reflection-docblock",
+            "version": "v2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
+                "reference": "c6fad15f7c878be21650c51e1f841bca7e49752e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/c6fad15f7c878be21650c51e1f841bca7e49752e",
+                "reference": "c6fad15f7c878be21650c51e1f841bca7e49752e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.14|^9"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Barryvdh": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.1.3"
+            },
+            "time": "2024-10-23T11:41:03+00:00"
+        },
+        {
             "name": "composer/ca-bundle",
             "version": "1.4.0",
             "source": {
@@ -4479,6 +4617,347 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-20T20:07:39+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "2.13.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "c480849ca3ad6706a39c970cdfe6888fa8a058b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c480849ca3ad6706a39c970cdfe6888fa8a058b8",
+                "reference": "c480849ca3ad6706a39c970cdfe6888fa8a058b8",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0|^2.0",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.1 || ^8"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "9.0.0",
+                "jetbrains/phpstorm-stubs": "2021.1",
+                "phpstan/phpstan": "1.4.6",
+                "phpunit/phpunit": "^7.5.20|^8.5|9.5.16",
+                "psalm/plugin-phpunit": "0.16.1",
+                "squizlabs/php_codesniffer": "3.6.2",
+                "symfony/cache": "^4.4",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
+                "vimeo/psalm": "4.22.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlanywhere",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/2.13.9"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-02T20:28:55+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9",
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+            },
+            "time": "2024-01-30T19:34:25+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "95aa4cb529f1e96576f3fda9f5705ada4056a520"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/95aa4cb529f1e96576f3fda9f5705ada4056a520",
+                "reference": "95aa4cb529f1e96576f3fda9f5705ada4056a520",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^0.5.3 || ^1",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^10",
+                "phpstan/phpstan": "~1.4.10 || ^1.8.8",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.24"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-10-12T20:51:15+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -7689,12 +8168,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.2.5|^8.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## issue
- ide-helper導入

composer require --dev barryvdh/laravel-ide-helper:^2.0
にて導入しました。

下記の、
＜＜★★ 確認事項_その１ ★★＞＞
＜＜★★ 確認事項_その２ ★★＞＞
について、確認をお願いします。

## 考慮してほしいこと（チーム開発時の環境と異なることがあった)

★★★
追記(2024/10/25   23:05)
レビューの指摘対応で、
AppServiceProvider.phpを元に戻しても
コマンドが正常動作するようになったので、
AppServiceProvider.phpを元に戻した版を再プッシュしてます。
ですので、当初の下記の記述で
◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆関係なくなりました START
◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆関係なくなりました END
の範囲の箇所は、関係なくなりました。
★★★

◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆関係なくなりました START
＜チーム開発時の環境と異なること_その１＞

チーム開発時の環境では、
他、なにも設定せずとも、
php artisan ide-helper:generate
が正常に動いて
_ide_helper.php
が出力された

しかし、実務案件環境は、なぜか
php artisan ide-helper:generate
実行時
There are no commands defined in the "ide-helper" namespace.
のエラーになってしまった。
AUTO-DETECTが効かない、何かがある (  webアプリと、APIのアプリの違い？。原因不明。 )

php artisan config:clear
php artisan cache:clear
php artisan route:clear
php artisan view:clear
composer dump-autoload
このあたり、やったが、状況、変わらない。

そこで、

開発時のみ動作させる方法論で、下記の解決策を図った。

app/Providers/AppServiceProvider.php
に
use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
を追加し
registerメソッドを
```
    public function register()
    {
        if ($this->app->environment() !== 'production') {
            $this->app->register(IdeHelperServiceProvider::class);
        }
    }
```
の形とした。
すると、
php artisan ide-helper:generate
が正常に動いて
_ide_helper.php
が出力された

上記の
IdeHelperServiceProvider::class
devの分もインストールされる時は存在しますが
--no-devでdevの分がインストールされない時は存在しません。


composer install --no-dev
でのインストール時 ( たぶん、本番デプロイ時 )
は、
$this->app->register(IdeHelperServiceProvider::class);
が動くと、存在しないため実行時エラーになります。

$this->app->environment() が、 'production'　
であれば、問題ありません。

現状、.env ファイルにて、
APP_ENV=local
がありますが、

本番デプロイ時に、composer install --no-dev   した状況での動作時は、
.env ファイルを
APP_ENV=production
にする想定ですよね？ (  それがお作法のようですが )・・・・＜＜★★ 確認事項_その１ ★★＞＞
その想定なら、問題ありません。

なお、
use文自体は、対象のモノが存在しなくても実行時エラーにならないとのこと。
つまり、
composer install --no-dev
で環境作ってて、Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;が存在しない状況でも
use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
自体は実行時エラーにならないとのこと
◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆◆関係なくなりました END

＜チーム開発時の環境と異なること_その２＞
チーム開発時の環境では、
私のUbuntu(WSL2)環境では、artisanのバイナリファイルが更新された
実務案件の環境では、
私のUbuntu(WSL2)環境では、artisanのバイナリファイルが更新されなかった

なぜか、不明。

## 使用方法は、
composer install
で導入後

php artisan ide-helper:generate
で、
_ide_helper.php
を出力する
これは一回やればよい

php artisan ide-helper:models --nowrite
で、
_ide_helper_models.php
を出力する
これは、DBの構造が変わって、モデルクラスの増減や、変更があったら
任意のタイミングでしておく

php artisan ide-helper:meta
は、
.phpstorm.meta.php
を出力する
これは一回やればよい
phpstormというIDEでの便利機能をVSコードにも移植してるプラグインを使いたい場合は必要
そうでなければ、要らない。別に出力しててもいい


## MTGでKouさんが、グローバルのものはしないほうがよいと言ってたのは

php artisan ide-helper:eloquent
のことですよね？・・・・＜＜★★ 確認事項_その２ ★★＞＞
～/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php
だけ1ファイルのヘッダーのコメントだけ、少しだけ追記される
（チーム開発時はそうだった）
が、一旦、しないことにした。


## 他
★★★
追記(2024/10/26 00:33)
レビューの指摘対応で、
.gitignore
のほうに
```
# ide-helper関連
/_ide_helper.php
/.phpstorm.meta.php
/_ide_helper_models.php
```
を追記してプッシュしましたので、
各個人専用のgitの無視リストの
.git/info/exclude
への追記を各自やる必要がなくなりました。

ただし、人によっては、artisanのバイナリファイルが更新されるかもしれないの件がありましたので、
もし、そうなった場合は、
必要に応じて、/artisanだけ、
.git/info/excludeに追加したり
それでも消えない場合は、
git update-index --assume-unchanged artisan
の対応などを行ってもらう必要があります。
artisanのバイナリファイルが更新される人が多い場合は、
.gitignoreのほうへの追加も検討されるかもしれません。
★★★

.git/info/exclude
に
/_ide_helper.php
/.phpstorm.meta.php
/_ide_helper_models.php

を追加し、git statusであがってこないようにする
もし、artisanのバイナリファイルが更新された人は、
/artisan
も追記

それでも、消えない時は、
git update-index --assume-unchanged artisan
など

## 参考
私の個人ブログ
https://zenn.dev/tazzae999jp/articles/07bed12c3ae6c0
の
下記の目次項目参照のこと

ide-helperのインストールおよび、設定

.git/info/exclude (個人別無視リスト)の補足事項

