### PR TITLE
Managerの「お知らせ一覧-タイプ変更API」の「type」を「notification_type」にする(大川)

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -241,13 +241,13 @@ class NotificationController extends Controller
             ], 403);
         }
 
-        $type = $request->type;
+        $notificationType = $request->notification_type;
 
         DB::beginTransaction();
         try {
-            $notifications->each(function (Notification $notification) use ($type) {
+            $notifications->each(function (Notification $notification) use ($notificationType) {
                 $notification->fill([
-                    'type' => $type,
+                    'type' => $notificationType,
                 ])->save();
             });
             DB::commit();

--- a/app/Http/Requests/Manager/NotificationPutTypeRequest.php
+++ b/app/Http/Requests/Manager/NotificationPutTypeRequest.php
@@ -20,7 +20,7 @@ class NotificationPutTypeRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
-            'type' => $this->route('type'),
+            'notification_type' => $this->route('notification_type'),
         ]);
     }
 
@@ -32,7 +32,7 @@ class NotificationPutTypeRequest extends FormRequest
     public function rules()
     {
         return [
-            'type' => ['required',  new NotificationUpdateStatusRule()],
+            'notification_type' => ['required',  new NotificationUpdateStatusRule()],
             'notifications.*' => ['integer', 'exists:notifications,id,deleted_at,NULL'],
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -242,7 +242,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                         Route::delete('/', 'Api\Manager\NotificationController@delete');
                     });
-                    Route::put('type/{type}', 'Api\Manager\NotificationController@updateType');
+                    Route::put('type/{notification_type}', 'Api\Manager\NotificationController@updateType');
                     Route::delete('/', 'Api\Manager\NotificationController@bulkDelete');
                 });
             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -237,13 +237,13 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-お知らせ
                 Route::prefix('notification')->group(function () {
                     Route::get('index', 'Api\Manager\NotificationController@index');
+                    Route::put('type/{notification_type}', 'Api\Manager\NotificationController@updateType');
+                    Route::delete('/', 'Api\Manager\NotificationController@bulkDelete');
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', 'Api\Manager\NotificationController@show');
                         Route::patch('/', 'Api\Manager\NotificationController@update');
                         Route::delete('/', 'Api\Manager\NotificationController@delete');
                     });
-                    Route::put('type/{notification_type}', 'Api\Manager\NotificationController@updateType');
-                    Route::delete('/', 'Api\Manager\NotificationController@bulkDelete');
                 });
             });
         });


### PR DESCRIPTION
## issue
- JKA-1045 マネージャー側お知らせ周りのルーティングの微修正

上記の記載を変更します。
Kouさんからslackでふられたタスクについて、
ゆきひろさんが、JKA-1045で作ってるのに気が付いたため
変更前)
JKA-1046 Managerの「お知らせ一覧-タイプ変更API」の「type」を「notification_type」にする


## slackで連携されたとおり

変更前）
Method: PUT, URI: /api/v1/instructor/notification/type/{notification_type}
Method: PUT, URI: /api/v1/manager/notification/type/{type}
変更後）
Method: PUT, URI: /api/v1/instructor/notification/type/{notification_type}
Method: PUT, URI: /api/v1/manager/notification/type/{notification_type}

マネージャー側を{notification_type}に修正する。

## テスト

https://www.dropbox.com/scl/fi/acxe8j5kyww6kfhmnc8p2/JKA-1046_.xlsx?rlkey=6kzndxotelhrt1bsiu9473laj&dl=0

にて、

左側のInstructor側
と同レベルの動作となることを
右側のManager側
で確認した

## 後で追記
JKA-1045 マネージャー側お知らせ周りのルーティングの微修正
のJiraの記述を発見し、
Kouさんからslackでふられたタスクと同じ内容であることがわかりました。
「JKA-1045 マネージャー側お知らせ周りのルーティングの微修正」では、
動画でapi.phpの記述順をInstructorに合わせる件も
説明があったため、その件修正し再プッシュしました。

## エラー系を例外を投げる対応はあえてしてません

その１）
```
        // アクセス権限のチェック
        if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
            return response()->json([
                'result' => false,
                'message' => 'Forbidden.',
            ], 403);
        }
```
そのままにてしてます

その２）
```
        } catch (Exception $e) {
            DB::rollBack();
            Log::error($e);
            return response()->json([
                'result' => false,
            ], 500);
        }
````
そのままにしてます。


その１）は、
https://github.com/yukihiroLaravel/juko_laravel/pull/706
側のプルリクで最後
```
laravel.logは自動ではでないようです。
＞ログの出力は不要
とのことで、スルーしてます。
```
がそれでOKで、そちらのプルリクが通るならば
その１）は、同レベルの対応ができます。

その２）は、
```
        } catch (Exception $e) {
            DB::rollBack();
            Log::error($e);
            throw $e;
        }
````
「throw $e;」でよければ対応できます。
それか、別の専用の例外クラスをcatch句で投げるのか
その際は、スタックトレースで元のcatchした例外も、中身出るように
（　エラーの直接原因となった箇所もスタックレースでて障害対応しやすいように )
（　Log::error($e); してるから要らんかもというのもあります。専用の例外だったときLaravelが自動でlaravel.logに投げるかの兼ね合いもあります )
専用の例外に食わせて作って投げるかなどのところも、連携願います。

A: その１）は、前プルリクの結果がどうか
B: その２）は、上記のようにthrow $e;に変更するかどうか
C: そもそも、一旦、エラー系は、当プルリクでは変更なしでいいか (  Serviceに分けた時に対応で、一旦しないなど )

上記、A, B, Cを、ご連絡いただければ続き対応するか、そのまま放置するか、行いますので
よろしくお願いします。
