### PR TITLE
Instructor/ChapterController.php の bulkDelete() の微修正

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -345,11 +345,7 @@ class ChapterController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-        
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -245,11 +245,11 @@ class ChapterController extends Controller
             ]);
         } catch (ValidationErrorException $e) {
             DB::rollBack();
-    
+
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),
-            ], 403);    
+            ], 403);
         } catch (Exception $e) {
             Log::error($e);
             throw $e;
@@ -345,7 +345,7 @@ class ChapterController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-        
+
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use App\Exceptions\ValidationErrorException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\ChapterBulkDeleteRequest;
 use App\Http\Requests\Instructor\ChapterDeleteAllRequest;
@@ -124,6 +123,7 @@ class ChapterController extends Controller
 
     /**
      * チャプター更新API
+     * TODO このメソッドは削除予定
      */
     public function updateStatus(ChapterUpdateStatusRequest $request): JsonResponse
     {
@@ -150,7 +150,7 @@ class ChapterController extends Controller
     }
 
     /**
-     * 複数チャプターの公開/非公開API
+     * チャプターの公開/非公開API
      */
     public function patchStatus(ChapterPatchStatusRequest $request): JsonResponse
     {
@@ -168,11 +168,11 @@ class ChapterController extends Controller
             $chapters->each(function (Chapter $chapter) use ($instructorId, $courseId) {
                 // チャプターに紐づく講師でない場合は許可しない
                 if ((int) $instructorId !== $chapter->course->instructor_id) {
-                    throw new ValidationErrorException('Invalid instructor_id.');
+                    throw new AuthorizationException('Forbidden, invalid instructor_id.');
                 }
                 // チャプターに紐づく講座IDがリクエストの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $chapter->course_id) {
-                    throw new ValidationErrorException('Invalid course_id.');
+                    throw new AuthorizationException('Forbidden, invalid course_id.');
                 }
             });
 
@@ -184,15 +184,7 @@ class ChapterController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ValidationErrorException $e) {
-            DB::rollBack();
-
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 403);
         } catch (Exception $e) {
-            DB::rollBack();
             Log::error($e);
             throw $e;
         }
@@ -215,41 +207,27 @@ class ChapterController extends Controller
             $chapters->each(function (Chapter $chapter) use ($instructorId, $courseId) {
                 // チャプターに紐づく講師でない場合は許可しない
                 if ((int) $instructorId !== $chapter->course->instructor_id) {
-                    throw new ValidationErrorException('Invalid instructor_id.');
+                    throw new AuthorizationException('Forbidden, invalid instructor_id.');
                 }
                 // チャプターに紐づく講座IDがリクエストの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $chapter->course_id) {
-                    throw new ValidationErrorException('Invalid course_id.');
+                    throw new AuthorizationException('Forbidden, invalid course_id.');
                 }
             });
 
-            /*
-                「紐づくlessonsが0件」、または、
-                「全ての紐づくlessonが配下のlessonAttendancesが0件である ( ! ～ ->exists()で判定 ) 」
-                の場合に削除可能($canDelete=true)となる。
-            */
-            $canDelete = true;
             $lessonIds = $chapters->pluck('lessons.*.id')->flatten();
-            if (! $lessonIds->isEmpty()) {
-                $canDelete = ! LessonAttendance::whereIn('lesson_id', $lessonIds)->exists();
-            }
-            if (! $canDelete) {
-                throw new ValidationErrorException('Some chapters contain lessons with attendance records.');
+            if (LessonAttendance::whereIn('lesson_id', $lessonIds)->exists()) {
+                // 受講中のレッスンがあれば、エラー応答
+                throw new AuthorizationException('Forbidden, this lesson has attendance.');
             }
 
             // チャプターを一括で削除
             Chapter::whereIn('id', $chapters->pluck('id'))->delete();
 
+            // TODO レッスンも削除する必要がある。
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ValidationErrorException $e) {
-            DB::rollBack();
-
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 403);
         } catch (Exception $e) {
             Log::error($e);
             throw $e;
@@ -258,6 +236,7 @@ class ChapterController extends Controller
 
     /**
      * チャプター削除API
+     * TODO このメソッドは削除予定
      */
     public function delete(ChapterDeleteRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -202,17 +202,20 @@ class ChapterController extends Controller
                 'result' => true,
             ]);
         } catch (ValidationErrorException $e) {
+            DB::rollBack();
+
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),
-            ]);
+            ], 403);
         } catch (Exception $e) {
+            DB::rollBack();
             Log::error($e);
 
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),
-            ]);
+            ], 500);
         }
     }
 
