### PR TITLE
JKA-1094：Instructor/LessonControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -205,11 +205,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to delete lessons.',
-            ], 500);
+            throw $e;
         }
     }
 
@@ -221,18 +217,12 @@ class LessonController extends Controller
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
 
         if (Auth::guard('instructor')->user()->id !== $lesson->chapter->course->instructor_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'invalid instructor_id.',
-            ], 403);
+            throw new AuthorizationException('invalid instructor_id.');
         }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id) {
             // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は更新を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid chapter_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid chapter_id.');
         }
 
         $lesson->update([
@@ -253,24 +243,15 @@ class LessonController extends Controller
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
 
         if ($lesson->chapter->course->instructor_id !== $user->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id',
-            ], 403);
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         if ((int) $request->course_id !== $lesson->chapter->course_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid chapter_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid chapter_id.');
         }
 
         $lesson->update([
@@ -294,18 +275,12 @@ class LessonController extends Controller
 
         // 現在の講師がチャプターの講座の作成者であるか確認
         if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid instructor_id.');
         }
 
         // 指定された course_id がチャプターに関連付けられている course_id と一致するか確認
         if ((int) $request->course_id !== $chapter->course->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid course_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid course_id.');
         }
 
         // チャプターに紐づく全レッスンIDを取得
@@ -313,10 +288,7 @@ class LessonController extends Controller
         $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
         if ($attendedLessonIds->isNotEmpty()) {
             // 出席のあるレッスンがあれば削除を許可しない
-            return response()->json([
-                'result' => false,
-                'message' => 'This lessons contains attendance.',
-            ], 403);
+            throw new AuthorizationException('This lessons contains attendance.');
         }
 
         // 認可チェックをパスした後にトランザクションを開始
@@ -334,11 +306,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to delete lessons.',
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -366,10 +366,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ]);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -7,14 +7,15 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\LessonBulkDeleteRequest;
 use App\Http\Requests\Instructor\LessonDeleteRequest;
 use App\Http\Requests\Instructor\LessonPatchStatusRequest;
+use App\Http\Requests\Instructor\LessonPutRequest;
 use App\Http\Requests\Instructor\LessonPutStatusRequest;
 use App\Http\Requests\Instructor\LessonsAllDeleteRequest;
 use App\Http\Requests\Instructor\LessonSortRequest;
 use App\Http\Requests\Instructor\LessonStoreRequest;
-use App\Http\Requests\Instructor\LessonUpdateRequest;
 use App\Http\Requests\Instructor\LessonUpdateTitleRequest;
 use App\Model\Attendance;
 use App\Model\Chapter;
