### PR TITLE
JKA-1036 マネージャー側 講座情報登録ルーティングの重複分の削除と動作確認

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -165,9 +165,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     });
                 });
                 // マネージャー-講座
-                Route::prefix('course')->group(function () {
+                Route::prefix('course')->group(function () {                  
                     Route::get('index', 'Api\Manager\CourseController@index');
-                    Route::post('store', 'Api\Manager\CourseController@store');
+                    //Route::post('store', 'Api\Manager\CourseController@store');
                     Route::put('status', 'Api\Manager\CourseController@status');
                     Route::post('/', 'Api\Manager\CourseController@store');
                     Route::prefix('{course_id}')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -165,9 +165,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     });
                 });
                 // マネージャー-講座
-                Route::prefix('course')->group(function () {                  
+                Route::prefix('course')->group(function () {
                     Route::get('index', 'Api\Manager\CourseController@index');
-                    Route::put('status', 'Api\Manager\CourseController@status');                    
+                    Route::put('status', 'Api\Manager\CourseController@status');
                     Route::post('/', 'Api\Manager\CourseController@store');
                     Route::prefix('{course_id}')->group(function () {
                         Route::get('/', 'Api\Manager\CourseController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -167,7 +167,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {                  
                     Route::get('index', 'Api\Manager\CourseController@index');
-                    Route::put('status', 'Api\Manager\CourseController@status');
+                    Route::put('status', 'Api\Manager\CourseController@status');                    
                     Route::post('/', 'Api\Manager\CourseController@store');
                     Route::prefix('{course_id}')->group(function () {
                         Route::get('/', 'Api\Manager\CourseController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -167,7 +167,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-講座
                 Route::prefix('course')->group(function () {                  
                     Route::get('index', 'Api\Manager\CourseController@index');
-                    //Route::post('store', 'Api\Manager\CourseController@store');
                     Route::put('status', 'Api\Manager\CourseController@status');
                     Route::post('/', 'Api\Manager\CourseController@store');
                     Route::prefix('{course_id}')->group(function () {


### PR DESCRIPTION
## issue
- Closes #JKA-1036　マネージャー側 講座情報登録ルーティングの重複分の削除と動作確認

## 概要
- URLにstoreと付いている上の方のルーティングを削除して
その後残ったルーティングがきちんと動作して講座登録できるかどうかを動作確認

## 動作確認手順
- Postmanで、以下のテストを実施
下記instructorでログインしたうえで
講座情報登録URLを実行
adminerで登録したデータがあることを確認

instructor
http://localhost:8080/login/instructor 
email: test_instructor@example.com
password: password

講座情報登録URL
http://localhost:8080/api/v1/manager/course
title: 任意のタイトルを指定
image: 任意の画像を指定

出力例
```
{
    "result": true,
    "data": {
        "instructor_id": 1,
        "title": "Rby入門",
        "image": "course/ec70d92e-0666-455c-afdf-22e055e70482.png",
        "status": "private",
        "created_at": "2024-11-26 21:36:44",
        "updated_at": "2024-11-26 21:36:44",
        "id": 11
    }
```

## 考慮して欲しいこと
- なし

## 確認して欲しいこと
- なし
