### PR TITLE
Stundent/AttendanceControllerとStundent/LessonAttendanceControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -265,7 +265,7 @@ class ChapterController extends Controller
             $chapter = Chapter::with('course', 'lessons')->findOrFail($request->chapter_id);
 
             if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-                 // ログインしている講師が作成していないチャプターの更新を許可しない
+                // ログインしている講師が作成していないチャプターの更新を許可しない
                 throw new AuthorizationException('Invalid instructor_id.');
             }
 

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -103,10 +103,8 @@ class AttendanceController extends Controller
             ->findOrFail($request->attendance_id);
 
         if ($authId !== $attendance->student_id) {
-            return response()->json([
-                'result' => false,
-                'error_message' => 'Not authorized.',
-            ], 403);
+            // ログインしている生徒が受講しているコースではない
+            throw new AuthorizationException('Not authorized.');
         }
 
         $progressData = [

--- a/app/Http/Controllers/Api/Student/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/Student/LessonAttendanceController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Student\LessonAttendancePatchRequest;
 use App\Model\LessonAttendance;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class LessonAttendanceController extends Controller
 {
@@ -18,16 +19,14 @@ class LessonAttendanceController extends Controller
     public function update(LessonAttendancePatchRequest $request)
     {
         try {
+            throw new RuntimeException('テスト');
             /** @var LessonAttendance $lessonAttendance */
             $lessonAttendance = LessonAttendance::with('attendance')
                 ->find($request->lesson_attendance_id);
 
             if ($request->user()->id !== $lessonAttendance->attendance->student_id) {
-                return response()->json([
-                    'result' => false,
-                    'error_code' => 403,
-                    'error_message' => 'Forbidden.',
-                ]);
+                // ログインしている生徒が受講しているコースではない
+                throw new AuthorizationException('Forbidden.');
             }
 
             $lessonAttendance->update([
@@ -40,9 +39,7 @@ class LessonAttendanceController extends Controller
         } catch (RuntimeException $e) {
             Log::error($e->getMessage());
 
-            return response()->json([
-                'result' => false,
-            ]);
+            throw $e;
         }
     }
 }

--- a/app/Http/Controllers/Api/Student/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/Student/LessonAttendanceController.php
@@ -16,16 +16,15 @@ class LessonAttendanceController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function update(LessonAttendancePatchRequest $request)
+    public function patchStatus(LessonAttendancePatchRequest $request)
     {
         try {
-            /** @var LessonAttendance $lessonAttendance */
             $lessonAttendance = LessonAttendance::with('attendance')
                 ->find($request->lesson_attendance_id);
+            assert($lessonAttendance instanceof LessonAttendance);
 
             if ($request->user()->id !== $lessonAttendance->attendance->student_id) {
-                // ログインしている生徒が受講しているコースではない
-                throw new AuthorizationException('Forbidden.');
+                throw new AuthorizationException('Forbidden, invalid student');
             }
 
             $lessonAttendance->update([
@@ -37,7 +36,6 @@ class LessonAttendanceController extends Controller
             ]);
         } catch (RuntimeException $e) {
             Log::error($e->getMessage());
-
             throw $e;
         }
     }

--- a/app/Http/Controllers/Api/Student/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/Student/LessonAttendanceController.php
@@ -19,7 +19,6 @@ class LessonAttendanceController extends Controller
     public function update(LessonAttendancePatchRequest $request)
     {
         try {
-            throw new RuntimeException('テスト');
             /** @var LessonAttendance $lessonAttendance */
             $lessonAttendance = LessonAttendance::with('attendance')
                 ->find($request->lesson_attendance_id);

--- a/app/Http/Controllers/Api/Student/LessonAttendanceController.php
+++ b/app/Http/Controllers/Api/Student/LessonAttendanceController.php
@@ -5,9 +5,9 @@ namespace App\Http\Controllers\Api\Student;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Student\LessonAttendancePatchRequest;
 use App\Model\LessonAttendance;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class LessonAttendanceController extends Controller
 {

--- a/app/Http/Requests/Student/LessonAttendancePatchRequest.php
+++ b/app/Http/Requests/Student/LessonAttendancePatchRequest.php
@@ -17,6 +17,13 @@ class LessonAttendancePatchRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'lesson_attendance_id' => $this->route('lesson_attendance_id'),
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -25,7 +32,7 @@ class LessonAttendancePatchRequest extends FormRequest
     public function rules()
     {
         return [
-            'lesson_attendance_id' => ['required', 'integer', 'exists:lesson_attendances,id'],
+            'lesson_attendance_id' => ['required', 'integer', 'exists:lesson_attendances,id,deleted_at,NULL'],
             'status' => ['required', new LessonAttendanceStatusRule],
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,7 +46,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         });
 
         // 受講生-レッスン受講
-        Route::patch('lesson_attendance', 'Api\Student\LessonAttendanceController@update');
+        Route::patch('lesson_attendance/{lesson_attendance_id}', [App\Http\Controllers\Api\Student\LessonAttendanceController::class, 'patchStatus']);
 
         // 受講生-お知らせ
         Route::prefix('notification')->group(function () {

--- a/tests/Feature/Api/Student/Attendance/ProgressTest.php
+++ b/tests/Feature/Api/Student/Attendance/ProgressTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Api\Student;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProgressTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講進捗を取得_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/1/progress');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_受講進捗を取得_他の生徒の進捗を取得_失敗(): void
+    {
+        // arrange
+        $student = Student::find(2);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/1/progress');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/abc/progress');
+
+        // assert
+        $response->assertStatus(422);
+    }
+}

--- a/tests/Feature/Api/Student/LessonAttendance/PatchStatusTest.php
+++ b/tests/Feature/Api/Student/LessonAttendance/PatchStatusTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Api\LessonAttendance;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PatchStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_レッスン受講状態を更新_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->patchJson('/api/v1/lesson_attendance/1', [
+            'status' => 'before_attendance',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('lesson_attendances', [
+            'id' => 1,
+            'status' => 'before_attendance',
+        ]);
+    }
+
+    public function test_レッスン受講状態を更新_他の生徒の受講状態を更新_失敗(): void
+    {
+        // arrange
+        $student = Student::find(2);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->patchJson('/api/v1/lesson_attendance/1', [
+            'status' => 'before_attendance',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->patchJson('/api/v1/lesson_attendance/abc', [
+            'status' => 'aaa',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'lesson_attendance_id',
+            'status',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes
#JKA-1076 Stundent/AttendanceControllerとStundent/LessonAttendanceControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 概要
- 各メソッドのif文に「throw new AuthorizationException('エラーメッセージ');」の修正
- catchの中の「return response()～」を「throw $e;」に修正

## 動作確認手順
全てstudents_idは1でログインしています。

progress（http://localhost:8080/api/v1/attendance/:attendance_id/progress）
- attendance_idが4の場合（ログインしている生徒が受講しているコース）
正常に動作できる。
- attendance_idが2の場合（ログインしている生徒が受講しているコースではない）
"message": "Not authorized."
が出力される。

update（http://localhost:8080/api/v1/lesson_attendance）
- "lesson_attendance_id": 1を更新（ログインしている生徒が受講しているコース）
正常に動作できる。
- "lesson_attendance_id": 2を更新（ログインしている生徒が受講しているコースではない）
"message": "Forbidden."
が出力される。
- 明示的にthrow new RuntimeExceptionを記載した場合
"message": "テスト"
"exception": "RuntimeException"
が出力される。

## 考慮して欲しいこと
## 確認して欲しいこと
「LessonAttendanceController.php」のupdateメソッドで「throw new AuthorizationException('Forbidden.');」を追加するとエラーになったため、
「use Illuminate\Auth\Access\AuthorizationException;」を記載しました。