+use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
@@ -34,6 +35,10 @@ class LessonController extends Controller
     public function store(LessonStoreRequest $request): JsonResponse
     {
         $maxOrder = Lesson::where('chapter_id', $request->chapter_id)->max('order');
+        $course = Course::findOrFail($request->course_id);
+        if ($course->instructor_id !== $request->user()->id) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
 
         DB::beginTransaction();
         try {
@@ -58,6 +63,7 @@ class LessonController extends Controller
 
             return response()->json([
                 'result' => true,
+                'lesson_id' => $lesson->id,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -69,17 +75,22 @@ class LessonController extends Controller
     /**
      * レッスン更新API
      */
-    public function update(LessonUpdateRequest $request): JsonResponse
+    public function put(LessonPutRequest $request): JsonResponse
     {
         $user = Instructor::find($request->user()->id);
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
+        assert($lesson instanceof Lesson);
 
         if ($lesson->chapter->course->instructor_id !== $user->id) {
-            throw new AuthorizationException('Invalid instructor_id');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
-        if ((int) $request->chapter_id !== $lesson->chapter->id || (int) $request->course_id !== $lesson->chapter->course_id) {
-            throw new AuthorizationException('Invalid chapter_id or course_id.');
+        if ((int) $request->course_id !== $lesson->chapter->course_id) {
+            throw new AuthorizationException('Forbidden, invalid course_id.');
+        }
+
+        if ((int) $request->chapter_id !== $lesson->chapter->id) {
+            throw new AuthorizationException('Forbidden, invalid chapter_id.');
         }
 
         $lesson->update([
@@ -104,7 +115,7 @@ class LessonController extends Controller
             $lesson = Lesson::with('chapter')->findOrFail($request->lesson_id);
 
             if (Auth::guard('instructor')->user()->id !== $lesson->chapter->course->instructor_id) {
-                throw new AuthorizationException('Invalid instructor_id.');
+                throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
 
             if ((int) $request->chapter_id !== $lesson->chapter->id) {
@@ -113,7 +124,7 @@ class LessonController extends Controller
             }
 
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
-                throw new AuthorizationException('This lesson has attendance.');
+                throw new AuthorizationException('Forbidden, this lesson has attendance.');
             }
 
             // 削除対象レッスンのorderカラムを0に設定する

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -62,10 +62,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -78,17 +75,11 @@ class LessonController extends Controller
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
 
         if ($lesson->chapter->course->instructor_id !== $user->id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid instructor_id',
-            ], 403);
+            throw new AuthorizationException('Invalid instructor_id');
         }
 
         if ((int) $request->chapter_id !== $lesson->chapter->id || (int) $request->course_id !== $lesson->chapter->course_id) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Invalid chapter_id or course_id.',
-            ], 403);
+            throw new AuthorizationException('Invalid chapter_id or course_id.');
         }
 
         $lesson->update([
@@ -113,25 +104,16 @@ class LessonController extends Controller
             $lesson = Lesson::with('chapter')->findOrFail($request->lesson_id);
 
             if (Auth::guard('instructor')->user()->id !== $lesson->chapter->course->instructor_id) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid instructor_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid instructor_id.');
             }
 
             if ((int) $request->chapter_id !== $lesson->chapter->id) {
                 // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は更新を許可しない
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Invalid chapter_id.',
-                ], 403);
+                throw new AuthorizationException('Invalid chapter_id.');
             }
 
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'This lesson has attendance.',
-                ], 403);
+                throw new AuthorizationException('This lesson has attendance.');
             }
 
             // 削除対象レッスンのorderカラムを0に設定する
