### PR TITLE
JKA-1048 講師側 BulkDeleteRequest.php のファイル名とクラス名を変更してそれに関わるルーティングも変更(しみず)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Exceptions\ValidationErrorException;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\BulkDeleteRequest;
+use App\Http\Requests\Instructor\ChapterBulkDeleteRequest;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
 use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
@@ -216,7 +216,7 @@ class ChapterController extends Controller
     /**
      * 選択済チャプターの削除API
      */
-    public function bulkDelete(BulkDeleteRequest $request): JsonResponse
+    public function bulkDelete(ChapterBulkDeleteRequest $request): JsonResponse
     {
         try {
             $courseId = $request->course_id;

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -17,6 +17,7 @@ use App\Model\StudentAuthorization;
 use App\Services\Student\QueryService;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -191,7 +192,7 @@ class StudentController extends Controller
         }
     }
 
-    public function verifyCode(UserAuthenticationRequest $request, $token)
+    public function verifyCode(UserAuthenticationRequest $request): JsonResponse
     {
 
         $code = $request->code;
@@ -199,7 +200,7 @@ class StudentController extends Controller
         $currentTime = date('Y-m-d H:i:s');
 
         try {
-            $studentAuth = StudentAuthorization::where('token', $token)->firstOrFail();
+            $studentAuth = StudentAuthorization::where('token', $request->token)->firstOrFail();
             $student = student::findOrFail($studentAuth->student_id);
 
             // 有効期限の判定

--- a/app/Http/Requests/Instructor/ChapterBulkDeleteRequest.php
+++ b/app/Http/Requests/Instructor/ChapterBulkDeleteRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class BulkDeleteRequest extends FormRequest
+class ChapterBulkDeleteRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
## issue
-  #JKA-1048 講師側 BulkDeleteRequest.php のファイル名とクラス名を変更してそれに関わるルーティングも変更(しみず)

## テスト
### Postmanにて確認
複数のチャプターを削除でできるか
URL：http://localhost:8080/api/v1/instructor/course/1/chapter
body：{
    "chapters": [1, 2, 3]
}
"result": true
<img width="923" alt="スクリーンショット 2024-12-03 18 22 59" src="https://github.com/user-attachments/assets/77388092-3785-47bc-9b77-66b6b1731393">

出席しているものはエラーになるか確認
URL：http://localhost:8080/api/v1/instructor/course/1/chapter
body：body：{
    "chapters": [1, 2, 3]
}
 "result": false,
    "message": "Some chapters contain lessons with attendance records."
<img width="922" alt="スクリーンショット 2024-12-03 18 24 02" src="https://github.com/user-attachments/assets/398494d3-3985-4784-af14-aeba110d9cc8">

## 質問
- ルーティングはマネージャーのところと一致していましたので変更していませんが、あっていますでしょうか。

