### PR TITLE
StudentPostRequest.phpの文字数制限の修正（川原）

### DIFF
--- a/app/Http/Requests/Student/StudentPostRequest.php
+++ b/app/Http/Requests/Student/StudentPostRequest.php
@@ -26,8 +26,8 @@ class StudentPostRequest extends FormRequest
     {
         return [
             'nick_name' => ['required', 'string', 'max:50'],
-            'last_name' => ['required', 'string', 'max:30'],
-            'first_name' => ['required', 'string', 'max:30'],
+            'last_name' => ['required', 'string', 'max:50'],
+            'first_name' => ['required', 'string', 'max:50'],
             'email' => ['required', 'email', 'max:255', 'unique:students'],
             'occupation' => ['required', 'string', 'max:50'],
             'purpose' => ['required', 'string', 'max:255'],


### PR DESCRIPTION
## issue
JKA-1087 StudentPostRequest.phpの文字数制限の修正

## 概要
app/Http/Requests/Student/StudentPostRequest.php

のrules()

'last_name' => ['required', 'string', 'max:30'],
'first_name' => ['required', 'string', 'max:30'],

は、いずれも、max:50であるべきだが、間違ってるので修正する。

## 動作確認
[POST] http://localhost:8080/api/v1/student
上記のリクエストをポストマンを使って確認する。

以下をボディとした時に、'last_name' 、  "first_name"を50文字以上でエラーが返ってくればOK。
反対に、50文字以内ではエラーメッセージが返ってこないことも確認する。
※50文字ぴったりだとエラーにならないが、51文字を超えるとエラーになる。

{
  "nick_name": "ニックネーム",
  **"last_name": "名字",
  "first_name": "名前",**
  "occupation": "エンジニア",
  "purpose": "スキルアップのため",
  "email": "test@example.com",
  "birth_date": "2022-10-17",
  "gender": "man",
  "address": "東京都"
}

## ご確認いただきたいこと
上記の動作確認ができればマージお願いいたします。