### PR TITLE
Topic/shimizu/jka 991/chapter all delete

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Exceptions\ValidationErrorException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterBulkDeleteRequest;
+use App\Http\Requests\Instructor\ChapterDeleteAllRequest;
 use App\Http\Requests\Instructor\ChapterDeleteRequest;
 use App\Http\Requests\Instructor\ChapterPatchRequest;
 use App\Http\Requests\Instructor\ChapterPatchStatusRequest;
@@ -338,11 +339,13 @@ class ChapterController extends Controller
     }
 
     /**
-     * チャプター全削除API
+     * 全チャプター削除API
+     *
+     * @return JsonResponse
      */
-    public function deleteAll($course_id)
+    public function deleteAll(ChapterDeleteAllRequest $request)
     {
-        $courseId = $course_id;
+        $courseId = $request->input('course_id');
 
         DB::beginTransaction();
         try {
@@ -373,11 +376,6 @@ class ChapterController extends Controller
                 'result' => true,
             ]);
 
-        } catch (ValidationErrorException $e) {
-            // バリデーションエラーが発生した場合の処理
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -342,15 +342,13 @@ class ChapterController extends Controller
      */
     public function deleteAll($course_id)
     {
-
         $courseId = $course_id;
 
         DB::beginTransaction();
         try {
 
             //コースに紐づくチャプター情報とレッスン情報を取得
-            $course = Course::with('chapters.lessons')->
-            find($courseId);
+            $course = Course::with('chapters.lessons')->find($courseId);
             $chapterIds = $course->chapters->pluck('id')->toArray();
 
             // ログイン中の講師の講座のチャプターでなければエラー応答

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -340,10 +340,8 @@ class ChapterController extends Controller
 
     /**
      * 全チャプター削除API
-     *
-     * @return JsonResponse
      */
-    public function deleteAll(ChapterDeleteAllRequest $request)
+    public function deleteAll(ChapterDeleteAllRequest $request): JsonResponse
     {
         $courseId = $request->input('course_id');
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -340,10 +340,11 @@ class ChapterController extends Controller
     /**
      * チャプター全削除API
      */
-    public function deleteAll($course_id){
+    public function deleteAll($course_id)
+    {
 
         $courseId = $course_id;
-        
+
         DB::beginTransaction();
         try {
 
@@ -366,7 +367,7 @@ class ChapterController extends Controller
 
             // チャプターを削除
             Chapter::where('course_id', $courseId)->delete();
-            Lesson::whereIn('chapter_id',$chapterIds)->delete();
+            Lesson::whereIn('chapter_id', $chapterIds)->delete();
 
             DB::commit();
 
@@ -379,7 +380,6 @@ class ChapterController extends Controller
             DB::rollBack();
             Log::error($e);
             throw $e;
-            
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -17,9 +17,11 @@ use App\Http\Resources\Instructor\ChapterShowResource;
 use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Chapter\QueryService;
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
@@ -332,6 +334,56 @@ class ChapterController extends Controller
             return response()->json([
                 'result' => false,
             ], 500);
+        }
+    }
+
+    /**
+     * チャプター全削除API
+     */
+    public function deleteAll($course_id){
+
+        $courseId = $course_id;
+        
+        DB::beginTransaction();
+        try {
+
+            //コースに紐づくチャプター情報とレッスン情報を取得
+            $course = Course::with('chapters.lessons')->
+            find($courseId);
+            $chapterIds = $course->chapters->pluck('id')->toArray();
+
+            // ログイン中の講師の講座のチャプターでなければエラー応答
+            if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
+                throw new AuthorizationException('Invalid instructor_id.');
+            }
+
+            // チャプターに紐づく全レッスンIDを取得
+            $lessonIds = $course->chapters->pluck('lessons')->flatten()->pluck('id')->toArray();
+            if (LessonAttendance::whereIn('lesson_id', $lessonIds)->exists()) {
+                // 受講中のレッスンがあれば、エラー応答
+                throw new AuthorizationException('This lesson has attendance.');
+            }
+
+            // チャプターを削除
+            Chapter::where('course_id', $courseId)->delete();
+            Lesson::whereIn('chapter_id',$chapterIds)->delete();
+
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+            ]);
+
+        } catch (ValidationErrorException $e) {
+            // バリデーションエラーが発生した場合の処理
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+            
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
         }
     }
 

--- a/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\instructor;
+namespace App\Http\Requests\Instructor;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChapterDeleteAllRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     * 
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
+++ b/app/Http/Requests/Instructor/ChapterDeleteAllRequest.php
@@ -8,7 +8,7 @@ class ChapterDeleteAllRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     * 
+     *
      * @return bool
      */
     public function authorize()

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::put('status', 'Api\Instructor\ChapterController@putStatus');
                         Route::patch('status', 'Api\Instructor\ChapterController@patchStatus');
                         Route::delete('/', 'Api\Instructor\ChapterController@bulkDelete');
+                        Route::delete('all', 'Api\Instructor\ChapterController@deleteAll');
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', 'Api\Instructor\ChapterController@show');
                             Route::patch('/', 'Api\Instructor\ChapterController@update');


### PR DESCRIPTION
## issue
JKA-991　親-講師側 チャプター作成画面 全チャプターを削除するAPI作成
topicブランチからnext-developへのプルリク

## テスト
### Postmanにて確認
インストラクター２でログイン

- ログイン中の講師の受け持ちチャプターでなければエラー
URL：http://localhost:8080/api/v1/instructor/course/1/chapter/all
"message": "Invalid instructor_id."

- 受講中のレッスンであればエラー
"message"： 'This lesson has attendance.'

- コース２で消えるか確認
URL：http://localhost:8080/api/v1/instructor/course/2/chapter/all
"result": true
Adminerにて該当チャプターと紐づいているレッスンが削除されたのを確認

- テストと仮に入れてのExceptionの確認
"message"： "テスト"、
"exception":"Exception"