### PR TITLE
JKA-1023 親-講師側 チャプター削除時に受講中のチャプターは削除できないように変更(しみず)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -298,7 +298,7 @@ class ChapterController extends Controller
 
         try {
             /** @var Chapter $chapter */
-            $chapter = Chapter::with('course','lessons')->findOrFail($request->chapter_id);
+            $chapter = Chapter::with('course', 'lessons')->findOrFail($request->chapter_id);
 
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
                 return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -298,7 +298,7 @@ class ChapterController extends Controller
 
         try {
             /** @var Chapter $chapter */
-            $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+            $chapter = Chapter::with('course','lessons')->findOrFail($request->chapter_id);
 
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
                 return response()->json([
@@ -312,6 +312,15 @@ class ChapterController extends Controller
                 return response()->json([
                     'result'  => false,
                     'message' => 'Invalid course_id.',
+                ], 403);
+            }
+
+            //受講中のチャプターは削除できないようにする
+            $lessonIds = $chapter->lessons->pluck('id')->toArray();
+            if (LessonAttendance::whereIn('lesson_id', $lessonIds)->exists()) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'This chapter contains attendance.'
                 ], 403);
             }
 


### PR DESCRIPTION
## 概要
- #JKA-1023 親-講師側 チャプター削除時に受講中のチャプターは削除できないように変更

## 動作確認

### 受講中で削除できない場合

- 講師側でログイン
email:test_instructor@example.com
password:password

- DELETEリクエスト
URL:http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id

- パラメータ
course_id:1
chapter_id:2

- レスポンス
```
{
    "result": false,
    "message": "This chapter contains attendance."
}
```
<img width="870" alt="スクリーンショット 2024-11-12 21 10 12" src="https://github.com/user-attachments/assets/b7a95f26-3578-4fb6-bed0-dc27da57350b">

### 受講中でないため、削除できた場合

- 講師側でログイン
email:test_instructor@example.com
password:password

- DELETEリクエスト
URL:http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id

- パラメータ
course_id:1
chapter_id:3

- レスポンス
```
{
    "result": true
}
```
<img width="851" alt="スクリーンショット 2024-11-12 21 27 56" src="https://github.com/user-attachments/assets/c8d0c0c0-beaa-497e-ba69-4b83b5f01464">

## 確認したいこと
似たような動きのコードのところにflattenを使っているものを見ました。必要でしょうか。