### PR TITLE
Instructor/ChapterControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -265,7 +265,7 @@ class ChapterController extends Controller
             $chapter = Chapter::with('course', 'lessons')->findOrFail($request->chapter_id);
 
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-                 // ログインしている講師が作成していないチャプターの更新を許可しない
+                // ログインしている講師が作成していないチャプターの更新を許可しない
                 throw new AuthorizationException('Invalid instructor_id.');
             }
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -41,16 +41,14 @@ class ChapterController extends Controller
         // チャプターを取得
         $chapter = $queryService->getChapter($request->chapter_id);
 
-        if ((int) $request->course_id !== $chapter->course->id) {
-            return response()->json([
-                'message' => 'Invalid course_id.',
-            ], 403);
+        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
+            // ログインしている講師が作成していないチャプターの更新を許可しない
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
-        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-            return response()->json([
-                'message' => 'Invalid instructor_id.',
-            ], 403);
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         return new ChapterShowResource($chapter);
@@ -72,10 +70,7 @@ class ChapterController extends Controller
 
             if ($course->instructor_id !== $user->id) {
                 // 講座の作成者が現在の講師と一致しない場合はエラーを返す
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid instructor_id for this course.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id for this course.');
             }
 
             $order = $course->chapters->count();
@@ -93,9 +88,7 @@ class ChapterController extends Controller
         } catch (Exception $e) {
             Log::error($e);
 
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -111,18 +104,13 @@ class ChapterController extends Controller
         $chapter = Chapter::findOrFail($request->chapter_id);
 
         if ($chapter->course->instructor_id !== $user->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id',
-            ], 403);
+            // ログインしている講師が作成していないチャプターの更新を許可しない
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         $chapter->update([
@@ -143,18 +131,13 @@ class ChapterController extends Controller
         $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
 
         if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'invalid instructor_id.',
-            ], 403);
+            // ログインしている講師が作成していないチャプターの更新を許可しない
+            throw new AuthorizationException('invalid instructor_id.');
         }
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         $chapter->update([
@@ -209,10 +192,7 @@ class ChapterController extends Controller
         } catch (Exception $e) {
             Log::error($e);
 
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ]);
+            throw $e;
         }
     }
 
@@ -269,10 +249,7 @@ class ChapterController extends Controller
         } catch (Exception $e) {
             Log::error($e);
 
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ]);
+            throw $e;
         }
     }
 
@@ -288,27 +265,19 @@ class ChapterController extends Controller
             $chapter = Chapter::with('course', 'lessons')->findOrFail($request->chapter_id);
 
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid instructor_id.',
-                ], 403);
+                 // ログインしている講師が作成していないチャプターの更新を許可しない
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             if ((int) $request->course_id !== $chapter->course->id) {
                 // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid course_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid course_id.');
             }
 
             //受講中のチャプターは削除できないようにする
             $lessonIds = $chapter->lessons->pluck('id')->toArray();
             if (LessonAttendance::whereIn('lesson_id', $lessonIds)->exists()) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'This chapter contains attendance.',
-                ], 403);
+                throw new AuthorizationException('This chapter contains attendance.');
             }
 
             // 削除対象チャプターのorderカラムを0に設定する
@@ -332,9 +301,7 @@ class ChapterController extends Controller
             DB::rollBack();
             Log::error($e);
 
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -373,7 +340,6 @@ class ChapterController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
@@ -394,10 +360,8 @@ class ChapterController extends Controller
             $course = Course::findOrFail($courseId);
 
             if ($user->id !== $course->instructor_id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid instructor_id.',
-                ], 403);
+                // 講座の作成者が現在の講師と一致しない場合はエラーを返す
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             foreach ($chapters as $chapter) {
@@ -417,17 +381,12 @@ class ChapterController extends Controller
         } catch (ModelNotFoundException $e) {
             DB::rollBack();
 
-            return response()->json([
-                'result' => false,
-                'message' => 'Not found.',
-            ], 404);
+            throw new AuthorizationException('Not found.');
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
 
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -440,10 +399,8 @@ class ChapterController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized.',
-            ], 403);
+            // ログインしていない講師の更新を許可しない
+            throw new AuthorizationException('Not authorized.');
         }
 
         Chapter::chapterUpdateAll($request->course_id, $request->status);


