### PR TITLE
JKA-1068：Manager/LessonControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -7,11 +7,11 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\LessonBulkDeleteRequest;
 use App\Http\Requests\Manager\LessonDeleteRequest;
 use App\Http\Requests\Manager\LessonPatchStatusRequest;
+use App\Http\Requests\Manager\LessonPutRequest;
 use App\Http\Requests\Manager\LessonPutStatusRequest;
 use App\Http\Requests\Manager\LessonsAllDeleteRequest;
 use App\Http\Requests\Manager\LessonSortRequest;
 use App\Http\Requests\Manager\LessonStoreRequest;
-use App\Http\Requests\Manager\LessonUpdateRequest;
 use App\Http\Requests\Manager\LessonUpdateTitleRequest;
 use App\Model\Attendance;
 use App\Model\Chapter;
@@ -48,7 +48,7 @@ class LessonController extends Controller
 
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座でなければエラー応答
-            throw new AuthorizationException('Forbidden, not allowed to create new lesson.');
+            throw new AuthorizationException('Forbidden, not allowed to this lesson.');
         }
 
         $maxOrder = Lesson::where('chapter_id', $request->chapter_id)->max('order');
@@ -91,16 +91,19 @@ class LessonController extends Controller
      *
      * @return JsonResponse
      */
-    public function update(LessonUpdateRequest $request)
+    public function put(LessonPutRequest $request)
     {
         $managerId = Auth::guard('instructor')->user()->id;
+
         // 配下の講師情報を取得
-        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($managerId);
+        assert($manager instanceof Instructor);
+
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
+        assert($lesson instanceof Lesson);
 
         if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
             // 配下の講師でない場合は403エラー

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -271,26 +271,17 @@ class LessonController extends Controller
 
         if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
             // 自身もしくは配下の講師の講座でなければエラー応答
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id.',
-            ], 403);
+            throw new ValidationErrorException('Invalid instructor_id.');
         }
 
         if ((int) $request->course_id !== $lesson->chapter->course->id) {
             // 指定した講座IDがレッスンの講座IDと一致しない場合は更新を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new ValidationErrorException('Invalid course_id.');
         }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id) {
             // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は更新を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid chapter_id.',
-            ], 403);
+            throw new ValidationErrorException('Invalid chapter_id.');
         }
 
         $lesson->update([
@@ -324,24 +315,15 @@ class LessonController extends Controller
 
         // 自分、または配下の講師の講座のレッスンでなければエラー応答
         if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Unauthorized access to update lesson title.',
-            ], 403);
+            throw new ValidationErrorException('Unauthorized access to update lesson title.');
         }
 
         if ((int) $request->course_id !== $lesson->chapter->course_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new ValidationErrorException('Invalid course_id.');
         }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid chapter_id.',
-            ], 403);
+            throw new ValidationErrorException('Invalid chapter_id.');
         }
 
         $lesson->update([
@@ -430,6 +412,8 @@ class LessonController extends Controller
         try {
             DB::beginTransaction();
 
+            throw new Exception('テスト');
+
             $lesson->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
                 // 自身もしくは配下の講師の講座・チャプターに紐づくレッスンでない場合は許可しない
                 if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
@@ -471,11 +455,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to delete lesson.',
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -40,7 +40,7 @@ class LessonController extends Controller
 
         // 配下の講師情報を取得
         /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrfail($managerId);
+        $manager = Instructor::with('managings')->findOrFail($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
@@ -61,13 +61,14 @@ class LessonController extends Controller
                 'status' => Lesson::STATUS_PRIVATE,
                 'order' => (int) $maxOrder + 1,
             ]);
+            assert($lesson instanceof Lesson);
 
             $attendances = Attendance::where('course_id', $request->course_id)->get();
-            $lesson_id = $lesson->id;
-            $attendances->each(function ($attendance) use (&$lesson_id) {
+            $lessonId = $lesson->id;
+            $attendances->each(function (Attendance $attendance) use ($lessonId) {
                 LessonAttendance::create([
                     'attendance_id' => $attendance->id,
-                    'lesson_id' => $lesson_id,
+                    'lesson_id' => $lessonId,
                     'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
                 ]);
             });
@@ -76,6 +77,7 @@ class LessonController extends Controller
 
             return response()->json([
                 'result' => true,
+                'lesson_id' => $lesson->id,
             ]);
         } catch (Exception $e) {
             DB::rollBack();

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -413,7 +413,6 @@ class LessonController extends Controller
             DB::beginTransaction();
 
             throw new Exception('テスト');
-
             $lesson->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
                 // 自身もしくは配下の講師の講座・チャプターに紐づくレッスンでない場合は許可しない
                 if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -246,7 +246,10 @@ class LessonController extends Controller
                 'result' => true,
             ]);
         } catch (ValidationErrorException $e) {
-            throw $e;
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ], 422);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
@@ -412,7 +415,6 @@ class LessonController extends Controller
         try {
             DB::beginTransaction();
 
-            throw new Exception('テスト');
             $lesson->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
                 // 自身もしくは配下の講師の講座・チャプターに紐づくレッスンでない場合は許可しない
                 if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -246,17 +246,11 @@ class LessonController extends Controller
                 'result' => true,
             ]);
         } catch (ValidationErrorException $e) {
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 422);
+            throw $e;
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ]);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -155,7 +155,7 @@ class LessonController extends Controller
 
             // 自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない
             if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-                throw new AuthorizationException('Invalid instructor_id.');
