### PR TITLE
JKA-1020-講師側_マネージャー側_チャプター選択削除時に受講中のチャプターは削除できないように変更(大川)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -237,7 +237,7 @@ class ChapterController extends Controller
             // 認証ユーザー情報取得
             $instructorId = Auth::guard('instructor')->user()->id;
 
-            $chapters = Chapter::whereIn('id', $request->chapters)->with('course')->get();
+            $chapters = Chapter::whereIn('id', $request->chapters)->with(['course', 'lessons.lessonAttendances'])->get();
 
             // バリデーション
             $chapters->each(function (Chapter $chapter) use ($instructorId, $courseId) {
@@ -248,6 +248,19 @@ class ChapterController extends Controller
                 // チャプターに紐づく講座IDがリクエストの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $chapter->course_id) {
                     throw new ValidationErrorException('Invalid course_id.');
+                }
+
+                /*
+                    「$chapter->lessons」が0件時、->every()はtrueを返すため
+                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である」
+                    場合に削除可能($canDelete=true)となる。
+                */
+                $canDelete = $chapter->lessons->every(function ($lesson) {
+                    return $lesson->lessonAttendances->isEmpty();
+                });
+
+                if(!$canDelete) {
+                    throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");
                 }
             });
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -237,7 +237,7 @@ class ChapterController extends Controller
             // 認証ユーザー情報取得
             $instructorId = Auth::guard('instructor')->user()->id;
 
-            $chapters = Chapter::whereIn('id', $request->chapters)->with(['course', 'lessons.lessonAttendances'])->get();
+            $chapters = Chapter::whereIn('id', $request->chapters)->with(['course', 'lessons'])->get();
 
             // バリデーション
             $chapters->each(function (Chapter $chapter) use ($instructorId, $courseId) {
@@ -252,11 +252,11 @@ class ChapterController extends Controller
 
                 /*
                     「$chapter->lessons」が0件時、->every()はtrueを返すため
-                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である」
+                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
                     場合に削除可能($canDelete=true)となる。
                 */
                 $canDelete = $chapter->lessons->every(function ($lesson) {
-                    return $lesson->lessonAttendances->isEmpty();
+                    return !$lesson->lessonAttendances()->exists();
                 });
 
                 if (!$canDelete) {

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -259,7 +259,7 @@ class ChapterController extends Controller
                     return $lesson->lessonAttendances->isEmpty();
                 });
 
-                if(!$canDelete) {
+                if (!$canDelete) {
                     throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");
                 }
             });

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -6,6 +6,7 @@ use Exception;
 use App\Model\Course;
 use App\Model\Chapter;
 use App\Model\Instructor;
+use App\Model\LessonAttendance;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -256,7 +257,7 @@ class ChapterController extends Controller
                     場合に削除可能($canDelete=true)となる。
                 */
                 $canDelete = $chapter->lessons->every(function ($lesson) {
-                    return !$lesson->lessonAttendances()->exists();
+                    return !LessonAttendance::where("lesson_id", $lesson->id)->exists();
                 });
 
                 if (!$canDelete) {

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -250,22 +250,21 @@ class ChapterController extends Controller
                 if ((int) $courseId !== $chapter->course_id) {
                     throw new ValidationErrorException('Invalid course_id.');
                 }
-
-                /*
-                    「紐づくlessonsが0件」、または、
-                    「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
-                    の場合に削除可能($canDelete=true)となる。
-                */
-                $canDelete = true;
-                if (!$chapter->lessons->isEmpty()) {
-                    $lessonIds = $chapter->lessons->pluck('id');
-                    $canDelete = !LessonAttendance::whereIn("lesson_id", $lessonIds)->exists();
-                }
-
-                if (!$canDelete) {
-                    throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");
-                }
             });
+
+            /*
+                「紐づくlessonsが0件」、または、
+                「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
+                の場合に削除可能($canDelete=true)となる。
+            */
+            $canDelete = true;
+            $lessonIds = $chapters->pluck('lessons.*.id')->flatten();
+            if (!$lessonIds->isEmpty()) {
+                $canDelete = !LessonAttendance::whereIn("lesson_id", $lessonIds)->exists();
+            }
+            if (!$canDelete) {
+                throw new ValidationErrorException("Some chapters contain lessons with attendance records.");
+            }
 
             // チャプターを一括で削除
             Chapter::whereIn('id', $chapters->pluck('id'))->delete();

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -252,13 +252,15 @@ class ChapterController extends Controller
                 }
 
                 /*
-                    「$chapter->lessons」が0件時、->every()はtrueを返すため
-                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
-                    場合に削除可能($canDelete=true)となる。
+                    「紐づくlessonsが0件」、または、
+                    「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
+                    の場合に削除可能($canDelete=true)となる。
                 */
-                $canDelete = $chapter->lessons->every(function ($lesson) {
-                    return !LessonAttendance::where("lesson_id", $lesson->id)->exists();
-                });
+                $canDelete = true;
+                if (!$chapter->lessons->isEmpty()) {
+                    $lessonIds = $chapter->lessons->pluck('id');
+                    $canDelete = !LessonAttendance::whereIn("lesson_id", $lessonIds)->exists();
+                }
 
                 if (!$canDelete) {
                     throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -222,22 +222,21 @@ class ChapterController extends Controller
                     // 指定した講座に属するチャプターでなければエラー応答
                     throw new ValidationErrorException('Invalid course.');
                 }
