### PR TITLE
JKA-1052(親タスクJKA-1044)フォームリクエストの作成(西山しょうこ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -19,8 +19,8 @@ use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Http\Requests\Instructor\NotificationPutTypeRequest;
 use App\Http\Resources\Instructor\NotificationIndexResource;
+use App\Http\Requests\Instructor\NotificationDeleteRequest;
 use App\Http\Requests\Instructor\NotificationBulkDeleteRequest;
-use Illuminate\Http\Request;
 
 class NotificationController extends Controller
 {
@@ -112,17 +112,17 @@ class NotificationController extends Controller
     /**
      * お知らせ削除
      *
-     * @param
+     * @param NotificationDeleteRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function delete(Request $request, int $notification_id)
+    public function delete(NotificationDeleteRequest $request): JsonResponse
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 指定されたお知らせを取得
         /** @var Notification $notification */
-        $notification = Notification::findOrFail($notification_id);
+        $notification = Notification::findOrFail($request->notification_id);
 
         // お知らせが、現在ログインしている講師のものでなければエラー
         if ($instructorId !== $notification->instructor_id) {

--- a/app/Http/Requests/Instructor/NotificationDeleteRequest.php
+++ b/app/Http/Requests/Instructor/NotificationDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NotificationDeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_id' => $this->route('notification_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'notification_id' => ['required', 'integer', 'exists:notifications,id,deleted_at,NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue

- Closes JKA-1052(親タスクJKA-1044)フォームリクエストの作成(西山しょうこ)

## 概要

- 講師側　お知らせ削除（１つだけ）のAPI作成　子課題「フォームリクエストの作成」

## 動作確認手順

PostmanとAdminerで、「ロジックの作成」時と同じテストを再実施

- ログイン中の通常講師（id:2）が作成したお知らせ（id:2） を削除するテスト
【Postman】
　　URL：　http://localhost:8080/api/v1/instructor/notification/2
　　"result": true
【Adminer】
　　お知らせ２　が削除された。
　　中間テーブル（生徒id:2 とお知らせid:2 の関係を示すデータ）も、削除された。

- 別の講師（id:4）でログインした状態で、講師 id:2 が作ったお知らせ（id:2）を削除するテスト
【Postman】
　　URL：　http://localhost:8080/api/v1/instructor/notification/2
　　"result": 403 Forbidden
　　"message": 　"Invalid instructor_id.",

- 今回のテストで削除された　お知らせ（id:2）と、中間テーブルのデータ（生徒 id:2 とお知らせid:2 の繋がり）は、Adminerで復元済みです。
