### PR TITLE
JKA-1057 Manager/NotificationControllerとInstructor/NotificationControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -50,10 +50,7 @@ class NotificationController extends Controller
             ->findOrFail($request->notification_id);
 
         if ($notification->instructor_id !== Auth::guard('instructor')->user()->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to access this notification.',
-            ], 403);
+            throw new AuthorizationException('Forbidden, not allowed to access this notification.');
         }
 
         return new NotificationShowResource($notification);
@@ -191,10 +188,7 @@ class NotificationController extends Controller
             })
         ) {
             // 講師と一致しないお知らせが含まれている場合はエラー
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException('Forbidden.');
         }
 
         // トランザクション開始
@@ -214,17 +208,9 @@ class NotificationController extends Controller
                 'result' => true,
             ]);
         } catch (Exception $e) {
-            // ロールバック
             DB::rollBack();
-
-            // ログ出力
-            Log::debug($e->getMessage());
-
-            // エラーレスポンスを返す
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to delete notifications.',
-            ], 500);
+            Log::error($e);
+            throw $e;
         }
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -50,7 +50,7 @@ class NotificationController extends Controller
             ->findOrFail($request->notification_id);
 
         if ($notification->instructor_id !== Auth::guard('instructor')->user()->id) {
-            throw new AuthorizationException('Forbidden, not allowed to access this notification.');
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         return new NotificationShowResource($notification);
@@ -143,9 +143,7 @@ class NotificationController extends Controller
                 return $notification->instructor_id !== $instructorId;
             })
         ) {
-            throw new AuthorizationException(
-                'Forbidden, not allowed to access this notification.'
-            );
+            throw new AuthorizationException('Invalid instructor_id.');
         }
         DB::beginTransaction();
         try {
@@ -188,7 +186,7 @@ class NotificationController extends Controller
             })
         ) {
             // 講師と一致しないお知らせが含まれている場合はエラー
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         // トランザクション開始

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -73,7 +73,7 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         return new NotificationShowResource($notification);
@@ -97,7 +97,7 @@ class NotificationController extends Controller
         /** @var Course $course */
         $course = Course::findOrFail($request->course_id);
         if (! in_array($course->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         Notification::create([
@@ -138,7 +138,7 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         $notification->fill([
@@ -177,7 +177,7 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, not allowed to delete this notification.');
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         DB::beginTransaction();
@@ -216,9 +216,7 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
-            throw new AuthorizationException(
-                'Forbidden, not allowed to access this notification.'
-            );
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         $notificationType = $request->notification_type;
@@ -263,7 +261,7 @@ class NotificationController extends Controller
 
         // アクセス権のチェック
         if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         DB::beginTransaction();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -73,10 +73,7 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException('Forbidden.');
         }
 
         return new NotificationShowResource($notification);
@@ -100,10 +97,7 @@ class NotificationController extends Controller
         /** @var Course $course */
         $course = Course::findOrFail($request->course_id);
         if (! in_array($course->instructor_id, $instructorIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException('Forbidden.');
         }
 
         Notification::create([
@@ -144,10 +138,7 @@ class NotificationController extends Controller
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException('Forbidden.');
         }
 
         $notification->fill([
@@ -272,10 +263,7 @@ class NotificationController extends Controller
 
         // アクセス権のチェック
         if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException('Forbidden.');
         }
 
         DB::beginTransaction();
@@ -295,10 +283,7 @@ class NotificationController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 }


### PR DESCRIPTION
## issue

- Closes JKA-1057 Manager/NotificationControllerとInstructor/NotificationControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（西山しょうこ）

## 概要

- マネージャ側&講師側　NotificationControllerの未対応部分の403/500エラーの記述方法を変更
- 【追加修正分】２つのNotificationControllerについて、アクセス権限に関するエラー文言を全て Invalid instructor_id. に統一

## 動作確認手順（１つ失敗）
Postmanにて以下の方法でそれぞれテスト

**<ins>マネージャ側　NotificationController</ins>　マネージャー（ id:1 ）でログイン**

＜403をthrow new AuthorizationException（）に変更し、アクセス権限のテストを実施。それぞれ指定のエラーメッセージが出ればOK。＞　
- **showメソッド**　配下でない講師４が作成したお知らせ３でテスト　
　URL：【GET】api/v1/manager/notification/3　
　結果：Forbiddenが出たのでOK！

- **storeメソッド** 　配下ではない講師４が作成したcourse_id:4をURLに入れてテスト
　URL：【POST】api/v1/manager/course/4/notification~~api/v1/manager/course/notification~~ 
　body ：
```
　"course_id": 4,
　"instructor_id": 1,
　"title": "あああああ",
　"type": "always",
　"start_date": "2024-11-27 15:30:45",
　"end_date": "2025-11-27 15:30:45",
　"content": "あああああああああああああああああああああ"
```
　~~結果：本来出てくるべきエラーとは違う下記のようなエラーが出てきてしまった。course_id は数値にしているつもりです。statusは必須となっていますが、validationルールには書いていないように思いますので何を記載すべきかわからないです。失敗。~~ 
**結果：Forbidden　が出たので今度はOK！** 

- **updateメソッド** 　配下でない講師４が作成したお知らせ３でテスト　
　URL：【PATCH】api/v1/manager/notification/3　
　body：
```
　{
   　 "title": "あああああ",
    　"type": "always",
    　"start_date": "2024-11-27 15:30:45",
    　"end_date": "2025-11-27 15:30:45",
    　"content": "あああああああああああああああああああああ"
　}
```
　結果：　Forbidden　が出たのでOK！

- **bulkDeleteメソッド**　関係ない講師が作成したお知らせ３をフロント側で選択したと仮定しテスト
　URL：【DELETE】api/v1/manager/notification
　body：　
```
　{
   　 "notifications": [3]
　}
```
　結果：Forbiddenが出たのでOK！

＜500エラー箇所をthrow $eに変更。意図的に例外を発生させてcatchブロックに飛ばすテスト＞　
- **bulkDeleteメソッド**
　catchブロックのthrow $eをテストするため、VScodeのtryの下に一時的にエラーを追加。（テスト後削除）
```
   　         throw new \Exception('テスト');
```
　ログインした講師が作成したお知らせ１をフロント側で選択したと仮定しテスト
　URL：【DELETE】api/v1/manager/notification
　body：　
```
　{
  　  "notifications": [1]
　}
```
　結果：500 Internal Server Error 、"message": "テスト”。意図的に発生させた例外「テスト」というメッセージが含まれているので、例外が正しくスローされてキャッチされた。OK！


**<ins>講師側　Notification Controller</ins>　講師（ id:2 ）でログイン**

＜403をthrow new AuthorizationException（）に変更し、アクセス権限のテストを実施。それぞれ指定されているエラーメッセージが出ればOK。＞　　

- **showメソッド** 　別の講師が作成したお知らせ３でテスト
　URL：【GET】api/v1/instructor/notification/3
　結果："Forbidden, not allowed to access this notification.” が出たのでOK！

- **bulkDeleteメソッド**　別の講師が作成したお知らせ３をフロント側で選択したと仮定しテスト
　URL：【DELETE】api/v1/instructor/notification
　body：　
```
　{
  　  "notifications": [3]
　}
```
　結果：Forbiddenが出たのでOK！

＜500エラー箇所をthrow $eに変更。意図的に例外を発生させてcatchブロックに飛ばすテスト＞　
- **bulkDeleteメソッド**
　catchブロックのthrow $eをテストするため、tryの下に一時的にエラーを追加。（テスト後削除）
```
   　         throw new \Exception('テスト');
```
　ログインしている講師が作成したお知らせ２をフロント側で選択したと仮定しテスト。
　URL：【DELETE】api/v1/instructor/notification
　body：
```
　{
  　  "notifications": [2]
　}
```
　結果：500 Internal Server Error 、"message": "テスト”。意図的に発生させた例外「テスト」というメッセージが含まれているので、例外が正しくスローされてキャッチされた。OK！
