### PR TITLE
 JKA-1005(親タスクJKA-990) リクエストフォームの作成(西山しょうこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -25,7 +25,7 @@ use App\Http\Requests\Manager\LessonPutStatusRequest;
 use App\Http\Requests\Manager\LessonBulkDeleteRequest;
 use App\Http\Requests\Manager\LessonPatchStatusRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
-use Illuminate\Http\Request;
+use App\Http\Requests\Manager\LessonsAllDeleteRequest;
 
 class LessonController extends Controller
 {
@@ -526,12 +526,12 @@ class LessonController extends Controller
     }
 
     /**
-     * チャプターに紐づくレッスン全削除API
-     *
-     * @param
-     * @return JsonResponse
-     */
-    public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
+    * チャプターに紐づく全レッスンを削除するAPI
+    *
+    * @param LessonsAllDeleteRequest $request
+    * @return JsonResponse
+    */
+    public function deleteAll(LessonsAllDeleteRequest $request): JsonResponse
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
@@ -544,7 +544,7 @@ class LessonController extends Controller
 
         // チャプターを取得
         /** @var Chapter $chapter */
-        $chapter = Chapter::with('course')->findOrFail($chapter_id);
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
         // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
@@ -552,7 +552,7 @@ class LessonController extends Controller
         }
 
         // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-        if ((int) $course_id !== $chapter->course->id) {
+        if ((int) $request->course_id !== $chapter->course->id) {
             throw new AuthorizationException('Invalid course_id.');
         }
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -526,11 +526,11 @@ class LessonController extends Controller
     }
 
     /**
-    * チャプターに紐づく全レッスンを削除するAPI
-    *
-    * @param LessonsAllDeleteRequest $request
-    * @return JsonResponse
-    */
+     * チャプターに紐づく全レッスンを削除するAPI
+     *
+     * @param LessonsAllDeleteRequest $request
+     * @return JsonResponse
+     */
     public function deleteAll(LessonsAllDeleteRequest $request): JsonResponse
     {
         // ログイン中の講師IDを取得

--- a/app/Http/Requests/Manager/LessonsAllDeleteRequest.php
+++ b/app/Http/Requests/Manager/LessonsAllDeleteRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonsAllDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue

- Closes JKA-1005(親タスクJKA-990) リクエストフォームの作成(西山しょうこ)

## 概要

- マネージャー側　チャプターに紐づくレッスン全削除API作成の子課題「リクエストフォームの作成」

## 動作確認手順

Postmanで、以下のテストを実施
- ログイン中の講師（マネージャー権限）が作成したチャプターに紐づくレッスンの全削除
 （チャプター８レッスン９は、私がAdminerで作成したものです）
　URL：　api/v1/manager/course/5/chapter/8/lesson/all
　"result": true

- 出席のあるレッスンがあれば削除を許可しない
　URL：　api/v1/manager/course/1/chapter/2/lesson/all
　403 Forbidden
　"message": "This lessons contains attendance.",,,,,, 以下、たくさんのコードが続く

- 講師の管理下にあるインストラクターが作成したチャプターに紐づくレッスンの全削除
 （チャプターID４の中のレッスン７は、確か私がAdminerで作成したものです）
　URL：　api/v1/manager/course/2/chapter/4/lesson/all
　"result": true