+                throw new AuthorizationException('Forbidden, not allowed to delete this lesson.');
             }
 
             // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
@@ -170,7 +170,7 @@ class LessonController extends Controller
 
             // 受講情報が登録されている場合は許可しない
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
-                throw new AuthorizationException('This lesson has attendance.');
+                throw new AuthorizationException('Forbidden, not allowed to delete this lesson.');
             }
 
             // 対象レッスンの削除処理

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -48,10 +48,7 @@ class LessonController extends Controller
 
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座でなければエラー応答
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to create new lesson.',
-            ], 403);
+            throw new AuthorizationException('Forbidden, not allowed to create new lesson.');
         }
 
         $maxOrder = Lesson::where('chapter_id', $request->chapter_id)->max('order');
@@ -83,10 +80,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -108,26 +102,17 @@ class LessonController extends Controller
 
         if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
             // 配下の講師でない場合は403エラー
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden, not allowed to this lesson.',
-            ], 403);
+            throw new AuthorizationException('Forbidden, not allowed to this lesson.');
         }
 
         if ((int) $request->course_id !== $lesson->chapter->course_id) {
             // 講座IDが不正な場合は403エラー
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id) {
             // チャプターIDが不正な場合は403エラー
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid chapter_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid chapter_id.');
         }
 
         $lesson->update([
@@ -165,34 +150,22 @@ class LessonController extends Controller
 
             // 自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない
             if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid instructor_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
             if ((int) $request->chapter_id !== $lesson->chapter->id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid chapter_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid chapter_id.');
             }
 
             // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
             if ((int) $request->course_id !== $lesson->chapter->course_id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid course_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid course_id.');
             }
 
             // 受講情報が登録されている場合は許可しない
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'This lesson has attendance.',
-                ], 403);
+                throw new AuthorizationException('This lesson has attendance.');
             }
 
             // 対象レッスンの削除処理
@@ -213,10 +186,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Requests/Manager/LessonPutRequest.php
+++ b/app/Http/Requests/Manager/LessonPutRequest.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests\Manager;
 use App\Rules\LessonStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 
-class LessonUpdateRequest extends FormRequest
+class LessonPutRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/database/seeders/ChapterSeeder.php
+++ b/database/seeders/ChapterSeeder.php
@@ -56,6 +56,14 @@ class ChapterSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'course_id' => 5,
+                'order' => 1,
+                'title' => 'Pythonとは？',
+                'status' => Chapter::STATUS_PUBLIC,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }

--- a/database/seeders/LessonSeeder.php
+++ b/database/seeders/LessonSeeder.php
@@ -96,6 +96,26 @@ class LessonSeeder extends Seeder
                 'updated_at' => Carbon::now(),
                 'order' => 1,
             ],
