### PR TITLE
JKA-1051(親タスクJKA-1044) ロジックの作成(西山しょうこ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -20,6 +20,7 @@ use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Requests\Instructor\NotificationPutTypeRequest;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Http\Requests\Instructor\NotificationBulkDeleteRequest;
+use Illuminate\Http\Request;
 
 class NotificationController extends Controller
 {
@@ -109,14 +110,41 @@ class NotificationController extends Controller
     }
 
     /**
-     * お知らせ詳細-削除
+     * お知らせ削除
      *
      * @param
-     * @return
+     * @return \Illuminate\Http\JsonResponse
      */
-    public function delete()
+    public function delete(Request $request, int $notification_id)
     {
-        return response()->json([]);
+        // 認証している講師のIDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        // 指定されたお知らせを取得
+        /** @var Notification $notification */
+        $notification = Notification::findOrFail($notification_id);
+
+        // お知らせが、現在ログインしている講師のものでなければエラー
+        if ($instructorId !== $notification->instructor_id) {
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
+        DB::beginTransaction();
+        try {
+            // 中間テーブルにお知らせと生徒の関係があれば行を削除
+            $notification->students()->detach();
+            $notification->delete();
+            DB::commit();
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            return response()->json([
+                'result' => false,
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -135,15 +135,14 @@ class NotificationController extends Controller
             $notification->students()->detach();
             $notification->delete();
             DB::commit();
+
             return response()->json([
                 'result' => true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -191,25 +191,22 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (!in_array($notification->instructor_id, $instructorIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to update this notification.',
-            ], 403);
+            throw new AuthorizationException('Forbidden, not allowed to delete this notification.');
         }
+
         DB::beginTransaction();
         try {
             $notification->students()->detach();
             $notification->delete();
             DB::commit();
+
             return response()->json([
                 'result' => true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -169,7 +169,7 @@ class NotificationController extends Controller
     }
 
     /**
-     * お知らせ詳細-削除
+     * お知らせ削除
      *
      * @param NotificationDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse


### PR DESCRIPTION
## issue

- Closes JKA-1051(親タスクJKA-1044)ロジックの作成(西山しょうこ)

## 概要

- 講師側　お知らせ削除（１つだけ）のAPI作成　子課題「ロジックの作成」

## 動作確認手順

PostmanとAdminerで、以下のテストを実施

- ログイン中の通常講師（id:2）が作成したお知らせ（id:2） を削除するテスト
【Postman】
　　URL：　http://localhost:8080/api/v1/instructor/notification/2
　　"result": true
【Adminer】
　　お知らせ２　が削除された。
　　中間テーブル（生徒id:2 とお知らせid:2 の関係を示すデータ）も、削除された。

- 別の講師（id:4）でログインした状態で、講師 id:2 が作ったお知らせ（id:2）を削除するテスト
【Postman】
　　URL：　http://localhost:8080/api/v1/instructor/notification/2
　　"result": 403 Forbidden
　　"message": 　"Invalid instructor_id.",

- 今回のテストで削除された　お知らせ（id:2）と、中間テーブルのデータ（生徒 id:2 とお知らせid:2 の繋がり）は、Adminerで復元済みです。

## ご確認をお願いしたいこと
Postmanでのテストがまだ慣れていないこともあり不安です。
上記のテストが、今回のタスク内容にきちんと沿っているか（的を得ているか）、ご確認とご指摘をいただきたいです。
