### PR TITLE
JKA-1043 api.phpの不要なprefixグループを消す マネージャー側のルーティング(ゆうじ)

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -231,7 +231,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::delete('/', 'Api\Manager\AttendanceController@delete');
                     });
                 });
-                Route::prefix('instructor')->group(function () {});
                 // マネージャー-生徒
                 Route::prefix('student')->group(function () {
                     Route::get('{student_id}', 'Api\Manager\StudentController@show');


### PR DESCRIPTION
## issue
- JKA-1043

## 概要
- api.phpの不要なprefixグループを消す マネージャー側のルーティング
https://gut-familie.atlassian.net/browse/JKA-1043

## 動作確認手順
- Postmanで、以下のテストを実施
  - 講師側でログイン（マネージャー権限）
    - email：`test_instructor@example.com`
    - password：`password`

  - GETリクエストで「講師情報を取得する。」が問題なく動作することを確認。
    - URL：http://localhost:8080/api/v1/manager/instructor/1
  
  - POSTリクエストで「講師情報を更新する。」が問題なく動作することを確認。
    - URL：http://localhost:8080/api/v1/manager/instructor/2

     - ボディのRaw一例
  ```json
  {
    "nick_name": "Hanako10",
    "last_name": "山本10",
    "first_name": "花子10",
    "email": "test_instructor10@example.com"
  }
  ```

  - Postmanからのレスポンスがtrue、Adminerの`instructors`テーブル該当欄のデータが更新されていることを確認
http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=instructors

### 考慮して欲しいこと
タスク通りapi.php234行目辺りの重複していた不要なprefixグループを削除し、Kouさんからの助言通り157行目周辺のprefix('instructor')を含むルーティングの動作確認を行いました。

## 確認して欲しいこと
最初間違えてmainにプルリクエストしてしまいました。すぐにリクエスト先をnext-developに変更しましたが、問題なくリクエストがされているか念の為ご確認をお願いいたします。