### PR TITLE
JKA-1028 親タスク-マネージャー側 講師詳細画面 講師詳細APIに講師タイプを追加(ゆうじ)

### DIFF
--- a/app/Http/Resources/Manager/InstructorShowResource.php
+++ b/app/Http/Resources/Manager/InstructorShowResource.php
@@ -24,6 +24,7 @@ class InstructorShowResource extends JsonResource
             'first_name' => $this->resource->first_name,
             'email' => $this->resource->email,
             'profile_image' => $this->resource->profile_image,
+            'instructor_type' => $this->resource->type,
         ];
     }
 }


### PR DESCRIPTION
## issue
- JKA-1028

## 概要
- 親タスク-マネージャー側 講師詳細画面 講師詳細APIに講師タイプを追加
https://gut-familie.atlassian.net/browse/JKA-1028

## 動作確認手順
- Postmanで、以下のテストを実施
  - 講師側でログイン（マネージャー権限）
    - email：`test_instructor@example.com`
    - password：`password`

  - GETリクエストで「講師情報を取得する。」
    - URL：http://localhost:8080/api/v1/manager/instructor/1
  
     - レスポンス
  ```json
  {
    "data": {
        "instructor_id": 1,
        "nick_name": "Yamada",
        "last_name": "山田",
        "first_name": "太郎",
        "email": "test_instructor@example.com",
        "profile_image": "instructor/default.png",
        "instructor_type": "manager"
    }
  }
  ```


  - Postmanからのレスポンスに、Adminerの`instructors`テーブル`type`欄のデータが表示されていることを確認
http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=instructors

### 考慮して欲しいこと
特になし

## 確認して欲しいこと
特になし
