### PR TITLE
JKA-1050 (親:JKA-1044) 空の配列を返すルーターとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -111,8 +111,8 @@ class NotificationController extends Controller
     /**
      * お知らせ詳細-削除
      *
-     * @param 
-     * @return 
+     * @param
+     * @return
      */
     public function delete()
     {

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -109,6 +109,17 @@ class NotificationController extends Controller
     }
 
     /**
+     * お知らせ詳細-削除
+     *
+     * @param 
+     * @return 
+     */
+    public function delete()
+    {
+        return response()->json([]);
+    }
+
+    /**
      * お知らせ一覧-タイプ変更API
      *
      * @param NotificationPutTypeRequest $request

--- a/routes/api.php
+++ b/routes/api.php
@@ -145,6 +145,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', 'Api\Instructor\NotificationController@show');
                     Route::patch('/', 'Api\Instructor\NotificationController@update');
+                    Route::delete('/', 'Api\Instructor\NotificationController@delete');
                 });
             });
         });


### PR DESCRIPTION
## issue
- JKA-1050 空の配列を返すルーターとコントローラの作成

## 概要
- 講師側 お知らせ （1件）削除API作成の子課題「空の配列を返すルーターとコントローラの作成」

## 動作確認手順
- 講師 id:2 （マネージャ権限無し）でログインし、その講師が作成したお知らせ id:2 でAPIテストを実施
 URL:  http://localhost:8080/api/v1/instructor/notification/2
 リクエスト:  DELETE
 結果:  [ ]