+            [
+                'chapter_id' => 5,
+                'url' => 'KH4MmQsCDuz',
+                'title' => '環境構築',
+                'remarks' => null,
+                'status' => Lesson::STATUS_PUBLIC,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+                'order' => 2,
+            ],
+            [
+                'chapter_id' => 6,
+                'url' => 'KH4MmQsCDua',
+                'title' => '概要',
+                'remarks' => null,
+                'status' => Lesson::STATUS_PUBLIC,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+                'order' => 1,
+            ],
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -200,7 +200,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::delete('/', 'Api\Manager\LessonController@bulkDelete');
                                     Route::delete('all', 'Api\Manager\LessonController@deleteAll');
                                     Route::prefix('{lesson_id}')->group(function () {
-                                        Route::put('/', 'Api\Manager\LessonController@update');
+                                        Route::put('/', 'Api\Manager\LessonController@put');
                                         Route::delete('/', 'Api\Manager\LessonController@delete');
                                         Route::patch('status', 'Api\Manager\LessonController@updateStatus');
                                         Route::patch('title', 'Api\Manager\LessonController@updateTitle');

--- a/tests/Feature/Api/Manager/Lesson/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Lesson/DeleteTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Lesson;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_マネージャーのレッスン削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/5/chapter/6/lesson/10');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+
+        // 論理削除されているか確認
+        $this->assertSoftDeleted('lessons', [
+            'id' => 10,
+            'order' => 0,
+        ]);
+    }
+
+    public function test_配下の講師のレッスン登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/2/chapter/4/lesson/7');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        $this->assertSoftDeleted('lessons', [
+            'id' => 7,
+            'order' => 0,
+        ]);
+    }
+
+    public function test_マネージャーの受講済みレッスン削除_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/1/chapter/1/lesson/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to delete this lesson.',
+        ]);
+
+    }
+
+    public function test_配下でない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/2/chapter/4/lesson/7');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to delete this lesson.',
+        ]);
+    }
+
+    public function test_マネージャーではない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/2/chapter/4/lesson/7');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/aaa/chapter/bbb/lesson/ccc', []);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'lesson_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Lesson/PutTest.php
+++ b/tests/Feature/Api/Manager/Lesson/PutTest.php
@@ -6,7 +6,7 @@ use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class StoreTest extends TestCase
+class PutTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -17,29 +17,29 @@ class StoreTest extends TestCase
         $this->seed();
     }
 
-    public function test_マネージャーのレッスン登録_成功(): void
+    public function test_マネージャーのレッスン更新_成功(): void
     {
         // arrange
         $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/manager/course/1/chapter/1/lesson', [
+        $response = $this->putJson('/api/v1/manager/course/1/chapter/1/lesson/1', [
             'title' => 'title',
+            'url' => 'url',
+            'remarks' => 'remarks',
+            'status' => 'public',
         ]);
 
         // assert
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'result',
-            'lesson_id',
         ]);
         $this->assertDatabaseHas('lessons', [
+            'id' => 1,
             'chapter_id' => 1,
             'title' => 'title',
-        ]);
-        $this->assertDatabaseHas('lesson_attendances', [
-            'lesson_id' => $response['lesson_id'],
         ]);
     }
 
@@ -50,17 +50,20 @@ class StoreTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/manager/course/2/chapter/4/lesson', [
+        $response = $this->putJson('/api/v1/manager/course/2/chapter/4/lesson/7', [
             'title' => 'title',
+            'url' => 'url',
+            'remarks' => 'remarks',
+            'status' => 'public',
         ]);
 
         // assert
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'result',
-            'lesson_id',
         ]);
         $this->assertDatabaseHas('lessons', [
+            'id' => 7,
             'chapter_id' => 4,
             'title' => 'title',
         ]);
@@ -74,8 +77,11 @@ class StoreTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/manager/course/2/chapter/4/lesson', [
+        $response = $this->putJson('/api/v1/manager/course/2/chapter/4/lesson/7', [
             'title' => 'title',
+            'url' => 'url',
+            'remarks' => 'remarks',
+            'status' => 'public',
         ]);
 
         // assert
