### PR TITLE
JKA-1022親-マネージャー側 チャプター削除時に受講中のチャプターは削除できないように変更（有田健一郎）

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -189,13 +189,15 @@ class ChapterController extends Controller
             ], 403);
         }
 
-        if (LessonAttendance::whereIn('lesson_id', $lessonIds)
+        if (
+            LessonAttendance::whereIn('lesson_id', $lessonIds)
             ->where('status', LessonAttendance::STATUS_IN_ATTENDANCE)
-            ->exists()) {
+            ->exists()
+        ) {
             // 指定したチャプター内に受講中のレッスンがあればエラー応答
             return response()->json([
                 'result' => false,
-                'message' => 'This chapter has attendance.'    
+                'message' => 'This chapter has attendance.'
             ], 403);
         }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -167,7 +167,11 @@ class ChapterController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+        // チャプターを取得
+        $chapter = Chapter::with(['course', 'lessons'])->findOrFail($request->chapter_id);
+
+        // チャプターに紐づく全レッスンIDを取得
+        $lessonIds = $chapter->lessons->pluck('id')->toArray();
 
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座のチャプターでなければエラー応答
@@ -182,6 +186,16 @@ class ChapterController extends Controller
             return response()->json([
                 'result'  => false,
                 'message' => 'Invalid course_id.',
+            ], 403);
+        }
+
+        if (LessonAttendance::whereIn('lesson_id', $lessonIds)
+            ->where('status', LessonAttendance::STATUS_IN_ATTENDANCE)
+            ->exists()) {
+            // 指定したチャプター内に受講中のレッスンがあればエラー応答
+            return response()->json([
+                'result' => false,
+                'message' => 'This chapter has attendance.'    
             ], 403);
         }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -191,13 +191,12 @@ class ChapterController extends Controller
 
         if (
             LessonAttendance::whereIn('lesson_id', $lessonIds)
-            ->where('status', LessonAttendance::STATUS_IN_ATTENDANCE)
             ->exists()
         ) {
             // 指定したチャプター内に受講中のレッスンがあればエラー応答
             return response()->json([
                 'result' => false,
-                'message' => 'The lessons in this chapter are currently attended.'    
+                'message' => 'This lesson has attendance.'
             ], 403);
         }
 
@@ -357,11 +356,11 @@ class ChapterController extends Controller
         try {
             foreach ($chapters as $chapter) {
                 Chapter::where('id', $chapter['chapter_id'])
-                ->where('course_id', $courseId)
-                ->firstOrFail()
-                ->update([
-                    'order' => $chapter['order']
-                ]);
+                    ->where('course_id', $courseId)
+                    ->firstOrFail()
+                    ->update([
+                        'order' => $chapter['order']
+                    ]);
             }
 
             DB::commit();
@@ -420,11 +419,11 @@ class ChapterController extends Controller
 
         // チャプターのステータスを更新
         $chapter->update([
-          'status' => $request->status
+            'status' => $request->status
         ]);
 
         return response()->json([
-          'result' => true,
+            'result' => true,
         ]);
     }
 
@@ -470,7 +469,7 @@ class ChapterController extends Controller
         ]);
     }
 
-   /**
+    /**
      * 選択済みチャプターを公開/非公開にするAPI
      *
      * @param ChaptersPatchStatusRequest $request

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -197,7 +197,7 @@ class ChapterController extends Controller
             // 指定したチャプター内に受講中のレッスンがあればエラー応答
             return response()->json([
                 'result' => false,
-                'message' => 'The lessons in this chapter are currently attended.'    
+                'message' => 'The lessons in this chapter are currently attended.'
             ], 403);
         }
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -195,7 +195,7 @@ class ChapterController extends Controller
             // 指定したチャプター内に受講中のレッスンがあればエラー応答
             return response()->json([
                 'result' => false,
-                'message' => 'This chapter has attendance.'    
+                'message' => 'The lessons in this chapter are currently attended.'    
             ], 403);
         }
 


### PR DESCRIPTION
## 概要
-  [JKA-1022親-マネージャー側 チャプター削除時に受講中のチャプターは削除できないように変更（有田健一郎）](https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-1022)

## 動作確認
### チャプター削除に失敗するケース
- Postmanにて以下確認
  - URL：http://localhost:8000/api/v1/manager/course/1/chapter/2
  - 講師側でログイン（マネージャー権限）

    - email：`test_instructor@example.com`
    - password：`password`

- DELETEリクエスト
  - パラメータ
    - course_id：`1`
    - chapter_id：`2`

  - レスポンス
  ```json
  {
      "result": false,
      "message": "The lessons in this chapter are currently attended."
  }
  ```

<img width="1336" alt="スクリーンショット 2024-11-11 23 14 01" src="https://github.com/user-attachments/assets/376ca0f3-f5ba-4b38-b6ae-1ab3cc5f1fb4">


### チャプター削除を実行する場合
- Postmanにて以下確認
  - URL：ttp://localhost:8000/api/v1/manager/course/1/chapter/3
  - 講師側でログイン（マネージャー権限）

    - email：`test_instructor@example.com`
    - password：`password`

- DELETEリクエスト
  - パラメータ
    - course_id：`1`
    - chapter_id：`3`

  - レスポンス
  ```json
  {
      "result": true
  }
  ```

<img width="1336" alt="スクリーンショット 2024-11-11 23 16 47" src="https://github.com/user-attachments/assets/b0b453cf-a49e-4912-9e5a-c3bc6efe4440">


### 考慮してほしいこと
特になし

### 確認したいこと
特になし