### PR TITLE
JKA-1064 マネージャー側と講師側CourseControllerの403/404/500エラーの記述方法変更（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Auth\Access\AuthorizationException;
 use RuntimeException;
 
 class CourseController extends Controller
@@ -84,10 +85,7 @@ class CourseController extends Controller
             $imagePath = $course->image;
 
             if ($user->id !== $course->instructor_id) {
-                return new JsonResponse([
-                    'result' => false,
-                    'message' => 'Not authorized.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             if (isset($file)) {
@@ -113,11 +111,8 @@ class CourseController extends Controller
                 'result' => true,
             ]);
         } catch (RuntimeException $e) {
-            Log::error($e->getMessage());
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            Log::error($e);
+            throw $e;
         }
     }
 
@@ -131,17 +126,11 @@ class CourseController extends Controller
             $course = Course::findOrFail($request->course_id);
 
             if ($user->id !== $course->instructor_id) {
-                return new JsonResponse([
-                    'result' => false,
-                    'message' => 'Not authorized.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             if (Attendance::where('course_id', $request->course_id)->exists()) {
-                return new JsonResponse([
-                    'result' => false,
-                    'message' => 'This course has already been taken by students.',
-                ], 403);
+                throw new AuthorizationException('This course has already been taken by students.');
             }
 
             // publicディレクトリ配下の画像ファイルを削除
@@ -156,10 +145,7 @@ class CourseController extends Controller
             ]);
         } catch (RuntimeException $e) {
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -20,8 +20,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
-use RuntimeException;
 
 class CourseController extends Controller
 {
@@ -110,7 +110,7 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
         }
@@ -143,7 +143,7 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
         }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -15,13 +15,13 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Services\Course\QueryService;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Exception;
 
 class CourseController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -15,12 +15,12 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Services\Course\QueryService;
 use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Illuminate\Auth\Access\AuthorizationException;
 use RuntimeException;
 
 class CourseController extends Controller

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -21,8 +21,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
-use RuntimeException;
 
 class CourseController extends Controller
 {
@@ -143,10 +143,10 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
+
         } catch (ModelNotFoundException $e) {
-            Log::error($e);
             throw $e;
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
         }
@@ -187,9 +187,8 @@ class CourseController extends Controller
                 'result' => true,
             ]);
         } catch (ModelNotFoundException $e) {
-            Log::error($e);
             throw $e;
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
         }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Auth\Access\AuthorizationException;
 use RuntimeException;
 
 class CourseController extends Controller
@@ -63,10 +64,7 @@ class CourseController extends Controller
 
         // 自身 もしくは 配下の講師でない場合はエラー応答
         if (! in_array($course->instructor_id, $instructorIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to this course.',
-            ], 403);
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         return new CourseShowResource($course);
@@ -120,10 +118,7 @@ class CourseController extends Controller
 
             if (! in_array($course->instructor_id, $managingIds, true)) {
                 // 自分、または配下の講師の講座でなければエラー応答
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Forbidden, not allowed to update this course.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             if (isset($file)) {
@@ -148,17 +143,12 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ModelNotFoundException $exception) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Not Found course.',
-            ], 404);
+        } catch (ModelNotFoundException $e) {
+            Log::error($e);
+            throw $e;
         } catch (RuntimeException $e) {
-            Log::error($e->getMessage());
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            Log::error($e);
+            throw $e;
         }
     }
 
@@ -179,40 +169,29 @@ class CourseController extends Controller
 
             if (! in_array($course->instructor_id, $managingIds, true)) {
                 // 自分、または配下の講師の講座でなければエラー応答
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Forbidden, not allowed to delete this course.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             if (Attendance::where('course_id', $request->course_id)->exists()) {
-                return new JsonResponse([
-                    'result' => false,
-                    'message' => 'This course has already been taken by students.',
-                ], 403);
+                throw new AuthorizationException('This course has already been taken by students.');
             }
 
             // publicディレクトリ配下の画像ファイルを削除
             if (Storage::disk('public')->exists($course->image)) {
                 Storage::disk('public')->delete($course->image);
             }
-
+            
             $course->delete();
 
             return response()->json([
                 'result' => true,
             ]);
         } catch (ModelNotFoundException $e) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Not Found course.',
