### PR TITLE
JKA-1072 AttendanceControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（しみず）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -37,10 +37,9 @@ class AttendanceController extends Controller
             ->first();
 
         if ($attendance) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Attendance record already exists.',
-            ], 409);
+            throw new AuthorizationException(
+                'Attendance record already exists.'
+            );
         }
 
         DB::beginTransaction();
@@ -68,10 +67,7 @@ class AttendanceController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -106,10 +102,9 @@ class AttendanceController extends Controller
             $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);
 
             if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Unauthorized: The authenticated instructor does not have permission to delete this attendance record',
-                ], 403);
+                throw new AuthorizationException(
+                    'Unauthorized: The authenticated instructor does not have permission to delete this attendance record.'
+                );
             }
 
             $attendance->delete();
@@ -122,10 +117,7 @@ class AttendanceController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -50,18 +50,14 @@ class AttendanceController extends Controller
 
         if (! in_array($course->id, $courseIds, true)) {
             // 自分もしくは配下の講師の講座でない場合はエラーを返す
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException('Forbidden.');
         }
 
         if (Attendance::where('course_id', $request->course_id)->where('student_id', $request->student_id)->exists()) {
             // 受講状況が存在すれば、エラーを返す
-            return response()->json([
-                'result' => false,
-                'message' => 'Attendance record already exists.',
-            ], 409);
+            throw new AuthorizationException(
+                'Attendance record already exists.'
+            );
         }
 
         DB::beginTransaction();
@@ -96,10 +92,7 @@ class AttendanceController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -159,10 +152,7 @@ class AttendanceController extends Controller
 
             if (! in_array((int) $attendanceId, $managedAttendances, true)) {
                 // ログインしている講師、またはそのマネージャーが管理する受講データでない場合はエラーを返す
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Forbidden.',
-                ], 403);
+                throw new AuthorizationException('Forbidden.');
             }
 
             // 受講状況を削除
@@ -176,10 +166,7 @@ class AttendanceController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e->getMessage());
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -247,10 +234,9 @@ class AttendanceController extends Controller
         $course = Course::findOrFail($request->course_id);
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             // 自分と配下の講師の講座でない場合はエラーを返す
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to access this course.',
-            ], 403);
+            throw new AuthorizationException(
+                'Forbidden, not allowed to access this course.'
+            );
         }
 
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
@@ -311,10 +297,9 @@ class AttendanceController extends Controller
         $course = Course::findOrFail($request->course_id);
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             // 自分と配下の講師の講座でない場合はエラーを返す
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to access this course.',
-            ], 403);
+            throw new AuthorizationException(
+                'Forbidden, not allowed to access this course.'
+            );
         }
 
         // 今日完了したレッスンの個数を取得


### PR DESCRIPTION
## issue
#JKA-1072 講師とマネジャーのAttendanceControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用
## テスト
### Postmanにて確認
#### 受講状況確認
- 受講されているもの
URL：http://localhost:8080/api/v1/instructor/attendance
body：{
  "student_id": 1,
  "course_id": 1
}
"message": "Attendance record already exists."

 - 受講されていないものをテスト入力して確認
body：{
  "student_id": 3,
  "course_id": 1
}
"message"： "テスト"、
"exception":"Exception"

#### 受講状況削除
- 削除権限のない講師でログイン
URL：http://localhost:8080/api/v1/instructor/attendance/1
 "message": "Unauthorized: The authenticated instructor does not have permission to delete this attendance record."

 - 権限のある講師でテスト入力して確認
"message"： "テスト"、
"exception":"Exception"

#### 受講状況確認
- 権限のないマネジャーで確認
URL：http://localhost:8080/api/v1/manager/attendance
body：{
  "student_id": 1,
  "course_id": 1
}
"message": "Forbidden.",

 - 受講されているものを権限のあるマネジャーで確認
body：{
  "student_id": 1,
  "course_id": 1
}
"message": "Attendance record already exists."

- 受講されていないものを権限のあるマネジャーで確認
body：{
  "student_id": 1,
  "course_id": 3
}
"message"： "テスト"、
"exception":"Exception"

#### 受講状況削除
- 削除権限のないマネジャーでログイン
URL：http://localhost:8080/api/v1/manager/attendance/1
"message": "Forbidden.",

 - 権限のあるマネジャーでテスト入力して確認
"message"： "テスト"、
"exception":"Exception"

#### 今月のレッスン・チャプター完了数の取得
- 権限のないマネジャーでログイン
URL：http://localhost:8080/api/v1/manager/course/1/attendance/status/this-month
"message": 'Forbidden, not allowed to access this course.'

- 権限のないマネジャーでログイン
URL：http://localhost:8080/api/v1/manager/course/1/attendance/status/today
"message": 'Forbidden, not allowed to access this course.'