@@ -154,10 +136,7 @@ class LessonController extends Controller
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -329,7 +329,6 @@ class LessonController extends Controller
         DB::beginTransaction();
 
         try {
-            // 認証ユーザー情報取得
             $instructorId = Auth::guard('instructor')->user()->id;
 
             $courseId = $request->input('course_id');
@@ -340,23 +339,23 @@ class LessonController extends Controller
             $lessons = Lesson::with('chapter.course')->whereIn('id', array_column($inputLessons, 'lesson_id'))->get();
 
             // 認可
-            $lessons->each(function ($lesson) use ($instructorId, $courseId, $chapterId) {
+            $lessons->each(function (Lesson $lesson) use ($instructorId, $courseId, $chapterId) {
                 // 講座に紐づく講師でない場合は許可しない
                 if ((int) $instructorId !== $lesson->chapter->course->instructor_id) {
-                    throw new ValidationErrorException('Invalid instructor_id.');
+                    throw new AuthorizationException('Forbidden, invalid instructor.');
                 }
                 // 指定した講座IDが1レッスンの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $lesson->chapter->course_id) {
-                    throw new ValidationErrorException('Invalid course.');
+                    throw new AuthorizationException('Forbidden, invalid course.');
                 }
                 // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
                 if ((int) $chapterId !== $lesson->chapter_id) {
-                    throw new ValidationErrorException('Invalid chapter.');
+                    throw new AuthorizationException('Forbidden, invalid chapter.');
                 }
             });
 
             // orderカラムを更新（並び替え実施）
-            $lessons->each(function ($lesson) use ($inputLessons) {
+            $lessons->each(function (Lesson $lesson) use ($inputLessons) {
                 $collectionLessons = new Collection($inputLessons);
                 $inputLesson = $collectionLessons->firstWhere('lesson_id', $lesson->id);
                 $lesson->update([
@@ -369,11 +368,6 @@ class LessonController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ValidationErrorException $e) {
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 422);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -144,8 +144,9 @@ class LessonController extends Controller
             // 自身と配下のinstructor情報を取得
             $managerId = Auth::guard('instructor')->user()->id;
 
-            /** @var Instructor $manager */
             $manager = Instructor::with('managings')->find($managerId);
+            assert($manager instanceof Instructor);
+
             $instructorIds = $manager->managings->pluck('id')->toArray();
             $instructorIds[] = $manager->id;
 
@@ -208,8 +209,9 @@ class LessonController extends Controller
             $managerId = Auth::guard('instructor')->user()->id;
 
             // マネージャーが管理する講師を取得
-            /** @var Instructor $manager */
             $manager = Instructor::with('managings')->find($managerId);
+            assert($manager instanceof Instructor);
+
             $instructorIds = $manager->managings->pluck('id')->toArray();
             $instructorIds[] = $manager->id;
 
@@ -224,19 +226,18 @@ class LessonController extends Controller
             $lessons->each(function (Lesson $lesson) use ($instructorIds, $courseId, $chapterId) {
                 // 講座に紐づく講師でない場合は許可しない
                 if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-                    throw new ValidationErrorException('Invalid instructor_id.');
+                    throw new AuthorizationException('Forbidden, not allowed to delete this lesson. Invalid instructor.');
                 }
                 // 指定した講座IDが1レッスンの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $lesson->chapter->course->id) {
-                    throw new ValidationErrorException('Invalid course.');
+                    throw new AuthorizationException('Forbidden, not allowed to delete this lesson. Invalid course_id.');
                 }
                 // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
                 if ((int) $chapterId !== $lesson->chapter->id) {
-                    throw new ValidationErrorException('Invalid chapter.');
+                    throw new AuthorizationException('Forbidden, not allowed to delete this lesson. Invalid chapter_id.');
                 }
             });
 
-            // レッスンのorderカラムを更新
             $lessons->each(function (Lesson $lesson) use ($inputLessons) {
                 $collectionLessons = new Collection($inputLessons);
                 $inputLesson = $collectionLessons->firstWhere('lesson_id', $lesson->id);
@@ -250,11 +251,6 @@ class LessonController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ValidationErrorException $e) {
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 422);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Requests/Instructor/LessonDeleteRequest.php
+++ b/app/Http/Requests/Instructor/LessonDeleteRequest.php
@@ -19,6 +19,8 @@ class LessonDeleteRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
             'lesson_id' => $this->route('lesson_id'),
         ]);
     }
@@ -31,6 +33,8 @@ class LessonDeleteRequest extends FormRequest
     public function rules()
     {
         return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
         ];
     }

--- a/app/Http/Requests/Instructor/LessonPutRequest.php
+++ b/app/Http/Requests/Instructor/LessonPutRequest.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests\Instructor;
 use App\Rules\LessonStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 
-class LessonUpdateRequest extends FormRequest
+class LessonPutRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,7 +93,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::delete('/', 'Api\Instructor\LessonController@bulkDelete');
                                 Route::delete('all', 'Api\Instructor\LessonController@deleteAll');
                                 Route::prefix('{lesson_id}')->group(function () {
-                                    Route::put('/', 'Api\Instructor\LessonController@update');
+                                    Route::put('/', 'Api\Instructor\LessonController@put');
                                     Route::delete('/', 'Api\Instructor\LessonController@delete');
                                     Route::patch('status', 'Api\Instructor\LessonController@updateStatus');
                                     Route::patch('title', 'Api\Instructor\LessonController@updateTitle');

--- a/tests/Feature/Api/Instructor/Lesson/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/DeleteTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Lesson;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_レッスン削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/5/chapter/6/lesson/10');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+
+        // 論理削除されているか確認
+        $this->assertSoftDeleted('lessons', [
+            'id' => 10,
+            'order' => 0,
+        ]);
+    }
+
+    public function test_受講済みレッスン削除_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/1/chapter/1/lesson/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, this lesson has attendance.',
+        ]);
+
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/5/chapter/6/lesson/10');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/aaa/chapter/bbb/lesson/ccc', []);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'lesson_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Lesson/PutTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/PutTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Lesson;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_レッスン更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/1/chapter/1/lesson/1', [
+            'title' => 'title',
+            'url' => 'url',
+            'remarks' => 'remarks',
+            'status' => 'public',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        $this->assertDatabaseHas('lessons', [
+            'id' => 1,
+            'chapter_id' => 1,
+            'title' => 'title',
+        ]);
+    }
+
+    public function test_権限がない講師のレッスン更新_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/2/chapter/4/lesson/7', [
+            'title' => 'title',
+            'url' => 'url',
+            'remarks' => 'remarks',
+            'status' => 'public',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/aaa/chapter/bbb/lesson/ccc', []);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'lesson_id',
+            'title',
+            'url',
+            'status',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Lesson/SortTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/SortTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Lesson;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SortTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_レッスン並び替え_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                ['lesson_id' => 5, 'order' => 1],
+                ['lesson_id' => 4, 'order' => 2],
+                ['lesson_id' => 3, 'order' => 3],
+                ['lesson_id' => 2, 'order' => 4],
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        collect([5, 4, 3, 2])->each(function ($id, $index) {
+            $this->assertDatabaseHas('lessons', [
+                'id' => $id,
+                'chapter_id' => 2,
+                'order' => $index + 1,
+            ]);
+        });
+    }
+
+    public function test_権限がない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                ['lesson_id' => 5, 'order' => 1],
+                ['lesson_id' => 4, 'order' => 2],
+                ['lesson_id' => 3, 'order' => 3],
+                ['lesson_id' => 2, 'order' => 4],
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/aaa/chapter/bbb/lesson/sort');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'lessons',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Lesson/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/StoreTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Lesson;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_レッスン登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter/1/lesson', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+            'lesson_id',
+        ]);
+        $this->assertDatabaseHas('lessons', [
+            'chapter_id' => 1,
+            'title' => 'title',
+        ]);
+        $this->assertDatabaseHas('lesson_attendances', [
+            'lesson_id' => $response['lesson_id'],
+        ]);
+    }
+
+    public function test_権限がない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/2/chapter/4/lesson', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/aaa/chapter/bbb/lesson', []);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'title',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Lesson/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Lesson/DeleteTest.php
@@ -39,7 +39,7 @@ class DeleteTest extends TestCase
         ]);
     }
 
