### PR TITLE
「openapi.yaml」と「アプリ側」のルーティング比較のコマンドの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,49 @@ composer sniffer
 ````
 composer sniffer-rewrite
 ````
+
+## OpenAPIとルーティングの比較チェック
+1. `laravel_next_docker/backend/laravelapp`ディレクトリにて下記コマンドを実行する。
+
+```shell
+cp ../../api/openapi.yaml .
+```
+
+2. `laravel_next_docker/backend/laravelapp`ディレクトリにて下記コマンドを実行する。
+
+```php
+php artisan dev:compare-route > compare-route.txt
+```
+
+## laravel-ide-helperの生成
+1. `laravel_next_docker/backend/laravelapp`ディレクトリにて下記コマンドを実行する。
+
+```shell
+php artisan ide-helper:generate
+```
+
+2. `laravel_next_docker/backend/laravelapp`ディレクトリにて下記コマンドを実行する。
+
+```shell
+php artisan ide-helper:models -N
+```
+
+3. `laravel_next_docker/backend/laravelapp`ディレクトリにて下記コマンドを実行する。
+
+```shell
+php artisan ide-helper:meta
+```
+
+## テスト実行
+1. `laravel_next_docker/backend/laravelapp`ディレクトリにて下記コマンドを実行する。
+
+```shell
+php artisan test
+```
+
+## 静的解析
+1. `laravel_next_docker/backend/laravelapp`ディレクトリにて下記コマンドを実行する。
+
+```shell
+composer analyze
+```

--- a/app/Console/Commands/CompareRoute.php
+++ b/app/Console/Commands/CompareRoute.php
@@ -82,6 +82,41 @@ class CompareRoute extends Command
         throw new Exception("invalid status. 00300");
     }
 