@@ -92,8 +98,11 @@ class StoreTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/manager/course/2/chapter/4/lesson', [
+        $response = $this->putJson('/api/v1/manager/course/2/chapter/4/lesson/7', [
             'title' => 'title',
+            'url' => 'url',
+            'remarks' => 'remarks',
+            'status' => 'public',
         ]);
 
         // assert
@@ -110,14 +119,17 @@ class StoreTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/manager/course/aaa/chapter/bbb/lesson', []);
+        $response = $this->putJson('/api/v1/manager/course/aaa/chapter/bbb/lesson/ccc', []);
 
         // assert
         $response->assertStatus(422);
         $response->assertJsonValidationErrors([
             'course_id',
             'chapter_id',
+            'lesson_id',
             'title',
+            'url',
+            'status',
         ]);
     }
 }

--- a/tests/Feature/Api/Manager/Lesson/StoreTest.php
+++ b/tests/Feature/Api/Manager/Lesson/StoreTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Lesson;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_マネージャーのレッスン登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/1/chapter/1/lesson', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+            'lesson_id',
+        ]);
+        $this->assertDatabaseHas('lessons', [
+            'chapter_id' => 1,
+            'title' => 'title',
+        ]);
+        $this->assertDatabaseHas('lesson_attendances', [
+            'lesson_id' => $response['lesson_id'],
+        ]);
+    }
+
+    public function test_配下の講師のレッスン登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/2/chapter/4/lesson', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+            'lesson_id',
+        ]);
+        $this->assertDatabaseHas('lessons', [
+            'chapter_id' => 4,
+            'title' => 'title',
+        ]);
+        // ! シーダーに受講データがないので、lesson_attendancesにはデータがない
+    }
+
+    public function test_配下でない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/2/chapter/4/lesson', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to create new lesson.',
+        ]);
+    }
+
+    public function test_マネージャーではない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/2/chapter/4/lesson', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/aaa/chapter/bbb/lesson', []);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'title',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1068：Manager/LessonControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 動作確認テスト
Postmanにて修正箇所に対する動作確認を実施。

### storeメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスンを作成できる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson
 - HTTPメソッド：POST
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師と紐づかない場合、エラー応答。
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/
 - HTTPメソッド：POST
 - 結果：403 Forbidden  
"message": "Forbidden, not allowed to create new lesson."

3. 異常：throw $e のエラー発生時の動作テスト
try{}の{}中に`throw new Exception('テスト');`を追記し、テスト実行。  
テスト後に`throw new Exception('テスト');`を削除。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/
 - HTTPメソッド：POST
 - 結果：500 Internal Server Error  
"message": "テスト”
***
### updateメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスン更新ができる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1
 - HTTPメソッド：PUT
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師が紐づかない場合、エラー応答
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1
 - HTTPメソッド：PUT
 - 結果：403 Forbidden 
"message": "Forbidden, not allowed to this lesson.”

3. 異常：講座がレッスンに紐づいていない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/5/chapter/1/lesson/1
 - HTTPメソッド：PUT
 - 結果：403 Forbidden 
"message": "Invalid course_id.”

4. 異常：チャプターがレッスンに紐づいていない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/5/lesson/1
 - HTTPメソッド：PUT
 - 結果：403 Forbidden 
"message": "Invalid chapter_id.”
***
### deleteメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスン削除ができる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson/7
 - HTTPメソッド：DELETE
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師が紐づかない場合、エラー応答。
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson/7
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Invalid instructor_id.”

3. 異常：チャプターがレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/5/lesson/1
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Invalid chapter_id.”

4. 異常：講座がレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/5/chapter/1/lesson/1
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Invalid course_id."

5. 異常：受講情報が登録されている場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "This lesson has attendance."

6. 異常：throw $e のエラー発生時の動作テスト
try{}の{}中に`throw new Exception('テスト');`を追記し、テスト実行。  
テスト後に`throw new Exception('テスト');`を削除。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson/7
 - HTTPメソッド：DELETE
 - 結果：500 Internal Server Error  
"message": "テスト”
***
### sortメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスンの並び替えができる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/2/lesson/sort
 - HTTPメソッド：POST
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師が紐づかない場合、エラー応答。
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/2/lesson/sort
 - HTTPメソッド：POST
 - 結果：500 Internal Server Error 