-    public function test_配下の講師のレッスン登録_成功(): void
+    public function test_配下の講師のレッスン削除_成功(): void
     {
         // arrange
         $instructor = Instructor::find(1);
@@ -76,7 +76,7 @@ class DeleteTest extends TestCase
 
     }
 
-    public function test_配下でない講師のレッスン登録_失敗(): void
+    public function test_配下でない講師のレッスン削除_失敗(): void
     {
         // arrange
         $instructor = Instructor::find(4);
@@ -92,7 +92,7 @@ class DeleteTest extends TestCase
         ]);
     }
 
-    public function test_マネージャーではない講師のレッスン登録_失敗(): void
+    public function test_マネージャーではない講師のレッスン削除_失敗(): void
     {
         // arrange
         $instructor = Instructor::find(2);

--- a/tests/Feature/Api/Manager/Lesson/SortTest.php
+++ b/tests/Feature/Api/Manager/Lesson/SortTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Lesson;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SortTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_マネージャーのレッスン並び替え_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                ['lesson_id' => 5, 'order' => 1],
+                ['lesson_id' => 4, 'order' => 2],
+                ['lesson_id' => 3, 'order' => 3],
+                ['lesson_id' => 2, 'order' => 4],
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        collect([5, 4, 3, 2])->each(function ($id, $index) {
+            $this->assertDatabaseHas('lessons', [
+                'id' => $id,
+                'chapter_id' => 2,
+                'order' => $index + 1,
+            ]);
+        });
+    }
+
+    public function test_配下でない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                ['lesson_id' => 5, 'order' => 1],
+                ['lesson_id' => 4, 'order' => 2],
+                ['lesson_id' => 3, 'order' => 3],
+                ['lesson_id' => 2, 'order' => 4],
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to delete this lesson. Invalid instructor.',
+        ]);
+    }
+
+    public function test_マネージャーではない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                ['lesson_id' => 5, 'order' => 1],
+                ['lesson_id' => 4, 'order' => 2],
+                ['lesson_id' => 3, 'order' => 3],
+                ['lesson_id' => 2, 'order' => 4],
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/aaa/chapter/bbb/lesson/sort');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'lessons',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1094：Instructor/LessonControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 動作確認テスト
Postmanにて修正箇所に対する動作確認を実施。

### storeメソッド
1. 異常：throw $e のエラー発生時の動作テスト  
try{}の{}中に`throw new Exception('テスト');`を追記し、テスト実行。  
テスト後に`throw new Exception('テスト');`を削除。
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/manager/course/2/chapter/1/lesson
 - HTTPメソッド：POST
 - 結果：500 Internal Server Error  
