### PR TITLE
Stundent/NotificationControllerとStundent/StudentControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

### DIFF
--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -12,9 +12,9 @@ use App\Model\Attendance;
 use App\Model\Notification;
 use App\Model\Student;
 use Carbon\CarbonImmutable;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class NotificationController extends Controller
 {
@@ -98,9 +98,9 @@ class NotificationController extends Controller
         /** @var Notification $notification */
         $notification = Notification::with(['course'])->findOrFail($request->notification_id);
 
-        if (!in_array($notification->course_id, $courseIds, true)) {
+        if (! in_array($notification->course_id, $courseIds, true)) {
             throw new AuthorizationException('Forbidden. You are not authorized to view this notification.');
-        }        
+        }
 
         return new NotificationShowResource($notification);
     }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -99,7 +99,7 @@ class NotificationController extends Controller
         $notification = Notification::with(['course'])->findOrFail($request->notification_id);
 
         if (!in_array($notification->course_id, $courseIds, true)) {
-            throw new AuthorizationException('Forbidden. You are not authorized to view this notification.');
+            throw new AuthorizationException('Forbidden, not allowed to this notification.');
         }        
 
         return new NotificationShowResource($notification);

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -14,6 +14,7 @@ use App\Model\Student;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class NotificationController extends Controller
 {
@@ -97,12 +98,9 @@ class NotificationController extends Controller
         /** @var Notification $notification */
         $notification = Notification::with(['course'])->findOrFail($request->notification_id);
 
-        if (! in_array($notification->course_id, $courseIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
-        }
+        if (!in_array($notification->course_id, $courseIds, true)) {
+            throw new AuthorizationException('Forbidden. You are not authorized to view this notification.');
+        }        
 
         return new NotificationShowResource($notification);
     }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -98,9 +98,9 @@ class NotificationController extends Controller
         /** @var Notification $notification */
         $notification = Notification::with(['course'])->findOrFail($request->notification_id);
 
-        if (!in_array($notification->course_id, $courseIds, true)) {
+        if (! in_array($notification->course_id, $courseIds, true)) {
             throw new AuthorizationException('Forbidden, not allowed to this notification.');
-        }        
+        }
 
         return new NotificationShowResource($notification);
     }

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -165,7 +165,6 @@ class StudentController extends Controller
                 'result' => true,
             ]);
         } catch (Exception $e) {
-            DB::rollBack();
             Log::error($e);
             throw $e;
         }
@@ -256,7 +255,6 @@ class StudentController extends Controller
                 'message' => 'Authorization success.',
             ]);
         } catch (Exception $e) {
-            DB::rollBack();
             Log::error($e);
             throw $e;
         }

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -19,6 +19,7 @@ use App\Services\Student\QueryService;
 use App\Services\Student\VerifyCodeService;
 use Carbon\CarbonImmutable;
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
@@ -28,7 +29,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class StudentController extends Controller
 {

--- a/app/Http/Controllers/Api/Student/StudentController.php
+++ b/app/Http/Controllers/Api/Student/StudentController.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class StudentController extends Controller
 {
@@ -128,10 +129,7 @@ class StudentController extends Controller
             $student = Student::findOrFail($request->user()->id);
 
             if ($request->user()->id !== $student->id) {
-                return response()->json([
-                    'result' => 'false',
-                    'message' => 'Not authorized.',
-                ], 403);
+                throw new AuthorizationException('Not authorized.');
             }
 
             $imagePath = $student->profile_image;
@@ -167,11 +165,9 @@ class StudentController extends Controller
                 'result' => true,
             ]);
         } catch (Exception $e) {
+            DB::rollBack();
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -260,6 +256,7 @@ class StudentController extends Controller
                 'message' => 'Authorization success.',
             ]);
         } catch (Exception $e) {
+            DB::rollBack();
             Log::error($e);
             throw $e;
         }


### PR DESCRIPTION
## issue
Stundent/NotificationControllerとStundent/StudentControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 動作確認テスト
Postmanにて、修正箇所に対する動作確認を実施。

例）[POST] http://localhost:8080/api/v1/student/update

送信後、以下のキャプチャのようなレスポンスが返ってくればOK。

![スクリーンショット 2025-01-17 133855](https://github.com/user-attachments/assets/b5fbad07-5f9d-4436-91ba-93325d227009)

★★注意★★
エラー発生時の動作確認方法としては、下記のコードのように、
　 try {} の{}の中に一時的に書いて、テストする（テスト後は削除する）
```
    try {

          throw new Exception('テスト');

　   } catch (Exception $e) { 

```
以上、ご確認よろしくお願いいたします。