### PR TITLE
JKA-991　全チャプター削除処理のリクエストフォーム作成(しみず)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Exceptions\ValidationErrorException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterBulkDeleteRequest;
+use App\Http\Requests\Instructor\ChapterDeleteAllRequest;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
 use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
@@ -338,11 +339,13 @@ class ChapterController extends Controller
     }
 
     /**
-     * チャプター全削除API
+     * 全チャプター削除API
+     *
+     * @return JsonResponse
      */
-    public function deleteAll($course_id)
+    public function deleteAll(ChapterDeleteAllRequest $request)
     {
-        $courseId = $course_id;
+        $courseId = $request->input('course_id');
 
         DB::beginTransaction();
         try {
@@ -373,11 +376,6 @@ class ChapterController extends Controller
                 'result' => true,
             ]);
 
-        } catch (ValidationErrorException $e) {
-            // バリデーションエラーが発生した場合の処理
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -340,10 +340,8 @@ class ChapterController extends Controller
 
     /**
      * 全チャプター削除API
-     *
-     * @return JsonResponse
      */
-    public function deleteAll(ChapterDeleteAllRequest $request)
+    public function deleteAll(ChapterDeleteAllRequest $request): JsonResponse
     {
         $courseId = $request->input('course_id');
 

--- a/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\instructor;
+namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChapterDeleteAllRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     * 
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
@@ -8,7 +8,7 @@ class ChapterDeleteAllRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     * 
+     *
      * @return bool
      */
     public function authorize()


### PR DESCRIPTION
## issue
JKA-991　全チャプター削除処理 ロジック作成
## テスト
### Postmanにて確認
インストラクター２でログイン
- ログイン中の講師の受け持ちチャプターでなければエラー
URL：http://localhost:8080/api/v1/instructor/course/1/chapter/all
"message": "Invalid instructor_id."

- 受講中のレッスンであればエラー
"message"： 'This lesson has attendance.'

- コース２で消えるか確認
URL：http://localhost:8080/api/v1/instructor/course/2/chapter/all
"result": true
Adminerにて該当チャプターと紐づいているレッスンが削除されたのを確認

- テストと仮に入れてのExceptionの確認
"message"： "テスト"、
"exception":"Exception"

ValidationErrorExceptionは削除しています。

- 質問事項
public function deleteAll(ChapterDeleteAllRequest $request): JsonRespons
と書いているところと
/**
     * 全チャプター削除API
     *
     * @return JsonResponse
     */
と書いているところがありました。

こちらの違いがわからず、ひとまず＊の方を採用しました。
調べてようとすると何かのページを開こうとしてしまうようで調べることが難しいです。
違いを教えていただけませんでしょうか。