"message": "テスト”
***
### updateメソッド
1. 正常：ログイン中の講師が紐づいているレッスンを更新できる
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/4/lesson/7
 - HTTPメソッド：PUT
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師が紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1
 - HTTPメソッド：PUT
 - 結果：403 Forbidden  
"message": "Invalid instructor_id”

3. 異常：講座がレッスンと紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/4/lesson/7
 - HTTPメソッド：PUT
 - 結果：403 Forbidden  
"message": "Invalid chapter_id or course_id.”

4. 異常：チャプターがレッスンと紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/1/lesson/7
 - HTTPメソッド：PUT
 - 結果：403 Forbidden  
"message": "Invalid chapter_id or course_id.”
***
### deleteメソッド
1. 正常：ログイン中の講師が紐づいている場合、レッスンを削除できる
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/4/lesson/7
 - HTTPメソッド：DELETE
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師が紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Invalid instructor_id.”

3. 異常：チャプターがレッスンと紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/5/lesson/7
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Invalid chapter_id.”

4. 異常：レッスンが受講中の場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "This lesson has attendance.”

5. 異常：throw $e のエラー発生時の動作テスト  
try{}の{}の中にthrow new Exception('テスト');を追記し、テスト実行。  
テスト後にthrow new Exception('テスト');を削除。
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/4/lesson/7
 - HTTPメソッド：DELETE
 - 結果：500 Internal Server Error  
"message": "テスト”
***
### bulkDeleteメソッド
1. 異常：throw $e のエラー発生時の動作テスト  
try{}の{}の中にthrow new Exception('テスト');を追記し、テスト実行。  
テスト後にthrow new Exception('テスト');を削除。
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/5/lesson
 - HTTPメソッド：DELETE
 - 結果：500 Internal Server Error  
"message": "テスト”
 ***
### updateStatusメソッド
1. 正常：ログイン中の講師が紐づいているレッスンのステータスを更新できる
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/4/lesson/7/status
 - HTTPメソッド：PATCH
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師が紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1/status
 - HTTPメソッド：PATCH
 - 結果：403 Forbidden  
"message": "invalid instructor_id.”

3. 異常：チャプターがレッスンと紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/5/lesson/7/status
 - HTTPメソッド：PATCH
 - 結果：403 Forbidden  
"message": "Invalid chapter_id.”
***
### updateTitleメソッド
1. 正常：ログイン中の講師が紐づいているレッスンのタイトルを更新できる
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/4/lesson/7/title
 - HTTPメソッド：PATCH
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師が紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/1/title
 - HTTPメソッド：PATCH
 - 結果：403 Forbidden  
"message": "Invalid instructor_id.”

3. 異常：講座がレッスンと紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/3/chapter/4/lesson/7/title
 - HTTPメソッド：PATCH
 - 結果：403 Forbidden  
"message": "Invalid course_id.”

4. 異常：チャプターがレッスンと紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/5/lesson/7/title
 - HTTPメソッド：PATCH
 - 結果：403 Forbidden  
"message": "Invalid chapter_id.”
***
### deleteAllメソッド
1. 正常：ログイン中の講師が紐づいているチャプターの全レッスンを削除できる
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/5/lesson/all
 - HTTPメソッド：DELETE
 - 結果：200 OK  
"result": true

2. 異常：ログイン中の講師が紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/1/lesson/all
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Invalid instructor_id.”

3. 異常：指定した講座がチャプターと紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/3/chapter/5/lesson/all
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Invalid course_id.”

4. 異常：レッスンが受講中の場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/chapter/2/lesson/all
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "This lessons contains attendance.”

5. 異常：throw $e のエラー発生時の動作テスト
try{}の{}の中に`throw new Exception('テスト');`を追記し、テスト実行。  
テスト後に`throw new Exception('テスト');`を削除。  
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/5/lesson/all
 - HTTPメソッド：DELETE
 - 結果：500 Internal Server Error  
"message": "テスト”
***
### sortメソッド
1. 異常：throw $e のエラー発生時の動作テスト
try{}の{}の中に`throw new Exception('テスト');`を追記し、テスト実行。  
テスト後に`throw new Exception('テスト');`を削除。  
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/chapter/5/lesson/sort
 - HTTPメソッド：POST
 - 結果：500 Internal Server Error  
"message": "テスト”