"message": "Invalid instructor_id."  
※ステータスコードが403ではない。

3. 異常：講座がレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/2/lesson/sort
 - HTTPメソッド：POST
 - 結果：500 Internal Server Error 
"message": "Invalid course."  
※ステータスコードが403ではない。

4. 異常：チャプターがレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/4/lesson/sort
 - HTTPメソッド：POST
 - 結果：500 Internal Server Error  
"message": "Invalid chapter."  
※ステータスコードが403ではない。

5. 異常：throw $e のエラー発生時の動作テスト
try{}の{}中に`throw new Exception('テスト');`を追記し、テスト実行。  
テスト後に`throw new Exception('テスト');`を削除。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/2/lesson/sort
 - HTTPメソッド：POST
 - 結果：500 Internal Server Error  
"message": "テスト”
***
### updateStatusメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスンステータスを更新できる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/status
 - HTTPメソッド：PATCH
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師が紐づかない場合、エラー応答。
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/status
 - HTTPメソッド：PATCH
 - 結果：500 Internal Server Error 
"message": "Invalid instructor_id.”  
※ステータスコードが403ではない。

3. 異常：講座がレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/1/lesson/1/status
 - HTTPメソッド：PATCH
 - 結果：500 Internal Server Error 
"message": "Invalid course_id.”  
※ステータスコードが403ではない。

4. 異常：チャプターがレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/5/lesson/1/status
 - HTTPメソッド：PATCH
 - 結果：500 Internal Server Error 
"message": "Invalid chapter_id.”
※ステータスコードが403ではない。
***
### updateTitleメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスンタイトルを変更できる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/title
 - HTTPメソッド：PATCH
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師が紐づかない場合、エラー応答。
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson/1/title
 - HTTPメソッド：PATCH
 - 結果：500 Internal Server Error 
"message": "Unauthorized access to update lesson title.”  
※ステータスコードが403ではない。

3. 異常：講座がレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/5/chapter/1/lesson/1/title
 - HTTPメソッド：PATCH
 - 結果：500 Internal Server Error 
"message": "Invalid course_id.”  
※ステータスコードが403ではない。

4. 異常：チャプターがレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/5/chapter/1/lesson/1/title
 - HTTPメソッド：PATCH
 - 結果：500 Internal Server Error 
"message": "Invalid chapter_id.”
※ステータスコードが403ではない。
***
### putStatusメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスンステータスを一括更新できる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/2/lesson/status
 - HTTPメソッド：PUT
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師が紐づかない場合、エラー応答。
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/2/lesson/status
 - HTTPメソッド：PUT
 - 結果：403 Forbidden 
"message": "Invalid instructor_id.”

3. 異常：講座がレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/2/lesson/status
 - HTTPメソッド：PUT
 - 結果：403 Forbidden 
"message": "Invalid course_id.”  

4. 異常：チャプターがレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/3/lesson/status
 - HTTPメソッド：PUT
 - 結果：403 Forbidden 
"message": "Invalid chapter_id.”
***
### bulkDeleteメソッド
1. 正常：ログイン中の講師または配下の講師が紐づく場合、レッスンを一括削除できる。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson
 - HTTPメソッド：DELETE
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師または配下の講師が紐づかない場合、エラー応答。
 - instructor_id=4でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden 
"message": "Invalid instructor_id.”

3. 異常：講座がレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/4/lesson
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden 
"message": "Invalid course_id.”  

4. 異常：チャプターがレッスンに紐づいていない場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/3/lesson
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden 
"message": "Invalid chapter_id.”

5. 異常：受講情報が登録されている場合、エラー応答。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/chapter/1/lesson
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden 
"message": "This lesson has attendance.”

6. 異常：throw $e のエラー発生時の動作テスト
try{}の{}中に`throw new Exception('テスト');`を追記し、テスト実行。  
テスト後に`throw new Exception('テスト');`を削除。
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/4/lesson
 - HTTPメソッド：DELETE
 - 結果：500 Internal Server Error  
"message": "テスト”