### PR TITLE
JKA-991　全チャプター削除処理2(しみず)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -339,7 +339,8 @@ class ChapterController extends Controller
     /**
      * チャプター全削除API
      */
-    public function deleteAll($course_id){
+    public function deleteAll($course_id)
+    {
 
         $courseId = $course_id;
         //コースに紐づくチャプター情報とレッスン情報を取得
@@ -352,7 +353,7 @@ class ChapterController extends Controller
         $chapterIds = $course->chapters->pluck('chapter_id')->toArray();
 
         // チャプターを削除
-        Lesson::whereIn('chapter_id',$chapterIds)->delete();
+        Lesson::whereIn('chapter_id', $chapterIds)->delete();
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -336,6 +336,13 @@ class ChapterController extends Controller
     }
 
     /**
+     * チャプター全削除API
+     */
+    public function deleteAll(){
+        return response()->json([]);
+    }
+
+    /**
      * チャプター並び替えAPI
      */
     public function sort(ChapterSortRequest $request): JsonResponse

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -338,8 +338,16 @@ class ChapterController extends Controller
     /**
      * チャプター全削除API
      */
-    public function deleteAll(){
-        return response()->json([]);
+    public function deleteAll($course_id){
+        
+        $courseId = $course_id;
+
+        // チャプターを削除
+        Chapter::where('course_id', $courseId)->delete();
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -17,6 +17,7 @@ use App\Http\Resources\Instructor\ChapterShowResource;
 use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Chapter\QueryService;
 use Exception;
@@ -339,11 +340,19 @@ class ChapterController extends Controller
      * チャプター全削除API
      */
     public function deleteAll($course_id){
-        
+
         $courseId = $course_id;
+        //コースに紐づくチャプター情報とレッスン情報を取得
+        $course = Course::with('chapters.lessons')->
+        get();
+        //find($courseId);
+        //return $course;
+        //$lessonIds = $course->pluck('lessons.*.id')->flatten();
+
+        $chapterIds = $course->chapters->pluck('chapter_id')->toArray();
 
         // チャプターを削除
-        Chapter::where('course_id', $courseId)->delete();
+        Lesson::whereIn('chapter_id',$chapterIds)->delete();
 
         return response()->json([
             'result' => true,

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::put('status', 'Api\Instructor\ChapterController@putStatus');
                         Route::patch('status', 'Api\Instructor\ChapterController@patchStatus');
                         Route::delete('/', 'Api\Instructor\ChapterController@bulkDelete');
+                        Route::delete('all', 'Api\Instructor\ChapterController@deleteAll');
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', 'Api\Instructor\ChapterController@show');
                             Route::patch('/', 'Api\Instructor\ChapterController@update');


### PR DESCRIPTION
## jka-991 全チャプター削除処理

###  概要
kou さんに段階を分けていただいて
- 第一目標 : 全チャプターを削除する処理
- 第二目標 : 全チャプターを削除時にレッスンが削除されていないことを確認し、レッスンも削除する処理(lessons)
- 第三目標 : レッスンの受講状態がある場合は削除できない仕様のため認可エラー(403)を返す(lesson_attendances)
- 第四目標 : リクエストの講座IDの作成者が認証ユーザーと一致しない場合は認可エラー(403)を返す
- 第五目標 : トランザクション処理を追加し、エラー時はロールバックする処理を追加し、エラーメッセージを返す処理を追加する
こちらの第二目標をやっています。
しかし、レッスンが消えず困っています。
今の状態では　"message": "Property [chapters] does not exist on this collection instance.",　とでています。
よろしくお願いいたします。

#### 補足
プルリクをトピックにしたかったのですが、うまくいきませんでしたのでnext-developにしています。