### PR TITLE
「openapi.yaml」と「アプリ側」のルーティング比較のコマンド作成

### DIFF
--- a/app/Console/Commands/CompareRoute.php
+++ b/app/Console/Commands/CompareRoute.php
@@ -55,7 +55,7 @@ class CompareRoute extends Command
      * 「:」を取り除きtrimする
      *
      * @param string $string
-     * @return void
+     * @return string
      */
     private function trimAndRemoveColon($string): string
     {
@@ -98,6 +98,7 @@ class CompareRoute extends Command
             throw new Exception("Failed to open file: {$filePath}");
         }
 
+        /** @var string[] $lines */
         $lines = [];
 
         $initialSkip = true;
@@ -194,6 +195,7 @@ class CompareRoute extends Command
     {
 
         // ルートリストを取得「php artisan route:list」と同じものが取得できるのは検証済
+        /** @var \Illuminate\Routing\Route[] $routes */
         $routes = Route::getRoutes();
 
         $routeList = [];

--- a/app/Console/Commands/CompareRoute.php
+++ b/app/Console/Commands/CompareRoute.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Route;
+
+class CompareRoute extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dev:compare-route';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '「openapi.yaml」と「アプリ側」のルーティング比較';
+
+    /**
+     * 「文字列長がnより大きく、かつ、先頭が半角スペースn個である、かつ、先頭が半角スペースn個の次の文字が半角スペースでない」かどうかを判定する。
+     *
+     * @param string $string 対象文字列
+     * @param int $n 半角スペースの数
+     * @return bool 判定結果
+     */
+    private function startsSpacesN(string $string, int $n): bool
+    {
+        // 文字列長がnより小さい場合はfalse
+        if (strlen($string) <= $n) {
+            return false;
+        }
+
+         // 半角スペースをn個作成
+        $spaces = str_repeat(' ', $n);
+
+        // 先頭が半角スペースn個で始まること
+        $ret1 = ( substr($string, 0, $n) === $spaces );
+
+        // 先頭が半角スペースn個の次の文字が半角スペースでないこと
+        $ret2 = ( substr($string, $n, 1) !== ' ' );
+
+        // 返却値
+        $ret = ($ret1 && $ret2);
+        
+        return $ret;
+    }
+
+    /**
+     * 「:」を取り除きtrimする
+     *
+     * @param string $string
+     * @return void
+     */
+    private function trimAndRemoveColon($string) : string {
+        return trim(str_replace(":", "", $string));
+    }
+
+    private function loadOpenapi() {
+        /*
+            当コマンドを実行するにあたっての前提
+
+            dockerコンテナ内部で当コマンドが実行され、
+            ホスト側の「openapi.yaml」を直接的に読み込みにいけないため
+            一旦、ホスト側の
+            /myDocker/laravel_next_docker/backend/laravelapp
+            の場所にて、
+            cp ../../api/openapi.yaml .
+            で、コピーして
+            /myDocker/laravel_next_docker/backend/laravelapp/openapi.yaml
+            が存在する状況。
+            すなわち、
+            /var/www/html/laravelapp/openapi.yaml
+            が存在する状況。
+            getcwd()
+            が「/var/www/html/laravelapp」を返す状況にて
+            当コマンドを実行することを前提にしている。
+        */
+
+        // カレントディレクトリを取得
+        $currentDirectory = getcwd();
+
+        $filePath = $currentDirectory . '/openapi.yaml';
+
+        if (!file_exists($filePath)) {
+            throw new Exception("File not found: {$filePath}");
+        }
+
+        $file = fopen($filePath, 'r');
+        if (!$file) {
+            throw new Exception("Failed to open file: {$filePath}");
+        }
+
+        $lines = [];
+
+        $initialSkip = true;
+        try {
+            while (($line = fgets($file)) !== false) {
+                // 末尾の改行を取り除く
+                $line = rtrim($line, "\n");
+
+                /*
+                    *****
+                    info:
+                      title: 受講管理API
+                      version: 1.0.0
+                    *****
+                    上記の部分で、「urlの次の行がmethodで取得するべき」の前提が崩れるため
+                    paths:
+                    までの部分を読み捨てることにした
+                */
+                if($line === "paths:") {
+                    $initialSkip = false;
+                    continue; 
+                }
+                if($initialSkip) {
+                    continue;
+                }
+
+                $lines[] = $line;
+            }    
+        } finally {
+            fclose($file);
+        }
+
+        $lineCount = count($lines);
+
+        $routeList = [];
+        for($index = 0 ; $index < $lineCount ; ++$index) {
+            $line = $lines[$index];
+
+            $retUri = false;
+            $retMethod = false;
+
+            $uri = "";
+            $method = "";
+
+            $isAddRouteList = false;
+
+            $retUri = $this->startsSpacesN($line, 2);
+            if($retUri) {
+
+                $checkFlag = false;
+
+                $uri = $this->trimAndRemoveColon($line);
+
+                $nextIndex = ( $index + 1 );
+
+                if($nextIndex < $lineCount) {
+                    $nextLine = $lines[$nextIndex];
+
+                    $retMethod = $this->startsSpacesN($nextLine, 4);
+                    if($retMethod) {
+                        $method = $this->trimAndRemoveColon($nextLine);
+
+                        $checkFlag = true;
+                    }
+                }
+
+                if(!$checkFlag) {
+                    //「uri」の次の行としての「method」が取得できない状況は、想定外の状況なので例外を投げる。
+                    throw new Exception("invalid status. 00100 lines:" . ( $index + 1 ));
+                }
+
+                $isAddRouteList = true;
+            }
+
+            if(!$isAddRouteList) {
+                continue;
+            }
+
+            $key = $method . "###" . $uri;
+
+            $routeList[] = [
+                'key' => $key,
+                'method' => $method,
+                'uri' => $uri,
+            ];
+        }
+
+        // $routeListをkeyで昇順ソート
+        $this->sortRouteListByKey($routeList);
+
+        return $routeList;
+    }
+
+    private function loadRoutes() {
+
+        // ルートリストを取得「php artisan route:list」と同じものが取得できるのは検証済
+        $routes = Route::getRoutes();
+
+        $routeList = [];
+
+        foreach ($routes as $route) {
+            /*
+                openapi.yamlとの比較がしやすいように加工
+            */
+            $method = implode('|', $route->methods());
+            $uri = "/" . $route->uri();
+
+            if($method == "GET|HEAD") {
+                $method = "get";
+            }
+
+            $method = strtolower($method);
+
+            $key = $method . "###" . $uri;
+
+            $routeList[] = [
+                'key' => $key,
+                'method' => $method,
+                'uri' => $uri,
+            ];
+        }
+
+        // $routeListをkeyで昇順ソート
+        $this->sortRouteListByKey($routeList);
+
+        return $routeList;
+    }
+
+    function sortRouteListByKey(& $routeList) {
+        // keyで昇順ソート
+        usort($routeList, function($a, $b) {
+            return $a['key'] <=> $b['key'];
+        });
+    }
+
+    /**
+     * 「次ループ処理ありかどうか」を判定する。
+     *
+     * @param int $leftIndex
+     * @param int $leftLength
+     * @param int $rightIndex
+     * @param int $rightLength
+     * @return boolean 次ループ処理ありかどうか
+     */
+    function hasNext($leftIndex, $leftLength, $rightIndex, $rightLength) : bool {
+        $isLeftEnd = ($leftIndex >= $leftLength);
+        $isRightEnd = ($rightIndex >= $rightLength);
+
+        $isEnd = ($isLeftEnd && $isRightEnd);
+
+        return !$isEnd;
+    }
+
+    function compare(
+        $leftRouteList,
+        $rightRouteList,
+        & $leftOnlyRouteList,
+        & $matchRouteList,
+        & $rightOnlyRouteList
+    ) {
+
+        $leftLength = count($leftRouteList);
+        $rightLength = count($rightRouteList);
+
+        $leftIndex = 0;
+        $rightIndex = 0;
+
+        $bigKey = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
+
+        while($this->hasNext($leftIndex, $leftLength, $rightIndex, $rightLength)) {
+            $currentLeft = [
+                'key' => $bigKey,
+                'method' => '',
+                'uri' => '',
+            ];
+            if($leftIndex < $leftLength) {
+                $currentLeft = $leftRouteList[$leftIndex];
+            }
+
+            $currentRight = [
+                'key' => $bigKey,
+                'method' => '',
+                'uri' => '',
+            ];
+            if($rightIndex < $rightLength) {
+                $currentRight = $rightRouteList[$rightIndex];
+            }
+
+            if(
+                ($currentLeft['key'] === $bigKey)
+                &&
+                ($currentRight['key'] === $bigKey)
+            ) {
+                throw new Exception("Invalid status 00200");
+            }
+
+            $currentCompare = $currentLeft['key'] <=> $currentRight['key'];
+
+            if($currentCompare < 0) {
+                // left only
+                $leftOnlyRouteList[] = $currentLeft;
+
+                ++$leftIndex;
+            } else if($currentCompare === 0) {
+                // match
+                $matchRouteList[] = $currentLeft;
+
+                ++$leftIndex;
+                ++$rightIndex;
+            } else {
+                // right only
+                $rightOnlyRouteList[] = $currentRight;
+
+                ++$rightIndex;
+            }
+        }
+    }
+
+    public function echoOneRoute($route)
+    {
+        echo 'Method: ' . strtoupper($route['method']) . ', URI: ' . $route['uri'] . "\n";
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        echo '#################################################################################################################' . "\n";
+        echo '全出力' . "\n";
+        echo '#################################################################################################################' . "\n";
+
+        $openapiRouteList = $this->loadOpenapi();
+        echo '#######################################################################' . "\n";
+        echo '「openapi.yaml」全出力' . "\n";
+        echo '#######################################################################' . "\n";
+        foreach ($openapiRouteList as $route) {
+            $this->echoOneRoute($route);
+        }
+
+        $applicationRouteList = $this->loadRoutes();
+
+        echo '#######################################################################' . "\n";
+        echo '「アプリ側」全出力' . "\n";
+        echo '#######################################################################' . "\n";
+        foreach ($applicationRouteList as $route) {
+            $this->echoOneRoute($route);
+        }
+
+        $openapiOnlyRouteList = [];
+        $matchRouteList = [];
+        $applicationOnlyRouteList = [];
+
+        $this->compare(
+            $openapiRouteList,
+            $applicationRouteList,
+            $openapiOnlyRouteList,
+            $matchRouteList,
+            $applicationOnlyRouteList
+        );
+
+        echo '#################################################################################################################' . "\n";
+        echo '比較結果出力' . "\n";
+        echo '#################################################################################################################' . "\n";
+
+        echo '#######################################################################' . "\n";
+        echo '「openapi.yaml」のみある分' . "\n";
+        echo '#######################################################################' . "\n";
+        foreach ($openapiOnlyRouteList as $route) {
+            $this->echoOneRoute($route);
+        }
+
+        echo '#######################################################################' . "\n";
+        echo '両方ある分(keyマッチ分)' . "\n";
+        echo '#######################################################################' . "\n";
+        foreach ($matchRouteList as $route) {
+            $this->echoOneRoute($route);
+        }
+
+        echo '#######################################################################' . "\n";
+        echo '「アプリ側」のみある分' . "\n";
+        echo '#######################################################################' . "\n";
+        foreach ($applicationOnlyRouteList as $route) {
+            $this->echoOneRoute($route);
+        }
+
+        return true;
+    }
+}