-            ], 404);
+            Log::error($e);
+            throw $e;
         } catch (RuntimeException $e) {
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -15,13 +15,13 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Services\Course\QueryService;
 use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Illuminate\Auth\Access\AuthorizationException;
 use RuntimeException;
 
 class CourseController extends Controller
@@ -180,7 +180,7 @@ class CourseController extends Controller
             if (Storage::disk('public')->exists($course->image)) {
                 Storage::disk('public')->delete($course->image);
             }
-            
+
             $course->delete();
 
             return response()->json([

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -15,6 +15,7 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Services\Course\QueryService;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
@@ -22,7 +23,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Exception;
 
 class CourseController extends Controller
 {


### PR DESCRIPTION
## issue

- Closes JKA-1064 Manager/CourseControllerとInstructor/CourseControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（西山しょうこ）

## 概要

- マネージャ側&講師側　CourseControllerの未対応部分の403/404/500エラーの記述方法を変更

## 動作確認手順
Postmanにて以下の方法でそれぞれテストしました。

**<ins>マネージャ側　CourseController</ins>　マネージャー（ id:1 ）でログイン**

＜403をthrow new AuthorizationException（）に変更し、アクセス権限のテストを実施。それぞれ指定のエラーメッセージが出ればOK。＞

- **showメソッド**　配下でない講師４が作成したコース４をURLに入れてテスト　
　URL：【GET】api/v1/manager/course/4　
　結果：Invalid instructor_id. が出たのでOK！

- **updateメソッド**　配下でない講師４が作成したコース４でテスト　
　URL：【POST】api/v1/manager/course/4　
　body：
```
　{
   　 "title": "あああああ",
    　"type": "private",
　}
```
　結果：　Invalid instructor_id. 　が出たのでOK！（bodyにimage無しでテストしました。）

- **deleteメソッド：その１**　配下ではない講師４が作成したcourse_id:4をURLに入れてテスト　
　URL：【DELETE】api/v1/manager/course/4
　結果：Invalid instructor_id. 　が出たのでOK！

- **deleteメソッド：その２**　attendancesテーブルに存在する（受講されている）、マネージャが作成したコース１をURLに入れてテスト
　URL：【DELETE】api/v1/manager/course/1
　結果："This course has already been taken by students.” が出たのでOK！

＜500エラー箇所をthrow $eに変更。意図的に例外を発生させてcatchブロックに飛ばすテスト＞

- **updateメソッド**　VScodeのtryのに一時的にエラーを追加。（テスト後に削除）
```
            // テスト用のExceptionを発生させる
            throw new Exception('テスト');
```
　ログインした講師が作成したコース１をURLに入れてテスト
　URL：【POST】api/v1/manager/course/1
　結果：500 Internal Server Error 、"message": "テスト”。意図的に発生させた例外が正しくスローされてキャッチされた。OK！（image無しでテスト）

- **deleteメソッド**　VScodeのtryのに一時的にエラーを追加。（テスト後に削除）
```
            // テスト用のExceptionを発生させる
            throw new Exception('テスト');
```
　関連ある講師が作成し、attendancesテーブルにないコース２をURLに入れてテスト
　URL：【DELETE】api/v1/manager/course/2
　結果：500 Internal Server Error 、"message": "テスト”。意図的に発生させた例外が正しくスローされてキャッチされた。OK！

＜404エラー(ModelNotFoundException)部分をthrow $eに変更。意図的に例外を発生させてcatchブロックに飛ばすテスト＞

- **updateメソッド**　tryの下に一時的にエラーを追加。（テスト後削除）
```
throw new ModelNotFoundException('てすと');
```
　管理下の講師が作成したコース２（生徒受講ナシ）をURLに入れてテスト。
　URL：【POST】api/v1/manager/course/2
　結果：404 Not Found 、"message": "てすと”。意図的に発生させた例外「てすと」と出たので、例外が正しくスローされてキャッチされた。OK！（image無しでテスト）

- **deleteメソッド**　tryの下に一時的にエラーを追加。（テスト後削除）
```
throw new ModelNotFoundException('てすと');
```
　管理下の講師が作成したコース２（生徒受講ナシ）をURLに入れてテスト。
　URL：【DELETE】api/v1/manager/course/2
　結果：404 Not Found 、"message": "てすと”。意図的に発生させた例外「てすと」と出たので、例外が正しくスローされてキャッチされた。OK！（image無しでテスト）


**<ins>講師側　CourseController</ins>　講師（ id:2 ）でログイン**

＜403をthrow new AuthorizationException（）に変更し、アクセス権限のテストを実施。それぞれ指定されているエラーメッセージが出ればOK。＞

- **updateメソッド**　別の講師が作成したコース１をURLに入れてテスト
　URL：【POST】api/v1/instructor/course/1　
　body：
```
　{
   　 "title": "あああああ",
    　"type": "private",
　}
```
　結果：　Invalid instructor_id. 　が出たのでOK！（bodyにimage無しでテストしました。）

- **deleteメソッド：その１**　別の講師が作成した、コース１をURLに入れてテスト
　URL：【DELETE】api/v1/instructor/course/1
　結果： Invalid instructor_id. 　が出たのでOK！

- **deleteメソッド：その２**　自身（講師２）が作成したコースで、attendancesテーブルに存在する（受講されている）コース６をURLに入れてテスト。
（この条件になるようにAdminerでattendancesテーブルにカラムを追加しました）
　URL：【DELETE】api/v1/instructor/course/6
　結果："This course has already been taken by students.” が出たのでOK！

＜500エラーをthrow $eに変更。意図的に例外を発生させてcatchブロックに飛ばすテスト＞

- **updateメソッド**　tryの下に一時的にエラーを追加。（テスト後削除）
```
throw new Exception('テスト');
```
　ログインしている講師が作成したコース２（生徒受講ナシ）をURLに入れてテスト。
　URL：【POST】api/v1/instructor/course/2
　結果：500 Internal Server Error 、"message": "テスト”。意図的に発生させた例外「テスト」と出たので、例外が正しくスローされてキャッチされた。OK！（image無しでテスト）

- **deleteメソッド**　tryの下に一時的にエラーを追加。（テスト後削除）
```
throw new Exception('テスト');
```
　ログインしている講師が作成したコース２（生徒受講ナシ）をURLに入れてテスト。
　URL：【DELETE】api/v1/instructor/course/2
　結果：500 Internal Server Error 、"message": "テスト”。意図的に発生させた例外「テスト」と出たので、例外が正しくスローされてキャッチされた。OK！


## ご確認いただきたいこと

~~全てのupdateメソッドに関して、Swaggerではbodyにimageも入れるようにとなっていましたが、fileを選択して画像を適当に選んで持ってくると受け付けてもらえず、一旦image無しで全てのテストを行いました。
image画像のアップロード方法をどうすれば良いか、教えていただきたいです。

全てのupdateメソッドで意図した結果が返ってきていましたが、もしbodyにimageを必ず入れた状態でのテストが必要であれば再度テストしたいと思います！~~
