### PR TITLE
JKA-1002(親:JKA-990) 空の配列を返すルーターとコントローラー作成(西山しょうこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -522,4 +522,8 @@ class LessonController extends Controller
             ], 500);
         }
     }
+
+    public function deleteAll() {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -523,7 +523,8 @@ class LessonController extends Controller
         }
     }
 
-    public function deleteAll() {
+    public function deleteAll()
+    {
         return response()->json([]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -197,6 +197,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
                                     Route::put('status', 'Api\Manager\LessonController@putStatus');
                                     Route::delete('/', 'Api\Manager\LessonController@bulkDelete');
+                                    Route::delete('all', 'Api\Manager\LessonController@deleteAll');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');


### PR DESCRIPTION
## issue

- Closes JKA-1002 (親：JKA-990) 

## 概要

- 空の配列を返すルーターとコントローラー作成

## 動作確認手順

- Postman にて、 
- ①　インストラクター（兼マネージャー）でログイン
- ②【DELETE】 http://localhost:8080/api/v1/manager/course/1/chapter/2/lesson/all　
　BODY無しでsendを押し、結果として　[ ]   が返ってきました。
　
- Postman でのテストの仕方が不安です。これで合ってますでしょうか？

![スクリーンショット 2024-11-07 110510](https://github.com/user-attachments/assets/56780d98-4683-452c-be33-cb4f92f0d879)