+    /**
+     * methodSortIndexを返す
+     *
+     * @param string $method HTTPのmethod
+     * @return string methodSortIndexを返す
+     */
+    private function getMethodSortIndex(string $method) : string {
+        /*
+            GET
+            POST
+            PATCH
+            PUT
+            DELETE
+            の順番になるようにするためのmethodSortIndexを返す
+        */
+        if($method === "get") {
+            return "0";
+        }
+        if($method === "post") {
+            return "1";
+        }
+        if($method === "patch") {
+            return "2";
+        }
+        if($method === "put") {
+            return "3";
+        }
+        if($method === "delete") {
+            return "4";
+        }
+
+        // $methodが上記以外となるのは、想定外のため例外を投げる
+        throw new Exception("invalid status. 00400");
+    }
+
     private function loadOpenapi()
     {
         /*
@@ -224,7 +259,10 @@ class CompareRoute extends Command
             }
 
             foreach ($methods as $method) {
-                $key = $uri . "###" . $method;
+                // methodSortIndexを返す
+                $methodSortIndex = $this->getMethodSortIndex($method);
+
+                $key = $uri . "###" . $methodSortIndex;
 
                 $routeList[] = [
                     'key' => $key,
@@ -262,7 +300,10 @@ class CompareRoute extends Command
 
             $method = strtolower($method);
 
-            $key = $uri . "###" . $method;
+            // methodSortIndexを返す
+            $methodSortIndex = $this->getMethodSortIndex($method);
+
+            $key = $uri . "###" . $methodSortIndex;
 
             $routeList[] = [
                 'key' => $key,

--- a/app/Console/Commands/CompareRoute.php
+++ b/app/Console/Commands/CompareRoute.php
@@ -74,7 +74,7 @@ class CompareRoute extends Command
     {
         for ($index = 0; $index < $uriIndexesExCount; ++$index) {
             $currentIndex = $uriIndexesEx[$index];
-            if($currentIndex > $argIndex) {
+            if ($currentIndex > $argIndex) {
                 return $currentIndex;
             }
         }
@@ -155,7 +155,7 @@ class CompareRoute extends Command
 
         /*
             「uriがあった位置のindex」および、末尾に「$lineCount」を追加
-            
+
             「uriの行index」から「 「次のの行index」の1つ手前の行index  または  「$lineCount」の1つ手前の行index　」
             までの間で、該当のuriに関連するmethodの繰り返しを複数個、拾うための探索処理の範囲の制御を
             するためには、あらかじめ、「uriの行index」および、末尾に「$lineCount」の値を
@@ -200,8 +200,7 @@ class CompareRoute extends Command
 
                 $methodLoopStartIndex = $index;
                 $methodLoopEndIndex = $this->getNextUriIndex($methodLoopStartIndex, $uriIndexesEx, $uriIndexesExCount);
-                for ( $methodSearchIndex = $methodLoopStartIndex; $methodSearchIndex < $methodLoopEndIndex; ++$methodSearchIndex) {
-
+                for ($methodSearchIndex = $methodLoopStartIndex; $methodSearchIndex < $methodLoopEndIndex; ++$methodSearchIndex) {
                     $methodSearchLine = $lines[$methodSearchIndex];
 
                     $retMethod = $this->startsSpacesN($methodSearchLine, 4);
@@ -224,14 +223,14 @@ class CompareRoute extends Command
                 continue;
             }
 
-            foreach($methods as $method) {
+            foreach ($methods as $method) {
                 $key = $uri . "###" . $method;
 
                 $routeList[] = [
                     'key' => $key,
                     'method' => $method,
                     'uri' => $uri,
-                ];    
+                ];
             }
         }
 

--- a/app/Console/Commands/CompareRoute.php
+++ b/app/Console/Commands/CompareRoute.php
@@ -88,7 +88,8 @@ class CompareRoute extends Command
      * @param string $method HTTPのmethod
      * @return string methodSortIndexを返す
      */
-    private function getMethodSortIndex(string $method) : string {
+    private function getMethodSortIndex(string $method): string
+    {
         /*
             GET
             POST
@@ -97,19 +98,19 @@ class CompareRoute extends Command
             DELETE
             の順番になるようにするためのmethodSortIndexを返す
         */
-        if($method === "get") {
+        if ($method === "get") {
             return "0";
         }
-        if($method === "post") {
+        if ($method === "post") {
             return "1";
         }
-        if($method === "patch") {
+        if ($method === "patch") {
             return "2";
         }
-        if($method === "put") {
+        if ($method === "put") {
             return "3";
         }
-        if($method === "delete") {
+        if ($method === "delete") {
             return "4";
         }
 

--- a/app/Console/Commands/CompareRoute.php
+++ b/app/Console/Commands/CompareRoute.php
@@ -62,6 +62,26 @@ class CompareRoute extends Command
         return trim(str_replace(":", "", $string));
     }
 
+    /**
+     * 「$argIndexの次のuriのindexまたは、末尾のindex」を取得する。
+     *
+     * @param int $argIndex 指定index
+     * @param array $uriIndexesEx uriまたは「末尾に「$lineCount」」のindex
+     * @param int $uriIndexesExCount 要素数
+     * @return int 「$argIndexの次のuriのindexまたは、末尾のindex」
+     */
+    private function getNextUriIndex(int $argIndex, array $uriIndexesEx, int $uriIndexesExCount): int
+    {
+        for ($index = 0; $index < $uriIndexesExCount; ++$index) {
+            $currentIndex = $uriIndexesEx[$index];
+            if($currentIndex > $argIndex) {
+                return $currentIndex;
+            }
+        }
+        // $uriIndexesExを作る時に、「  末尾に「$lineCount」を追加  」してるため、あり得ないはず。
+        throw new Exception("invalid status. 00300");
+    }
+
     private function loadOpenapi()
     {
         /*
@@ -133,6 +153,33 @@ class CompareRoute extends Command
 
         $lineCount = count($lines);
 
+        /*
+            「uriがあった位置のindex」および、末尾に「$lineCount」を追加
+            
+            「uriの行index」から「 「次のの行index」の1つ手前の行index  または  「$lineCount」の1つ手前の行index　」
+            までの間で、該当のuriに関連するmethodの繰り返しを複数個、拾うための探索処理の範囲の制御を
+            するためには、あらかじめ、「uriの行index」および、末尾に「$lineCount」の値を
+            $uriIndexesExで保持しておく必要がある
+            名前に「Ex」をつけてるのは、末尾に「$lineCount」の値を指定しているため
+            ループを継続する判定式では、「<」で判定のため
+            「$lineCount」の値をindex指定したアクセスが行われないことを前提にしてる。
+        */
+        $retUri = false;
+        $uriIndexesEx = [];
+        for ($index = 0; $index < $lineCount; ++$index) {
+            $line = $lines[$index];
+
+            $retUri = $this->startsSpacesN($line, 2);
+            if ($retUri) {
+                // 「uriがあった位置のindex」を追加
+                $uriIndexesEx[] = $index;
+            }
+        }
+        // 末尾に「$lineCount」を追加 ( passed the end )
+        $uriIndexesEx[] = $lineCount;
+        $uriIndexesExCount = count($uriIndexesEx);
+
+
         $routeList = [];
         for ($index = 0; $index < $lineCount; ++$index) {
             $line = $lines[$index];
@@ -141,7 +188,7 @@ class CompareRoute extends Command
             $retMethod = false;
 
             $uri = "";
-            $method = "";
+            $methods = [];
 
             $isAddRouteList = false;
 
@@ -151,14 +198,15 @@ class CompareRoute extends Command
 
                 $uri = $this->trimAndRemoveColon($line);
 
-                $nextIndex = ( $index + 1 );
+                $methodLoopStartIndex = $index;
+                $methodLoopEndIndex = $this->getNextUriIndex($methodLoopStartIndex, $uriIndexesEx, $uriIndexesExCount);
+                for ( $methodSearchIndex = $methodLoopStartIndex; $methodSearchIndex < $methodLoopEndIndex; ++$methodSearchIndex) {
 
-                if ($nextIndex < $lineCount) {
-                    $nextLine = $lines[$nextIndex];
+                    $methodSearchLine = $lines[$methodSearchIndex];
 
-                    $retMethod = $this->startsSpacesN($nextLine, 4);
+                    $retMethod = $this->startsSpacesN($methodSearchLine, 4);
                     if ($retMethod) {
-                        $method = $this->trimAndRemoveColon($nextLine);
+                        $methods[] = $this->trimAndRemoveColon($methodSearchLine);
 
                         $checkFlag = true;
                     }
@@ -176,13 +224,15 @@ class CompareRoute extends Command
                 continue;
             }
 
-            $key = $method . "###" . $uri;
+            foreach($methods as $method) {
+                $key = $uri . "###" . $method;
 
-            $routeList[] = [
-                'key' => $key,
-                'method' => $method,
-                'uri' => $uri,
-            ];
+                $routeList[] = [
+                    'key' => $key,
+                    'method' => $method,
+                    'uri' => $uri,
+                ];    
+            }
         }
 
         // $routeListをkeyで昇順ソート
@@ -213,7 +263,7 @@ class CompareRoute extends Command
 
             $method = strtolower($method);
 
-            $key = $method . "###" . $uri;
+            $key = $uri . "###" . $method;
 
             $routeList[] = [
                 'key' => $key,


### PR DESCRIPTION
## issue
- JKA-1053  「openapi.yaml」と「アプリ側」のルーティング比較のコマンドの修正

slack引用
```
uriの行の次の行にmethodが来る前提で、
yamlの読み込みをする
コマンドの実装にしてたです。
そのあたりで、間違ったかもしれません。
常に、methodの上の行にuriが来る前提で。
もしかして、1つのuriの下に、
methodが複数個繰り返し来る
構造だったら、その2つ目移行
読み込めておらず、OpenApi側にないと、
認識される
それ可能性があるため、夜に確認します。
```
まさに、上記が原因で
uriの行の下に複数個methodが繰り返しの時に、その2個目以降、
OpenApi側にあるとして認識できてない状況でした
(  methodの行前に必ず、uriの行があるような構造と勘違いしてた )

## slackで話題になってた下記の件
```
Method: DELETE, URI: /api/v1/instructor/course/{course_id}
OpenAPIに存在すると思われるため、追記不要。
```
の分と、
```
Method: DELETE, URI: /api/v1/instructor/course/{course_id}/chapter/{chapter_id}
OpenAPIに存在すると思われるため、追記不要。
```
の分は、
「両方ある分(keyマッチ分)」
の
ところに出力されるようになりました。
```
Method: DELETE, URI: /api/v1/instructor/course/{course_id}/chapter
説明: 選択済みチャプターを削除する
```
の分は、
「アプリ側」のみある分
で出力されてます。

## ついでに、並び順も変えた
methodが第1ソートキー、uriが第2ソートキーで出力
でしたが、
それを
uriが第1ソートキー、methodが第2ソートキーで出力
に変更しました。
そのほうが、アプリの仕様の意味の関連性が高いものが近い位置に出力されると思います。

## ただし、1行、1行の出力行の形式はそのまま

1行、1行の出力行の形式は、
例として、
Method: DELETE, URI: /api/v1/instructor/course/{course_id}/chapter
のままにしてます。
第2ソートキーのほうが左なのが気になり、そこは、迷ったのですが
uriをコピペして作業するときに、
右側に余計なものがないほうが、作業しやすいと思いましたので
出力形式は、ソートキーの第1、第2と、出力の第1、第2の
左右が逆であることは承知のうえで、そのままにしてます。

## さらに同一uri内で複数methodがあるケースのuri内の並び順について

さらに同一uri内で複数methodがあるケースのuri内の並び順について
GET
POST
PATCH
PUT
DELETE
の順番になるように、
下記のメソッドの結果をkeyに文字列連結した
```
    /**
     * methodSortIndexを返す
     *
     * @param string $method HTTPのmethod
     * @return string methodSortIndexを返す
     */
    private function getMethodSortIndex(string $method) : string {
        /*
            GET
            POST
            PATCH
            PUT
            DELETE
            の順番になるようにするためのmethodSortIndexを返す
        */
        if($method === "get") {
            return "0";
        }
        if($method === "post") {
            return "1";
        }
        if($method === "patch") {
            return "2";
        }
        if($method === "put") {
            return "3";
        }
        if($method === "delete") {
            return "4";
        }

        // $methodが上記以外となるのは、想定外のため例外を投げる
        throw new Exception("invalid status. 00400");
    }
```

そうやってuriと連結したkeyで昇順ソートしたもので
マッチング処理をする実装になった。