### PR DESCRIPTION
## issue
- Closes
#JKA-1066 Instructor/ChapterControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 概要
- 各メソッドのif文に「throw new AuthorizationException('エラーメッセージ');」の修正
- Exceptionのcatchの中の「return response()～」を「throw $e;」に修正

## 動作確認手順
全てinstructors_idは1でログインしています。

show（http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id）
- course_idが1、chapter_idが16の場合（ログインしている講師が作成したチャプター）
正常に動作できる。
- course_idが1、chapter_idが4の場合（ログインしている講師が作成していないチャプターの更新）
"message": "invalid instructor_id."
が出力される。
- course_idが2、chapter_idが1の場合（講座を作成した講師とチャプターを作成した講師が不一致の場合）
"message": "Invalid course_id."
が出力される。

store（http://localhost:8080/api/v1/instructor/course/:course_id/chapter）
- course_idが1の場合（ログインしている講師）
正常に動作できる。
- course_idが2の場合（ログインしていない講師）
"message": "Invalid instructor_id for this course."
が出力される。
- 明示的にthrow new Exceptionを記載した場合
"message": "例外処理"
"exception": "Exception"
が出力される。

update（http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id）
- course_idが1、chapter_idが22の場合（ログインしている講師が作成したチャプター）
正常に動作できる。
- course_idが1、chapter_idが4の場合（ログインしている講師が作成していないチャプターの更新）
"message": "Invalid instructor_id."
が出力される。
- course_idが2、chapter_idが1の場合（講座を作成した講師とチャプターを作成した講師が不一致の場合）
"message": "Invalid course_id."
が出力される。

updateStatus（http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id/status）
- course_idが1、chapter_idが22の場合（ログインしている講師が作成したチャプター）
正常に動作できる。
- course_idが1、chapter_idが4の場合（ログインしている講師が作成していないチャプターの更新）
"message": "invalid instructor_id."
が出力される。
- course_idが2、chapter_idが1の場合（講座を作成した講師とチャプターを作成した講師が不一致の場合）
"message": "Invalid course_id."
が出力される。

patchStatus（http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id/status）
- course_idが1の場合（ログインしている講師）
正常に動作できる。
- 明示的にthrow new Exceptionを記載した場合
"message": "例外処理"
"exception": "Exception"
が出力される。

delete（http://localhost:8080/api/v1/instructor/course/:course_id/chapter）
- course_idが1、chapter_idが22の場合（ログインしている講師が作成したチャプター）
正常に動作できる。
- course_idが1、chapter_idが4の場合（ログインしている講師が作成していないチャプターの更新）
"message": "invalid instructor_id."
が出力される。
- course_idが2、chapter_idが1の場合（講座を作成した講師とチャプターを作成した講師が不一致の場合）
"message": "Invalid course_id."
が出力される。
- course_idが1、chapter_idが1の場合（受講中のチャプターは削除できない）
"message": "This chapter contains attendance."
が出力される。
- 明示的にthrow new Exceptionを記載した場合
"message": "例外処理"
"exception": "Exception"
が出力される。

sort（http://localhost:8080/api/v1/instructor/course/:course_id/chapter/sort）
- course_idが1の場合（ログインしている講師）
正常に動作できる。
- course_idが2の場合（ログインしていない講師）
"message": "Invalid instructor_id."
が出力される。
- 明示的にthrow new ModelNotFoundExceptionを記載した場合
"message": "Not found."
が出力される。
- 明示的にthrow new Exceptionを記載した場合
"message": "例外処理"
"exception": "Exception"
が出力される。

putStatus（http://localhost:8080/api/v1/instructor/course/:course_id/chapter/status）
- course_idが1の場合（ログインしている講師）
正常に動作できる。
- course_idが2の場合（ログインしていない講師）
"message": "Not authorized."
が出力される。

## 考慮して欲しいこと
## 確認して欲しいこと
showメソッドですが、「Invalid instructor_id.」と「Invalid course_id.」のif文を入れ替えました。
そのままの場合、「Invalid instructor_id.」を発生させるパラメータを入れても「Invalid course_id.」のif文が通ってしまうためです。