### PR TITLE
JKA-1029 親タスク-マネージャー側 講師詳細画面 講座一覧APIに更新日を追加(中川)

### DIFF
--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -40,7 +40,8 @@ class InstructorCourseIndexResource extends JsonResource
             return [
                 "course_id" => $course->id,
                 "title" => $course->title,
-                "status" => $course->status
+                "status" => $course->status,
+                "updated_at" => $course->updated_at->format('Y/m/d H:i:s'),
             ];
         })
         ->toArray();


### PR DESCRIPTION
## issue
･Closes JKA-1029 featureブランチからdevelopブランチへのプルリク（なかがわ）


## 概要
・親タスク-マネージャー側 講師詳細画面 講座一覧APIに更新日を追加　『featureブランチからdevelopブランチへのプルリク』

##動作確認手順
-Postmanで、以下のテストを実施
講師詳細画面にログイン
http://localhost:8080/api/v1/manager/instructor/:instructor_id/course/index

更新日時 "updated_at": "2024-11-15T12:22:28.000000Z"の記載があることを確認
{
    "data": {
        "courses": [
            {
                "course_id": 2,
                "title": "Laravel入門講座",
                "status": "public",
                "updated_at": "2024-11-15T12:22:28.000000Z"
            },
            {
                "course_id": 6,
                "title": "Vue入門講座",
                "status": "public",
                "updated_at": "2024-11-15T12:22:28.000000Z"
            }
        ],
        "pagination": {
            "page": 1,
            "total": 2
        }
    }
}
