### PR TITLE
JKA-1068 Manager/LessonControllerとInstructor/LessonControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用の途中まで(マネージャー側のdeleteメソッドまで)適用実施(ゆうじ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -135,7 +135,8 @@ class LessonController extends Controller
     public function delete(LessonDeleteRequest $request)
     {
         DB::beginTransaction();
-        try {throw new Exception('テスト');
+        try {
+            throw new Exception('テスト');
             // 自身と配下のinstructor情報を取得
             $managerId = Auth::guard('instructor')->user()->id;
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -136,7 +136,6 @@ class LessonController extends Controller
     {
         DB::beginTransaction();
         try {
-            throw new Exception('テスト');
             // 自身と配下のinstructor情報を取得
             $managerId = Auth::guard('instructor')->user()->id;
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -48,10 +48,7 @@ class LessonController extends Controller
 
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座でなければエラー応答
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to create new lesson.',
-            ], 403);
+            throw new AuthorizationException('Forbidden, not allowed to create new lesson.');
         }
 
         $maxOrder = Lesson::where('chapter_id', $request->chapter_id)->max('order');
@@ -83,10 +80,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -108,26 +102,17 @@ class LessonController extends Controller
 
         if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
             // 配下の講師でない場合は403エラー
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to this lesson.',
-            ], 403);
+            throw new AuthorizationException('Forbidden, not allowed to this lesson.');
         }
 
         if ((int) $request->course_id !== $lesson->chapter->course_id) {
             // 講座IDが不正な場合は403エラー
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id) {
             // チャプターIDが不正な場合は403エラー
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid chapter_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid chapter_id.');
         }
 
         $lesson->update([
@@ -150,7 +135,7 @@ class LessonController extends Controller
     public function delete(LessonDeleteRequest $request)
     {
         DB::beginTransaction();
-        try {
+        try {throw new Exception('テスト');
             // 自身と配下のinstructor情報を取得
             $managerId = Auth::guard('instructor')->user()->id;
 
@@ -165,34 +150,22 @@ class LessonController extends Controller
 
             // 自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない
             if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid instructor_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
             if ((int) $request->chapter_id !== $lesson->chapter->id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid chapter_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid chapter_id.');
             }
 
             // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
             if ((int) $request->course_id !== $lesson->chapter->course_id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid course_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid course_id.');
             }
 
             // 受講情報が登録されている場合は許可しない
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'This lesson has attendance.',
-                ], 403);
+                throw new AuthorizationException('This lesson has attendance.');
             }
 
             // 対象レッスンの削除処理
@@ -213,10 +186,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 


### PR DESCRIPTION
## issue
- JKA-1068

## 概要
- JKA-1068 Manager/LessonControllerとInstructor/LessonControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用の途中まで(マネージャー側のdeleteメソッドまで)適用実施

## 動作確認手順
- Postmanで、以下の各テストを実施

- マネージャーのレッスン新規作成API
  - 講師側でログイン（マネージャー権限）
    - email：`test_instructor@example.com`
    - password：`password`

  - POSTリクエストで「レッスン情報を登録する。」が問題なく動作することを確認。
    - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson
    - ボディのRaw一例
  ```json
  {
    "title": "swaggerの書き方"
  }
  ```
  
  - 【自分、または配下の講師の講座でなければエラー応答】をテスト。別の講師でログインしPOSTリクエストで「レッスン情報を登録する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor4@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson
    - "message": "Forbidden, not allowed to create new lesson.",
  
  - throw $e のエラー発生時の動作をテスト。try {} の{}の中に【throw new Exception('テスト');】を一時的に書いて、テストする（テスト後は削除する）。
    - "message": "テスト",

- マネージャーのレッスン更新API
  - 講師側でログイン（マネージャー権限）
    - email：`test_instructor@example.com`
    - password：`password`

  - PUTリクエストで「レッスン情報を更新する。」が問題なく動作することを確認。
    - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson/7
    - ボディのRaw一例
  ```json
  {
    "title": "レッスンタイトル",
    "url": "https://www.youtube.com/watch?v=xxxxxxxxxxx",
    "remarks": "備考",
    "status": "public"
  }
  ```
  
  - 【配下の講師でない場合は403エラー】をテスト。別の講師でログインしPUTリクエストで「レッスン情報を更新する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor4@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson/7
    - "message": "Forbidden, not allowed to this lesson.",
  - 【講座IDが不正な場合は403エラー】をテスト。正規の講師でログインしURLを変更してPUTリクエストで「レッスン情報を更新する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/1/chapter/4/lesson/7
    - "message": "Invalid course_id.",
  - 【チャプターIDが不正な場合は403エラー】をテスト。正規の講師でログインしている状態でURLを変更しPUTリクエストで「レッスン情報を更新する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/2/chapter/3/lesson/7
    - "message": "Invalid chapter_id.",
   
- マネージャーのレッスン削除API
  - 講師側でログイン（マネージャー権限）
    - email：`test_instructor@example.com`
    - password：`password`

  - DELETEリクエストで「レッスン情報を削除する。」が問題なく動作することを確認。
    - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson/7

  
  - 【自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない】をテスト。別の講師でログインしDELETEリクエストで「レッスン情報を削除する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor4@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson/7
    - "message": "Invalid instructor_id.",
  - 【指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない】をテスト。正規の講師でログインしURLを変更してDELETEリクエストで「レッスン情報を削除する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/1/chapter/3/lesson/7
    - "message": "Invalid chapter_id.",
  - 【指定した講座IDがレッスンの講座IDと一致しない場合は許可しない】をテスト。正規の講師でログインしている状態でURLを変更しDELETEリクエストで「レッスン情報を削除する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/1/chapter/4/lesson/7
    - "message": "Invalid course_id.",
  - 【受講情報が登録されている場合は許可しない】をテスト。正規の講師でログインしている状態でURLを変更しDELETEリクエストで「レッスン情報を削除する。」を実行し、エラーメッセージが表示されることを確認。
    - email：`test_instructor@example.com`
    - password：`password`
    - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1
    - "message": "This lesson has attendance.",
  
  - throw $e のエラー発生時の動作をテスト。try {} の{}の中に【throw new Exception('テスト');】を一時的に書いて、テストする（テスト後は削除する）。
    - "message": "テスト",

### 考慮して欲しいこと
期限の都合上、途中までですがdeleteメソッドまで適用実施しましたので、ご確認よろしくお願いいたします。

## 確認して欲しいこと
slackにも記載したのですが139行目で【throw new Exception('テスト');】の記述を消し忘れてプッシュしてしまったので、修正して再プッシュしようとしたのですがエラーメッセージが返ってきました。再度プルも試してみましたが更新は無かった為エラーの解決には至りませんでした。現状は【throw new Exception('テスト');】の記述が残ったままのプルリクになってしまっております。申し訳ありません。