@@ -262,10 +265,12 @@ class ChapterController extends Controller
                 'result' => true,
             ]);
         } catch (ValidationErrorException $e) {
+            DB::rollBack();
+    
             return response()->json([
                 'result' => false,
                 'message' => $e->getMessage(),
-            ]);
+            ], 403);    
         } catch (Exception $e) {
             Log::error($e);
 
@@ -334,6 +339,7 @@ class ChapterController extends Controller
 
             return response()->json([
                 'result' => false,
+                'message' => $e->getMessage(),
             ], 500);
         }
     }
@@ -377,7 +383,11 @@ class ChapterController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-            throw $e;
+        
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ], 500);
         }
     }
 
@@ -427,6 +437,7 @@ class ChapterController extends Controller
 
             return response()->json([
                 'result' => false,
+                'message' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Http/Requests/Instructor/ChapterPatchStatusRequest.php
+++ b/app/Http/Requests/Instructor/ChapterPatchStatusRequest.php
@@ -33,9 +33,9 @@ class ChapterPatchStatusRequest extends FormRequest
     {
         return [
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
-            'status' => ['required', 'string', new ChapterStatusRule],
             'chapters' => ['required', 'array'],
             'chapters.*' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+            'status' => ['required', 'string', new ChapterStatusRule],
         ];
     }
 }

--- a/tests/Feature/Api/Instructor/Chapter/BulkDeleteTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/BulkDeleteTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Chapter;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BulkDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_チャプターの一括削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/5/chapter', [
+            'chapters' => [6],
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        $this->assertSoftDeleted('chapters', [
+            'id' => 6,
+        ]);
+    }
+
+    public function test_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/5/chapter', [
+            'chapters' => [6],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_講座が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/2/chapter', [
+            'chapters' => [6],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_受講している_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/1/chapter', [
+            'chapters' => [1],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, this lesson has attendance.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/aaa/chapter', [
+            'chapters' => [],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapters',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Chapter/PatchStatusTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/PatchStatusTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Chapter;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PatchStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_チャプターのステータス変更_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->patchJson('/api/v1/instructor/course/1/chapter/status', [
+            'chapters' => [1, 2],
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        $this->assertDatabaseHas('chapters', [
+            'id' => 1,
+            'status' => 'private',
+        ]);
+    }
+
+    public function test_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->patchJson('/api/v1/instructor/course/1/chapter/status', [
+            'chapters' => [1, 2],
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_講座が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->patchJson('/api/v1/instructor/course/2/chapter/status', [
+            'chapters' => [1, 2],
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->patchJson('/api/v1/instructor/course/aaa/chapter/status', [
+            'chapters' => 'string',
+            'status' => 'string',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapters',
+            'status',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
Instructor/ChapterController.php の bulkDelete() の微修正

## 動作確認テスト
Postmanにて、修正箇所に対する動作確認を実施。

例）[DELETE] http://localhost:8080/api/v1/instructor/course/1/chapter

送信後、以下のキャプチャのようなレスポンスが返ってくればOK。

![スクリーンショット 2025-01-17 133855](https://github.com/user-attachments/assets/f6354a32-d461-4ed3-87ec-05adb055f5ac)

★★注意★★
エラー発生時の動作確認方法としては、下記のコードのように、
　 try {} の{}の中に一時的に書いて、テストする（テスト後は削除する）
```
    try {

          throw new Exception('テスト');

　   } catch (Exception $e) { 
```

以上、ご確認よろしくお願いいたします。