### PR TITLE
JKA-990 親タスク-マネージャー側 チャプター作成画面 チャプターに紐づく全レッスンを削除するAPI作成。 topicブランチからdevelopへのプルリク。（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -25,7 +25,7 @@ use App\Http\Requests\Manager\LessonPutStatusRequest;
 use App\Http\Requests\Manager\LessonBulkDeleteRequest;
 use App\Http\Requests\Manager\LessonPatchStatusRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
-use Illuminate\Http\Request;
+use App\Http\Requests\Manager\LessonsAllDeleteRequest;
 
 class LessonController extends Controller
 {
@@ -526,12 +526,12 @@ class LessonController extends Controller
     }
 
     /**
-     * チャプターに紐づくレッスン全削除API
-     *
-     * @param
-     * @return JsonResponse
-     */
-    public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
+    * チャプターに紐づく全レッスンを削除するAPI
+    *
+    * @param LessonsAllDeleteRequest $request
+    * @return JsonResponse
+    */
+    public function deleteAll(LessonsAllDeleteRequest $request): JsonResponse
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
@@ -544,7 +544,7 @@ class LessonController extends Controller
 
         // チャプターを取得
         /** @var Chapter $chapter */
-        $chapter = Chapter::with('course')->findOrFail($chapter_id);
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
         // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
@@ -552,7 +552,7 @@ class LessonController extends Controller
         }
 
         // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-        if ((int) $course_id !== $chapter->course->id) {
+        if ((int) $request->course_id !== $chapter->course->id) {
             throw new AuthorizationException('Invalid course_id.');
         }
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -522,4 +522,8 @@ class LessonController extends Controller
             ], 500);
         }
     }
+
+    public function deleteAll() {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Manager;
 
 use Exception;
 use App\Model\Course;
+use App\Model\Chapter;
 use App\Model\Lesson;
 use App\Model\Attendance;
 use App\Model\Instructor;
@@ -24,6 +25,7 @@ use App\Http\Requests\Manager\LessonPutStatusRequest;
 use App\Http\Requests\Manager\LessonBulkDeleteRequest;
 use App\Http\Requests\Manager\LessonPatchStatusRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
+use Illuminate\Http\Request;
 
 class LessonController extends Controller
 {
@@ -523,8 +525,73 @@ class LessonController extends Controller
         }
     }
 
-    public function deleteAll()
+    /**
+     * チャプターに紐づくレッスン全削除API
+     *
+     * @param 
+     * @return JsonResponse
+     */
+    public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
-        return response()->json([]);
+        // チャプターを取得
+        /** @var Chapter $chapter */
+        $chapter = Chapter::with('course')->findOrFail($chapter_id);
+
+        // ログイン中の講師IDを取得
+        $managerId = Auth::guard('instructor')->user()->id;
+
+        // マネージャーと その管理下の講師を取得
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($managerId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
+        if (!in_array($chapter->course->instructor_id, $instructorIds)) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid instructor_id.'
+            ], 403);
+        }
+
+        // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
+        if ((int) $course_id !== $chapter->course->id) {
+            return response()->json([
+                'result' => false,
+                'message' => 'Invalid course_id.',
+            ], 403);
+        }
+
+        // チャプターに紐づく全レッスンIDを取得
+        $lessonIds = $chapter->lessons->pluck('id');
+        $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
+        if ($attendedLessonIds->isNotEmpty()) {
+            // 出席のあるレッスンがあれば削除を許可しない
+            return response()->json([
+                'result' => false,
+                'message' => 'This lessons contains attendance.'
+            ], 403);
+        }
+
+        // 認可チェックをパスした後にトランザクションを開始
+        DB::beginTransaction();
+
+        try {
+            // チャプターに紐づく全レッスンを削除
+            $chapter->lessons()->delete();
+
+            DB::commit();
+
+                return response()->json([
+                    'result' => true,
+                ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to delete lessons.',
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -533,10 +533,6 @@ class LessonController extends Controller
      */
     public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse
     {
-        // チャプターを取得
-        /** @var Chapter $chapter */
-        $chapter = Chapter::with('course')->findOrFail($chapter_id);
-
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -545,6 +541,10 @@ class LessonController extends Controller
         $manager = Instructor::with('managings')->find($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
+
+        // チャプターを取得
+        /** @var Chapter $chapter */
+        $chapter = Chapter::with('course')->findOrFail($chapter_id);
 
         // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
         if (!in_array($chapter->course->instructor_id, $instructorIds)) {
@@ -582,9 +582,9 @@ class LessonController extends Controller
 
             DB::commit();
 
-                return response()->json([
-                    'result' => true,
-                ]);
+            return response()->json([
+                'result' => true,
+            ]);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -523,7 +523,8 @@ class LessonController extends Controller
         }
     }
 
-    public function deleteAll() {
+    public function deleteAll()
+    {
         return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -547,30 +547,21 @@ class LessonController extends Controller
         $chapter = Chapter::with('course')->findOrFail($chapter_id);
 
         // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
-        if (!in_array($chapter->course->instructor_id, $instructorIds)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id.'
-            ], 403);
+        if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-        if ((int) $course_id !== $chapter->course->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+        if ((int) $course_id !== $chapter->course->id) { 
+            throw new AuthorizationException('Invalid course_id.'); 
         }
 
         // チャプターに紐づく全レッスンIDを取得
         $lessonIds = $chapter->lessons->pluck('id');
         $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
+        // 出席のあるレッスンがあれば削除を許可しない
         if ($attendedLessonIds->isNotEmpty()) {
-            // 出席のあるレッスンがあれば削除を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'This lessons contains attendance.'
-            ], 403);
+            throw new AuthorizationException('This lessons contains attendance.'); 
         }
 
         // 認可チェックをパスした後にトランザクションを開始

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\Api\Manager;
 
 use Exception;
 use App\Model\Course;
-use App\Model\Chapter;
 use App\Model\Lesson;
+use App\Model\Chapter;
 use App\Model\Attendance;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
@@ -23,9 +23,9 @@ use App\Http\Requests\Manager\LessonUpdateRequest;
 use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Manager\LessonPutStatusRequest;
 use App\Http\Requests\Manager\LessonBulkDeleteRequest;
+use App\Http\Requests\Manager\LessonsAllDeleteRequest;
 use App\Http\Requests\Manager\LessonPatchStatusRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
-use App\Http\Requests\Manager\LessonsAllDeleteRequest;
 
 class LessonController extends Controller
 {
@@ -546,25 +546,25 @@ class LessonController extends Controller
         /** @var Chapter $chapter */
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
-        // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければfalse
         if (!in_array($chapter->course->instructor_id, $instructorIds, true)) {
+            // ログイン中のマネージャーまたはその管理下の講師IDが、講座の作成者IDでなければエラー応答
             throw new AuthorizationException('Invalid instructor_id.');
         }
 
-        // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
         if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定された講座がチャプターに関連付けられている講座と一致しない場合はエラー応答
             throw new AuthorizationException('Invalid course_id.');
         }
 
         // チャプターに紐づく全レッスンIDを取得
         $lessonIds = $chapter->lessons->pluck('id');
         $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
-        // 出席のあるレッスンがあれば削除を許可しない
+
         if ($attendedLessonIds->isNotEmpty()) {
+            // 出席のあるレッスンがあれば削除を許可しない
             throw new AuthorizationException('This lessons contains attendance.');
         }
 
-        // 認可チェックをパスした後にトランザクションを開始
         DB::beginTransaction();
 
         try {
@@ -578,11 +578,8 @@ class LessonController extends Controller
             ]);
         } catch (Exception $e) {
             DB::rollBack();
-            Log::error($e);
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to delete lessons.',
-            ], 500);
+            Log::error($e->getMessage());
+            throw $e;
         }
     }
 }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -528,7 +528,7 @@ class LessonController extends Controller
     /**
      * チャプターに紐づくレッスン全削除API
      *
-     * @param 
+     * @param
      * @return JsonResponse
      */
     public function deleteAll(Request $request, int $course_id, int $chapter_id): JsonResponse

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -526,11 +526,11 @@ class LessonController extends Controller
     }
 
     /**
-    * チャプターに紐づく全レッスンを削除するAPI
-    *
-    * @param LessonsAllDeleteRequest $request
-    * @return JsonResponse
-    */
+     * チャプターに紐づく全レッスンを削除するAPI
+     *
+     * @param LessonsAllDeleteRequest $request
+     * @return JsonResponse
+     */
     public function deleteAll(LessonsAllDeleteRequest $request): JsonResponse
     {
         // ログイン中の講師IDを取得

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -552,8 +552,8 @@ class LessonController extends Controller
         }
 
         // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
