### PR TITLE
「お知らせ一覧-タイプ変更API」の例外処理の変更

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Access\AuthorizationException;
 use App\Model\ViewedOnceNotification;
 use Illuminate\Database\Eloquent\Collection;
 use App\Http\Requests\Instructor\NotificationShowRequest;
@@ -123,10 +124,9 @@ class NotificationController extends Controller
                 return $notification->instructor_id !== $instructorId;
             })
         ) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to access this notification.',
-            ], 403);
+            throw new AuthorizationException(
+                'Forbidden, not allowed to access this notification.'
+            );
         }
         DB::beginTransaction();
         try {
@@ -145,10 +145,7 @@ class NotificationController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Access\AuthorizationException;
 use App\Model\ViewedOnceNotification;
 use App\Http\Requests\Manager\NotificationShowRequest;
 use App\Http\Requests\Manager\NotificationIndexRequest;
@@ -218,7 +219,7 @@ class NotificationController extends Controller
      * @param NotificationPutTypeRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function updateType(NotificationPutTypeRequest $request)
+    public function updateType(NotificationPutTypeRequest $request): JsonResponse
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -235,10 +236,9 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException(
+                'Forbidden, not allowed to access this notification.'
+            );
         }
 
         $notificationType = $request->notification_type;
@@ -257,9 +257,7 @@ class NotificationController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 


### PR DESCRIPTION
## issue
- JKA-1049 「お知らせ一覧-タイプ変更API」の例外処理の変更

https://github.com/yukihiroLaravel/juko_laravel/pull/707
の最後のコメント部分の
その１，その２の実装を対応した。

### テスト

https://www.dropbox.com/scl/fi/z9hy66brp7ua3g04w8c9n/JKA-1049_.xlsx?rlkey=i9jpy5lripfbo27wnu78izwmn&dl=0
の
JKA-1049_テスト.xlsx
で実施

左側がInstructor側
右側がManager側

最初は、AuthorizationExceptionを投げるところのテスト。

EXCEL行25行目付近の図より
デバッガーで、AuthorizationExceptionを投げるところを通過したのを確認したうえで
EXCEL行54行目付近のレスポンスの出方 (  postmanでは403が返った )
EXCEL行行目付近の記載のとおり、
laravel.logは出力されない
これは、#707のプルリクで、
```
その１）は、
https://github.com/yukihiroLaravel/juko_laravel/pull/706
側のプルリクで最後

laravel.logは自動ではでないようです。
＞ログの出力は不要
とのことで、スルーしてます。
がそれでOKで、そちらのプルリクが通るならば
その１）は、同レベルの対応ができます。
```
の事前連絡通り

EXCEL行494行目付近より、
->save();
を
->save22222222222222222222222();
にコードを変えたうえで動作させて、
EXCEL行503行目付近より、
catch句に制御が入ったことをデバッガーで確認したうえで
EXCEL行503行目付近より、レスポンス (  postmanでは500が返った )
EXCEL行1018行目付近より、laravel.log

最後、
EXCEL行1164行目付近より、
->save();
に実装を戻して
正常系でデグレの確認
 (  postmanでは200が返った )
