### PR TITLE
JKA-1003(親タスクJKA-990) ロジック作成(西山しょうこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Manager;
 
 use Exception;
 use App\Model\Course;
+use App\Model\Chapter;
 use App\Model\Lesson;
 use App\Model\Attendance;
 use App\Model\Instructor;
@@ -24,6 +25,7 @@ use App\Http\Requests\Manager\LessonPutStatusRequest;
 use App\Http\Requests\Manager\LessonBulkDeleteRequest;
 use App\Http\Requests\Manager\LessonPatchStatusRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
+use Illuminate\Http\Request;
 
 class LessonController extends Controller
 {
@@ -523,8 +525,73 @@ class LessonController extends Controller
         }
     }
 
-    public function deleteAll()
+    /**
+     * チャプターに紐づくレッスン全削除API
+     *
+     * @param 
+     * @return JsonResponse
+     */
+    public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
-        return response()->json([]);
+        // チャプターを取得
+        /** @var Chapter $chapter */
+        $chapter = Chapter::with('course')->findOrFail($chapter_id);
+
+        // ログイン中の講師IDを取得
+        $managerId = Auth::guard('instructor')->user()->id;
+
+        // マネージャーと その管理下の講師を取得
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($managerId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
+        if (!in_array($chapter->course->instructor_id, $instructorIds)) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid instructor_id.'
+            ], 403);
+        }
+
+        // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
+        if ((int) $course_id !== $chapter->course->id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid course_id.',
+            ], 403);
+        }
+
+        // チャプターに紐づく全レッスンIDを取得
+        $lessonIds = $chapter->lessons->pluck('id');
+        $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
+        if ($attendedLessonIds->isNotEmpty()) {
+            // 出席のあるレッスンがあれば削除を許可しない
+            return response()->json([
+                'result' => false,
+                'message' => 'This lessons contains attendance.'
+            ], 403);
+        }
+
+        // 認可チェックをパスした後にトランザクションを開始
+        DB::beginTransaction();
+
+        try {
+            // チャプターに紐づく全レッスンを削除
+            $chapter->lessons()->delete();
+
+            DB::commit();
+
+                return response()->json([
+                    'result' => true,
+                ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to delete lessons.',
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -533,10 +533,6 @@ class LessonController extends Controller
      */
     public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
-        // チャプターを取得
-        /** @var Chapter $chapter */
-        $chapter = Chapter::with('course')->findOrFail($chapter_id);
-
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -545,6 +541,10 @@ class LessonController extends Controller
         $manager = Instructor::with('managings')->find($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
+
+        // チャプターを取得
+        /** @var Chapter $chapter */
+        $chapter = Chapter::with('course')->findOrFail($chapter_id);
 
         // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
         if (!in_array($chapter->course->instructor_id, $instructorIds)) {
@@ -582,9 +582,9 @@ class LessonController extends Controller
 
             DB::commit();
 
-                return response()->json([
-                    'result' => true,
-                ]);
+            return response()->json([
+                'result' => true,
+            ]);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -547,30 +547,21 @@ class LessonController extends Controller
         $chapter = Chapter::with('course')->findOrFail($chapter_id);
 
         // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
-        if (!in_array($chapter->course->instructor_id, $instructorIds)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id.'
-            ], 403);
+        if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-        if ((int) $course_id !== $chapter->course->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+        if ((int) $course_id !== $chapter->course->id) { 
+            throw new AuthorizationException('Invalid course_id.'); 
         }
 
         // チャプターに紐づく全レッスンIDを取得
         $lessonIds = $chapter->lessons->pluck('id');
         $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
+        // 出席のあるレッスンがあれば削除を許可しない
         if ($attendedLessonIds->isNotEmpty()) {
-            // 出席のあるレッスンがあれば削除を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'This lessons contains attendance.'
-            ], 403);
+            throw new AuthorizationException('This lessons contains attendance.'); 
         }
 
         // 認可チェックをパスした後にトランザクションを開始

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -528,7 +528,7 @@ class LessonController extends Controller
     /**
      * チャプターに紐づくレッスン全削除API
      *
-     * @param 
+     * @param
      * @return JsonResponse
      */
     public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -552,8 +552,8 @@ class LessonController extends Controller
         }
 
         // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-        if ((int) $course_id !== $chapter->course->id) { 
-            throw new AuthorizationException('Invalid course_id.'); 
+        if ((int) $course_id !== $chapter->course->id) {
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         // チャプターに紐づく全レッスンIDを取得
@@ -561,7 +561,7 @@ class LessonController extends Controller
         $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
         // 出席のあるレッスンがあれば削除を許可しない
         if ($attendedLessonIds->isNotEmpty()) {
-            throw new AuthorizationException('This lessons contains attendance.'); 
+            throw new AuthorizationException('This lessons contains attendance.');
         }
 
         // 認可チェックをパスした後にトランザクションを開始

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -58,6 +58,6 @@ class Instructor extends Authenticatable
      */
     public function managings(): BelongsToMany
     {
-        return $this->belongsToMany(Instructor::class, 'manage_instructors', 'instructor_id', 'manager_id');
+        return $this->belongsToMany(Instructor::class, 'manage_instructors', 'manager_id', 'instructor_id');
     }
 }


### PR DESCRIPTION
## issue

- Closes JKA-1003(親タスクJKA-990) ロジック作成(西山しょうこ)

## 概要

- マネージャー側　チャプターに紐づくレッスン全削除API作成の子課題「ロジックの作成」

## 動作確認手順

Postmanで、以下のテストを実施
- ログイン中の講師（マネージャー権限）が作成したチャプターに紐づくレッスンの全削除
 （チャプター８レッスン９は、私がAdminerで作成したものです）
　URL：　api/v1/manager/course/5/chapter/8/lesson/all
　"result": true

- **出席のあるレッスンがあれば削除を許可しない（コード修正で太字のように結果が変わりました）
　URL：　api/v1/manager/course/1/chapter/2/lesson/all**
　 ~~"result": false,~~
    ~~"message": "This lessons contains attendance."~~
**403 Forbidden
"message": "This lessons contains attendance.",,,,,, 以下、たくさんのコードが続く**

- 講師の管理下にあるインストラクターが作成したチャプターに紐づくレッスンの全削除
 （チャプターID４の中のレッスン７は、確か私がAdminerで作成したものです）
　URL：　api/v1/manager/course/2/chapter/4/lesson/all
　"result": true


## 確認して欲しいこと
- 　**コード修正で太字のように動作確認の結果が変わりました。**
- 　Postmanでのテストが、過不足なくできているかご確認よろしくお願いいたします。 
- 　コードは大半コピペですが、一部自分で書いたところもあるのでご確認よろしくお願いいたします。