### PR TITLE
マネージャー側_受講状況取得APIの作成(大川)

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Manager;
 
 use Exception;
 use App\Model\Course;
+use App\Model\Chapter;
 use App\Model\Lesson;
 use App\Model\Attendance;
 use App\Model\Instructor;
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\AttendanceShowRequest;
+use App\Http\Resources\Manager\AttendanceShowResource;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
 use App\Http\Requests\Manager\AttendanceShowThisMonthRequest;
@@ -97,6 +99,45 @@ class AttendanceController extends Controller
                 'result' => false,
             ], 500);
         }
+    }
+
+    /**
+     * 受講状況取得API
+     *
+     * @param AttendanceShowRequest $request
+     * @return AttendanceShowResource
+     */
+    public function show(AttendanceShowRequest $request)
+    {
+        $courseId = $request->course_id;
+
+        // 現在ログインしているinstructorのidを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        // ログインしている講師とその管理している講師を取得
+        $manager = Instructor::with('managings')->find($instructorId);
+        // 管理している講師のIDを配列として取得し、自分自身のIDも追加
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
+        $course = Course::findOrFail($courseId);
+        if (!in_array($course->instructor_id, $instructorIds, true)) {
+            // 自分と配下の講師の講座でない場合はエラーを返す
+            return response()->json([
+                'result'  => false,
+                'message' => "Forbidden, not allowed to access this course.",
+            ], 403);
+        }
+
+        /** @var Collection<int, Chapter> */
+        $chapters = Chapter::where('course_id', $courseId)->get();
+
+        /** @var int */
+        $studentsCount = Attendance::where('course_id', $courseId)->count();
+
+        return new AttendanceShowResource([
+            'chapters' => $chapters,
+            'studentsCount' => $studentsCount,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -108,7 +108,7 @@ class AttendanceController extends Controller
      * @param AttendanceShowRequest $request
      * @return AttendanceShowResource
      */
-    public function show(AttendanceShowRequest $request) : AttendanceShowResource
+    public function show(AttendanceShowRequest $request): AttendanceShowResource
     {
         $courseId = $request->course_id;
 

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Manager\AttendanceShowRequest;
 use App\Http\Resources\Manager\AttendanceShowResource;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
@@ -105,9 +106,9 @@ class AttendanceController extends Controller
      * 受講状況取得API
      *
      * @param AttendanceShowRequest $request
-     * @return AttendanceShowResource|JsonResponse
+     * @return AttendanceShowResource
      */
-    public function show(AttendanceShowRequest $request)
+    public function show(AttendanceShowRequest $request) : AttendanceShowResource
     {
         $courseId = $request->course_id;
 
@@ -122,10 +123,9 @@ class AttendanceController extends Controller
         $course = Course::findOrFail($courseId);
         if (!in_array($course->instructor_id, $instructorIds, true)) {
             // 自分と配下の講師の講座でない場合はエラーを返す
-            return response()->json([
-                'result'  => false,
-                'message' => "Forbidden, not allowed to access this course.",
-            ], 403);
+            throw new AuthorizationException(
+                "Forbidden, not allowed to access this course."
+            );
         }
 
         $chapters = Chapter::where('course_id', $courseId)->get();

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -105,7 +105,7 @@ class AttendanceController extends Controller
      * 受講状況取得API
      *
      * @param AttendanceShowRequest $request
-     * @return AttendanceShowResource
+     * @return AttendanceShowResource|JsonResponse
      */
     public function show(AttendanceShowRequest $request)
     {
@@ -128,7 +128,6 @@ class AttendanceController extends Controller
             ], 403);
         }
 
-        /** @var Collection<int, Chapter> */
         $chapters = Chapter::where('course_id', $courseId)->get();
 
         /** @var int */

--- a/app/Http/Resources/Manager/AttendanceShowResource.php
+++ b/app/Http/Resources/Manager/AttendanceShowResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use App\Model\Chapter;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AttendanceShowResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        /** @var Collection<int, Chapter>  */
+        $chapters = $this->resource['chapters'];
+
+        return [
+            'chapters' => $chapters->map(function (Chapter $chapter) {
+                return [
+                    'chapter_id' => $chapter->id,
+                    'title' => $chapter->title,
+                    'completed_count' => $chapter->completed_count,
+                ];
+            }),
+            'students_count' => $this->resource['studentsCount'],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -212,7 +212,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         //マネージャー生徒学習状況
                         Route::prefix('attendance')->group(function () {
                             Route::prefix('status')->group(function () {
-                                Route::get('', 'Api\Manager\AttendanceController@show');
+                                Route::get('/', 'Api\Manager\AttendanceController@show');
                                 Route::get('this-month', 'Api\Manager\AttendanceController@showStatusThisMonth');
                                 Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
                             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -212,6 +212,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         //マネージャー生徒学習状況
                         Route::prefix('attendance')->group(function () {
                             Route::prefix('status')->group(function () {
+                                Route::get('', 'Api\Manager\AttendanceController@show');
                                 Route::get('this-month', 'Api\Manager\AttendanceController@showStatusThisMonth');
                                 Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
                             });


### PR DESCRIPTION
## issue
- JKA-1041 マネージャー側_受講状況取得APIの作成

## 動画を見てInstructor側を参考にして実装した

swaggerのレスポンスの仕様が、InstructorとManagerで同じだった
他のタスクもInstructorとManagerで、ほぼ同じロジックも過去に見た。

違いは、
「自分と配下の講師の講座でない場合はエラーを返す」
これがあるかどうかの違いのケースが他にもあったが、

今回の分のその違いだけかな。思いました。
その方向性でしました。

なお、
Instructor側のshow()にあった
$chapters = Chapter::with('lessons.lessonAttendances')->where('course_id', $courseId)->get();
の
「with('lessons.lessonAttendances')->」部分は不要だったので

当Manager側のshowの実装時には、削りました


## テスト

https://www.dropbox.com/scl/fi/mg0im4v7w8jfcg71xxnyj/.xlsx?rlkey=dzby7481u6o4q0l0926yu050q&dl=0

で、

左側のInstructorのshow()
と、
右側のManagerのshow()
でレスポンスを比較し、一致を確認してます

swaggerのレスポンスの記載は、同じでした。

php artisan migrate:fresh --seedしたイメージのデータ状態で
course_id=4で動かしたら
```
        $course = Course::findOrFail($courseId);
        if (!in_array($course->instructor_id, $instructorIds, true)) {
            // 自分と配下の講師の講座でない場合はエラーを返す
            return response()->json([
                'result'  => false,
                'message' => "Forbidden, not allowed to access this course.",
            ], 403);
        }
の中に入って、レスポンス
{
    "result": false,
    "message": "Forbidden, not allowed to access this course."
}
が返ってくるのを確認した
```

## 追記
composer analyzeの対応をした