--- a/app/Console/Commands/CompareRoute.php
+++ b/app/Console/Commands/CompareRoute.php
@@ -47,7 +47,7 @@ class CompareRoute extends Command
 
         // 返却値
         $ret = ($ret1 && $ret2);
-        
+
         return $ret;
     }
 
@@ -57,11 +57,13 @@ class CompareRoute extends Command
      * @param string $string
      * @return void
      */
-    private function trimAndRemoveColon($string) : string {
+    private function trimAndRemoveColon($string): string
+    {
         return trim(str_replace(":", "", $string));
     }
 
-    private function loadOpenapi() {
+    private function loadOpenapi()
+    {
         /*
             当コマンドを実行するにあたっての前提
 
@@ -114,16 +116,16 @@ class CompareRoute extends Command
                     paths:
                     までの部分を読み捨てることにした
                 */
-                if($line === "paths:") {
+                if ($line === "paths:") {
                     $initialSkip = false;
-                    continue; 
+                    continue;
                 }
-                if($initialSkip) {
+                if ($initialSkip) {
                     continue;
                 }
 
                 $lines[] = $line;
-            }    
+            }
         } finally {
             fclose($file);
         }
@@ -131,7 +133,7 @@ class CompareRoute extends Command
         $lineCount = count($lines);
 
         $routeList = [];
-        for($index = 0 ; $index < $lineCount ; ++$index) {
+        for ($index = 0; $index < $lineCount; ++$index) {
             $line = $lines[$index];
 
             $retUri = false;
@@ -143,26 +145,25 @@ class CompareRoute extends Command
             $isAddRouteList = false;
 
             $retUri = $this->startsSpacesN($line, 2);
-            if($retUri) {
-
+            if ($retUri) {
                 $checkFlag = false;
 
                 $uri = $this->trimAndRemoveColon($line);
 
                 $nextIndex = ( $index + 1 );
 
-                if($nextIndex < $lineCount) {
+                if ($nextIndex < $lineCount) {
                     $nextLine = $lines[$nextIndex];
 
                     $retMethod = $this->startsSpacesN($nextLine, 4);
-                    if($retMethod) {
+                    if ($retMethod) {
                         $method = $this->trimAndRemoveColon($nextLine);
 
                         $checkFlag = true;
                     }
                 }
 
-                if(!$checkFlag) {
+                if (!$checkFlag) {
                     //「uri」の次の行としての「method」が取得できない状況は、想定外の状況なので例外を投げる。
                     throw new Exception("invalid status. 00100 lines:" . ( $index + 1 ));
                 }
@@ -170,7 +171,7 @@ class CompareRoute extends Command
                 $isAddRouteList = true;
             }
 
-            if(!$isAddRouteList) {
+            if (!$isAddRouteList) {
                 continue;
             }
 
@@ -189,7 +190,8 @@ class CompareRoute extends Command
         return $routeList;
     }
 
-    private function loadRoutes() {
+    private function loadRoutes()
+    {
 
         // ルートリストを取得「php artisan route:list」と同じものが取得できるのは検証済
         $routes = Route::getRoutes();
@@ -203,7 +205,7 @@ class CompareRoute extends Command
             $method = implode('|', $route->methods());
             $uri = "/" . $route->uri();
 
-            if($method == "GET|HEAD") {
+            if ($method == "GET|HEAD") {
                 $method = "get";
             }
 
@@ -224,9 +226,10 @@ class CompareRoute extends Command
         return $routeList;
     }
 
-    function sortRouteListByKey(& $routeList) {
+    function sortRouteListByKey(&$routeList)
+    {
         // keyで昇順ソート
-        usort($routeList, function($a, $b) {
+        usort($routeList, function ($a, $b) {
             return $a['key'] <=> $b['key'];
         });
     }
@@ -240,7 +243,8 @@ class CompareRoute extends Command
      * @param int $rightLength
      * @return boolean 次ループ処理ありかどうか
      */
-    function hasNext($leftIndex, $leftLength, $rightIndex, $rightLength) : bool {
+    function hasNext($leftIndex, $leftLength, $rightIndex, $rightLength): bool
+    {
         $isLeftEnd = ($leftIndex >= $leftLength);
         $isRightEnd = ($rightIndex >= $rightLength);
 
@@ -252,9 +256,9 @@ class CompareRoute extends Command
     function compare(
         $leftRouteList,
         $rightRouteList,
-        & $leftOnlyRouteList,
-        & $matchRouteList,
-        & $rightOnlyRouteList
+        &$leftOnlyRouteList,
+        &$matchRouteList,
+        &$rightOnlyRouteList
     ) {
 
         $leftLength = count($leftRouteList);
@@ -265,13 +269,13 @@ class CompareRoute extends Command
 
         $bigKey = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
 
-        while($this->hasNext($leftIndex, $leftLength, $rightIndex, $rightLength)) {
+        while ($this->hasNext($leftIndex, $leftLength, $rightIndex, $rightLength)) {
             $currentLeft = [
                 'key' => $bigKey,
                 'method' => '',
                 'uri' => '',
             ];
-            if($leftIndex < $leftLength) {
+            if ($leftIndex < $leftLength) {
                 $currentLeft = $leftRouteList[$leftIndex];
             }
 
@@ -280,11 +284,11 @@ class CompareRoute extends Command
                 'method' => '',
                 'uri' => '',
             ];
-            if($rightIndex < $rightLength) {
+            if ($rightIndex < $rightLength) {
                 $currentRight = $rightRouteList[$rightIndex];
             }
 
-            if(
+            if (
                 ($currentLeft['key'] === $bigKey)
                 &&
                 ($currentRight['key'] === $bigKey)
@@ -294,12 +298,12 @@ class CompareRoute extends Command
 
             $currentCompare = $currentLeft['key'] <=> $currentRight['key'];
 
-            if($currentCompare < 0) {
+            if ($currentCompare < 0) {
                 // left only
                 $leftOnlyRouteList[] = $currentLeft;
 
                 ++$leftIndex;
-            } else if($currentCompare === 0) {
+            } elseif ($currentCompare === 0) {
                 // match
                 $matchRouteList[] = $currentLeft;
 


### PR DESCRIPTION
## issue
- JKA-1039

## 「openapi.yaml」と「アプリ側」のルーティング比較のコマンド作成

まずは、一旦、下記のコマンド作成をしました。

A)「openapi.yaml」

B)「アプリ側」・・・「php artisan route:list」のイメージ
について、(A)、(B)を比較する。
- (A)側のみに存在する
- (A)、(B)のともに存在する
- (B)側のみに存在する
を抽出するコマンドを作成し、
一旦の現状報告をする

今後の(A)、(B)の乖離が発生時の発見のためにもコマンドの作成をした。

コマンドの実装内容にて
(A)側と、(B)側について、
比較方法はmethodとuriを文字列連結したものを昇順ソート後
マッチング処理をしている。

「get、post、put、deleteなどのHTTPのmethod」と、
例として、/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status  などのuri
を、### 記号で連結した。

patch###/api/v1/manager/course/{course_id}/chapter/{chapter_id}/lesson/{lesson_id}/status
などの、key文字列を昇順ソート後、

(A)、(B)について、マッチング処理をおこなっている。

そのため、

ABC順で

DELETE、GET、PATCH、POST、PUT

の順でリスト表示されます。

比較結果のパターンは下記のとおり

- (A)側のみに存在する・・・・・URLの一部を誤登録してたり(末尾に/が余計にあるとか、「_」と「-」の違いとか、または、仕様として「openapi.yaml」に登録済だが実装が追いついてない可能性のものなど。

- (A)、(B)のともに存在する・・・・HTTPメソッド、uriでは、ともに一致を確認ただし、詳細部仕様部の比較までは当コマンドではできません。

- (B)側のみに存在する・・・・「openapi.yaml」への登録漏れ。実装側はある。

## 動作時の前提

実行プロセスがdockerコンテナ側であり、
ホスト側の「openapi.yaml」を直接的に読み込みにいけないため
一旦、ホスト側の
/myDocker/laravel_next_docker/backend/laravelapp
などの場所にて、
```
cp ../../api/openapi.yaml .
```
で、コピーして
/myDocker/laravel_next_docker/backend/laravelapp/openapi.yaml
が存在する状況。

つまり、

dockerコンテナで見た時に、
/var/www/html/laravelapp/openapi.yaml
が存在する状況。

としてから、
下記の「動作方法」で、実行することを前提としている。

## 動作方法

dockerコンテナ内の
/var/www/html/laravelapp
にて、
```
php artisan dev:compare-route
```
で実行する

## 現時点で下記のような結果が出力されました

https://www.dropbox.com/scl/fi/s0hpn2jsi1ce00o5pzz98/_2024_11_16.txt?rlkey=5mjb1trp4mkgu2qxq3r5v0hpv&dl=0
のように出力されてます

全出力
にて、
「openapi.yaml」全出力
「アプリ側」全出力
を出力してます。

比較結果出力
にて、
「openapi.yaml」のみある分
両方ある分(keyマッチ分)
「アプリ側」のみある分
を出力してます。

## 上記結果をExcel上で突合作業させた

https://www.dropbox.com/scl/fi/q4euim0c0hkyi7xvifxci/compare-_2024_11_16.xlsx?rlkey=qwnkv4inulpijnwi3yxd4bfdf&dl=0
にて、
Excel上で突合作業させた

Excel上で突合作業させたのは、今回の当コマンド自体のテストをする必要があったので突合作業をしましたが、

★★★  次回以降は、今回のようなExcel上で突合作業のようなメンドイ作業が不要かと思います。 ★★★

C列、kindの列で
leftonly   になってるのが「openapi.yaml」にのみある　（　なにかのケアレスミスとかでそうなってる？  )
match   になってるのが両方ある
rightonly   になってるのが「アプリ側」にのみある　（　「openapi.yaml」が未だ未対応分と思われる  )

B列、nearの列で
〇が打ってるのは「-」、「_」の違いなどのケアレスミスでの差分のように感じられる

## 今後
今回、一旦は、HTTPのmethodとURIの組み合わせの差異洗い出しコマンド作成のみした
および、
「openapi.yaml」にのみある分
や、
「アプリ側」にのみある分
の現状の結果報告にとどめる

今後のswaggerの整合性のタスクについて、続きの詳細方針を連携ください

## 訂正事項：11月08日分の下記の変更分取り込めてなかったので再度したら・・。

![1108の変更分](https://github.com/user-attachments/assets/7928d2de-30d7-44ca-98ec-d109b5355de1)

上の図の「11/08の変更分」取り込めてなかったので

取り込んでから再度実行した結果が

https://www.dropbox.com/scl/fi/z2g38h6bsdhvjyr6lfayt/_2024_11_16_-2.txt?rlkey=4ipl57x1wycyhmb6m9dfkgh24&dl=0

で、

#######################################################################
両方ある分(keyマッチ分)
#######################################################################
に、
Method: PATCH, URI: /api/v1/lesson_attendance
が出力されました。


取り込む前は、

#######################################################################
「openapi.yaml」のみある分
#######################################################################
に、
Method: PATCH, URI: /api/v1/lesson-attendance
が出力

#######################################################################
「アプリ側」のみある分
#######################################################################
に、
Method: PATCH, URI: /api/v1/lesson_attendance
が出力

#######################################################################
両方ある分(keyマッチ分)
#######################################################################
には、
上記のものが出力されない

だった。

## 「追記」。「composer analyze」で警告出てたので対応しでなくしました。
その
対応前で動作時の出力結果
と、
対応後で動作時の出力結果
が完全一致すること確認しました。
