### PR TITLE
JKA-1038 ChapterController@bulkPatchStatus関連のメソッド名など変更(しみず)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -21,10 +21,10 @@ use App\Http\Requests\Instructor\ChapterPatchRequest;
 use App\Http\Requests\Instructor\ChapterStoreRequest;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
 use App\Http\Resources\Instructor\ChapterShowResource;
-use App\Http\Requests\Instructor\BulkPatchStatusRequest;
+use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\Requests\Instructor\ChapterPutStatusRequest;
-use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
+use App\Http\Requests\Instructor\ChapterUpdateStatusRequest;
 
 class ChapterController extends Controller
 {
@@ -140,10 +140,10 @@ class ChapterController extends Controller
     /**
      * チャプター更新API
      *
-     * @param ChapterPatchStatusRequest $request
+     * @param ChapterUpdateStatusRequest $request
      * @return JsonResponse
      */
-    public function updateStatus(ChapterPatchStatusRequest $request): JsonResponse
+    public function updateStatus(ChapterUpdateStatusRequest $request): JsonResponse
     {
         /** @var Chapter $chapter */
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
@@ -175,10 +175,10 @@ class ChapterController extends Controller
     /**
      * 複数チャプターの公開/非公開API
      *
-     * @param BulkPatchStatusRequest $request
+     * @param ChapterPatchStatusRequest $request
      * @return JsonResponse
      */
-    public function bulkPatchStatus(BulkPatchStatusRequest $request): JsonResponse
+    public function patchStatus(ChapterPatchStatusRequest $request): JsonResponse
     {
         try {
             // リクエストで送られたcourseとchapterのidを変数に格納

--- a/app/Http/Requests/Instructor/ChapterPatchStatusRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPatchStatusRequest.php
@@ -21,7 +21,6 @@ class ChapterPatchStatusRequest extends FormRequest
     {
         $this->merge([
             'course_id' => $this->route('course_id'),
-            'chapter_id' => $this->route('chapter_id'),
         ]);
     }
 
@@ -34,8 +33,9 @@ class ChapterPatchStatusRequest extends FormRequest
     {
         return [
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
-            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
-            'status' => ['required', 'string',new ChapterStatusRule()],
+            'status' => ['required', 'string', new ChapterStatusRule()],
+            'chapters' => ['required', 'array'],
+            'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/ChapterUpdateStatusRequest.php
+++ b/app/Http/Requests/Instructor/ChapterUpdateStatusRequest.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests\Instructor;
 use Illuminate\Foundation\Http\FormRequest;
 use App\Rules\ChapterStatusRule;
 
-class BulkPatchStatusRequest extends FormRequest
+class ChapterUpdateStatusRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,6 +21,7 @@ class BulkPatchStatusRequest extends FormRequest
     {
         $this->merge([
             'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
         ]);
     }
 
@@ -33,9 +34,8 @@ class BulkPatchStatusRequest extends FormRequest
     {
         return [
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
-            'status' => ['required', 'string', new ChapterStatusRule()],
-            'chapters' => ['required', 'array'],
-            'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'status' => ['required', 'string',new ChapterStatusRule()],
         ];
     }
 }

--- a/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
+++ b/app/Http/Requests/Manager/ChapterPatchStatusRequest.php
@@ -34,7 +34,8 @@ class ChapterPatchStatusRequest extends FormRequest
     {
         return [
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
-            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'chapters' => ['required', 'array'],
+            'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'status' => ['required', 'string', new ChapterStatusRule()],
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -78,7 +78,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::post('/', 'Api\Instructor\ChapterController@store');
                         Route::post('sort', 'Api\Instructor\ChapterController@sort');
                         Route::put('status', 'Api\Instructor\ChapterController@putStatus');
-                        Route::patch('status', 'Api\Instructor\ChapterController@bulkPatchStatus');
+                        Route::patch('status', 'Api\Instructor\ChapterController@patchStatus');
                         Route::delete('/', 'Api\Instructor\ChapterController@bulkDelete');
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', 'Api\Instructor\ChapterController@show');


### PR DESCRIPTION
## issue
- #JKA-1038

## 概要
- ChapterController@bulkPatchStatus関連のメソッド名など変更

## 動作確認手順
### Postmanにて動作確認
- ファイル名のみ変更したチャプターの情報更新が動くか確認
URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1
body："title": "PHPって？"

"result": true

- ファイル名とルート部分を変更したチャプターのステータス更新が動くか確認
URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1/status
body："status": "private"

"result": true

- ファイル名とルート部分を変更したチャプターの一括ステータス更新が動くか確認
URL：http://localhost:8080/api/v1/instructor/course/1/chapter/status
body："status": "private"

"result": true
