### PR TITLE
JKA-1090(親1040)空の配列を返すルーターとコントローラの作成（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -219,6 +219,13 @@ class AttendanceController extends Controller
     }
 
     /**
+     * 完了済みレッスン数と完了済みチャプター数取得API
+     */
+    public function showStatus() {
+        return response()->json([]);
+    }
+
+    /**
      * 今月のレッスン・チャプター完了数の取得API
      */
     public function showStatusThisMonth(AttendanceShowThisMonthRequest $request): JsonResponse

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -221,7 +221,8 @@ class AttendanceController extends Controller
     /**
      * 完了済みレッスン数と完了済みチャプター数取得API
      */
-    public function showStatus() {
+    public function showStatus()
+    {
         return response()->json([]);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -216,8 +216,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                             Route::get('{period}', 'Api\Manager\AttendanceController@loginRate');
                             Route::prefix('status')->group(function () {
                                 Route::get('/', 'Api\Manager\AttendanceController@show');
-                                Route::get('this-month', 'Api\Manager\AttendanceController@showStatusThisMonth');
-                                Route::get('today', 'Api\Manager\AttendanceController@showStatusToday');
+                                Route::get('{period}', 'Api\Manager\AttendanceController@showStatus');
                             });
                         });
                     });


### PR DESCRIPTION
## issue

- JKA-1090 空の配列を返すルーターとコントローラの作成

## 概要

- 空の配列を返すルーターとコントローラの作成
（親：JKA-1040　マネージャー側 本日or当月のレッスン・チャプター完了数の取得APIを統合して１つにする）

## 動作確認

- Postmandに以下のURLを入れ、空の配列が返ることを確認
URL：【GET】http://localhost:8080/api/v1/manager/course/2/attendance/status/today
![スクリーンショット 2025-01-13 221128](https://github.com/user-attachments/assets/7eaddb8c-f375-43ab-b588-0f4c3f6937ad)

## 備考
以降の作業で参考にするため、コントローラー内に「今月のレッスン・チャプター完了数の取得API」と「本日のレッスン・チャプター完了数の取得API」の記述は残したままにしています。