-
-                /*
-                    「紐づくlessonsが0件」、または、
-                    「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
-                    の場合に削除可能($canDelete=true)となる。
-                */
-                $canDelete = true;
-                if (!$chapter->lessons->isEmpty()) {
-                    $lessonIds = $chapter->lessons->pluck('id');
-                    $canDelete = !LessonAttendance::whereIn("lesson_id", $lessonIds)->exists();
-                }
-
-                if (!$canDelete) {
-                    throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");
-                }
             });
+
+            /*
+                「紐づくlessonsが0件」、または、
+                「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
+                の場合に削除可能($canDelete=true)となる。
+            */
+            $canDelete = true;
+            $lessonIds = $chapters->pluck('lessons.*.id')->flatten();
+            if (!$lessonIds->isEmpty()) {
+                $canDelete = !LessonAttendance::whereIn("lesson_id", $lessonIds)->exists();
+            }
+            if (!$canDelete) {
+                throw new ValidationErrorException("Some chapters contain lessons with attendance records.");
+            }
 
             Chapter::whereIn('id', $chapterIds)->delete();
             DB::commit();

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -229,7 +229,7 @@ class ChapterController extends Controller
                     場合に削除可能($canDelete=true)となる。
                 */
                 $canDelete = $chapter->lessons->every(function ($lesson) {
-                    return !$lesson->lessonAttendances()->exists();
+                    return !LessonAttendance::where("lesson_id", $lesson->id)->exists();
                 });
 
                 if (!$canDelete) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -232,7 +232,7 @@ class ChapterController extends Controller
                     return $lesson->lessonAttendances->isEmpty();
                 });
 
-                if(!$canDelete) {
+                if (!$canDelete) {
                     throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");
                 }
             });

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -212,7 +212,7 @@ class ChapterController extends Controller
 
         DB::beginTransaction();
         try {
-            $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();
+            $chapters = Chapter::with(['course', 'lessons.lessonAttendances'])->whereIn('id', $chapterIds)->get();
             $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     // 自分、または配下の講師の講座のチャプターでなければエラー応答
@@ -221,6 +221,19 @@ class ChapterController extends Controller
                 if ((int) $courseId !== $chapter->course_id) {
                     // 指定した講座に属するチャプターでなければエラー応答
                     throw new ValidationErrorException('Invalid course.');
+                }
+
+                /*
+                    「$chapter->lessons」が0件時、->every()はtrueを返すため
+                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である」
+                    場合に削除可能($canDelete=true)となる。
+                */
+                $canDelete = $chapter->lessons->every(function ($lesson) {
+                    return $lesson->lessonAttendances->isEmpty();
+                });
+
+                if(!$canDelete) {
+                    throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");
                 }
             });
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -212,7 +212,7 @@ class ChapterController extends Controller
 
         DB::beginTransaction();
         try {
-            $chapters = Chapter::with(['course', 'lessons.lessonAttendances'])->whereIn('id', $chapterIds)->get();
+            $chapters = Chapter::with(['course', 'lessons'])->whereIn('id', $chapterIds)->get();
             $chapters->each(function (Chapter $chapter) use ($instructorIds, $courseId) {
                 if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
                     // 自分、または配下の講師の講座のチャプターでなければエラー応答
@@ -225,11 +225,11 @@ class ChapterController extends Controller
 
                 /*
                     「$chapter->lessons」が0件時、->every()はtrueを返すため
-                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である」
+                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
                     場合に削除可能($canDelete=true)となる。
                 */
                 $canDelete = $chapter->lessons->every(function ($lesson) {
-                    return $lesson->lessonAttendances->isEmpty();
+                    return !$lesson->lessonAttendances()->exists();
                 });
 
                 if (!$canDelete) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -224,13 +224,15 @@ class ChapterController extends Controller
                 }
 
                 /*
-                    「$chapter->lessons」が0件時、->every()はtrueを返すため
-                    「紐づくlessonsが0件」、または、「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
-                    場合に削除可能($canDelete=true)となる。
+                    「紐づくlessonsが0件」、または、
+                    「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
+                    の場合に削除可能($canDelete=true)となる。
                 */
-                $canDelete = $chapter->lessons->every(function ($lesson) {
-                    return !LessonAttendance::where("lesson_id", $lesson->id)->exists();
-                });
+                $canDelete = true;
+                if (!$chapter->lessons->isEmpty()) {
+                    $lessonIds = $chapter->lessons->pluck('id');
+                    $canDelete = !LessonAttendance::whereIn("lesson_id", $lessonIds)->exists();
+                }
 
                 if (!$canDelete) {
                     throw new ValidationErrorException("The chapter '{$chapter->title}' contains some lessons with attendance.");


### PR DESCRIPTION
## issue
- JKA-1020-講師側_マネージャー側_チャプター選択削除時に受講中のチャプターは削除できないように変更


対応内容は、下記のとおり、

＜chapterの削除が可能＞なケース
1) chapterの配下のlessonsが0件
2) chapterの配下のlessonsが1件以上で、すべての配下のlessonについて、その配下のlessonAttendancesが0件である

＜chapterの削除が不可能＞なケース
3) chapterの配下のlessonsが1件以上で、配下のlessonうちに1つでも、その配下のlessonAttendancesが1件以上である


引数で受けたchapterのidのリストのうち、
いずれか、1つでも、
＜chapterの削除が不可能＞なケース
に相当するchapterがあった場合は、

処理中断し、NGのJSONでクライアントまで返ってくる


テストは、

https://www.dropbox.com/scl/fi/tgex56qyrumsobzukqna0/.xlsx?rlkey=pb9lpx3xpj2amz2fbla7tpos2&dl=0

で、実施し上記の、1)、2)、3)を

InstructorのChapterController、ManagerのChapterControlleともに確認した。