-        if ((int) $course_id !== $chapter->course->id) { 
-            throw new AuthorizationException('Invalid course_id.'); 
+        if ((int) $course_id !== $chapter->course->id) {
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         // チャプターに紐づく全レッスンIDを取得
@@ -561,7 +561,7 @@ class LessonController extends Controller
         $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
         // 出席のあるレッスンがあれば削除を許可しない
         if ($attendedLessonIds->isNotEmpty()) {
-            throw new AuthorizationException('This lessons contains attendance.'); 
+            throw new AuthorizationException('This lessons contains attendance.');
         }
 
         // 認可チェックをパスした後にトランザクションを開始

--- a/app/Http/Requests/Manager/LessonsAllDeleteRequest.php
+++ b/app/Http/Requests/Manager/LessonsAllDeleteRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Manager;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LessonsAllDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+        ];
+    }
+}

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -58,6 +58,6 @@ class Instructor extends Authenticatable
      */
     public function managings(): BelongsToMany
     {
-        return $this->belongsToMany(Instructor::class, 'manage_instructors', 'instructor_id', 'manager_id');
+        return $this->belongsToMany(Instructor::class, 'manage_instructors', 'manager_id', 'instructor_id');
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -197,6 +197,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::post('sort', 'Api\Manager\LessonController@sort');
                                     Route::put('status', 'Api\Manager\LessonController@putStatus');
                                     Route::delete('/', 'Api\Manager\LessonController@bulkDelete');
+                                    Route::delete('all', 'Api\Manager\LessonController@deleteAll');
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', 'Api\Manager\LessonController@update');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');


### PR DESCRIPTION
## issue

- Closes JKA-990　topicブランチからdevelopへのプルリク。（西山しょうこ）

## 概要

- JKA-990 親タスク-マネージャー側 チャプター作成画面 チャプターに紐づく全レッスンを削除するAPI作成「topicブランチからdevelopへのプルリク」

## 動作確認手順

Postmanで、以下のテストを実施
- ログイン中の講師（マネージャー権限）が作成したチャプターに紐づくレッスンの全削除
　URL：　api/v1/manager/course/5/chapter/8/lesson/all
　"result": true

- 出席のあるレッスンがあれば削除を許可しない
　URL：　api/v1/manager/course/1/chapter/2/lesson/all
　403 Forbidden
　"message": "This lessons contains attendance.",,,,,, 以下、たくさんのコードが続く

- 講師の管理下にあるインストラクターが作成したチャプターに紐づくレッスンの全削除
　URL：　api/v1/manager/course/2/chapter/4/lesson/all
　"result": true
