### PR TITLE
Instructor/StudentControllerのindexメソッドの改修(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -46,6 +46,8 @@ class StudentController extends Controller
         $results = DB::table('attendances')
             ->select(
                 'attendances.student_id',
+                'attendances.course_id',
+                'courses.instructor_id',
                 'students.nick_name',
                 'students.email',
                 'students.profile_image',
@@ -54,7 +56,10 @@ class StudentController extends Controller
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
+            ->join('courses', 'attendances.course_id', '=', 'courses.id')
             ->where('attendances.course_id', $request->course_id)
+            // ログインしている講師IDを検索
+            ->where('courses.instructor_id', $request->instructor_id)
             ->whereNull('attendances.deleted_at')
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
             ->when($inputText, function ($query) use ($inputText) {

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -12,6 +12,8 @@ use App\Model\Course;
 use App\Model\Student;
 use App\Services\Student\QueryService;
 use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -20,10 +22,8 @@ class StudentController extends Controller
 {
     /**
      * 受講生一覧取得API
-     *
-     * @return StudentIndexResource|JsonResponse
      */
-    public function index(StudentIndexRequest $request)
+    public function index(StudentIndexRequest $request): StudentIndexResource
     {
         $perPage = $request->input('per_page', 10);
         $page = $request->input('page', 1);
@@ -39,10 +39,7 @@ class StudentController extends Controller
         if ($courseId !== null) {
             $instructorId = Course::findOrFail($request->course_id)->instructor_id;
             if ($loginId !== $instructorId) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Not authorized.',
-                ], 403);
+                throw new AuthorizationException('Forbidden, invalid course_id.');
             }
         }
 
@@ -61,38 +58,33 @@ class StudentController extends Controller
             ->join('students', 'attendances.student_id', '=', 'students.id')
             ->join('courses', 'attendances.course_id', '=', 'courses.id')
             // course_idのクエリパラメータがある時のみ、条件にcourse_idを含める
-            ->when($courseId, function ($query) use ($courseId) {
+            ->when($courseId, function (Builder $query) use ($courseId) {
                 $query->where('attendances.course_id', $courseId);
             })
             // ログインしている講師IDを検索
             ->where('courses.instructor_id', $loginId)
             ->whereNull('attendances.deleted_at')
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
-            ->when($inputText, function ($query) use ($inputText) {
+            ->when($inputText, function (Builder $query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
-                $query->where(function ($query) use ($inputText) {
+                $query->where(function (Builder $query) use ($inputText) {
                     $query->orWhere('students.nick_name', 'LIKE', "%{$inputText}%")
                         ->orWhere('students.email', 'LIKE', "%{$inputText}%")
                         ->orWhere(DB::raw('CONCAT(students.last_name, students.first_name)'), 'LIKE', "%{$inputText}%");
                 });
             })
             // 日付検索
-            ->when($startDate, function ($query) use ($startDate) {
+            ->when($startDate, function (Builder $query) use ($startDate) {
                 $query->where('attendances.created_at', '>=', $startDate);
             })
-            ->when($endDate, function ($query) use ($endDate) {
+            ->when($endDate, function (Builder $query) use ($endDate) {
                 $query->where('attendances.created_at', '<=', $endDate);
             })
             // ソート
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        $course = Course::find($request->course_id);
-
-        return new StudentIndexResource([
-            'course' => $course,
-            'data' => $results,
-        ]);
+        return new StudentIndexResource($results);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -36,7 +36,7 @@ class StudentController extends Controller
 
         $loginId = Auth::guard('instructor')->user()->id;
 
-        if($courseId !== null){
+        if ($courseId !== null) {
             $instructorId = Course::findOrFail($request->course_id)->instructor_id;
             if ($loginId !== $instructorId) {
                 return response()->json([

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -32,15 +32,18 @@ class StudentController extends Controller
         $inputText = $request->input('input_text');
         $startDate = $request->input('start_date');
         $endDate = $request->input('end_date');
+        $courseId = $request->input('course_id');
 
         $loginId = Auth::guard('instructor')->user()->id;
-        $instructorId = Course::findOrFail($request->course_id)->instructor_id;
 
-        if ($loginId !== $instructorId) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized.',
-            ], 403);
+        if($courseId !== null){
+            $instructorId = Course::findOrFail($request->course_id)->instructor_id;
+            if ($loginId !== $instructorId) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Not authorized.',
+                ], 403);
+            }
         }
 
         $results = DB::table('attendances')
@@ -57,9 +60,12 @@ class StudentController extends Controller
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
             ->join('courses', 'attendances.course_id', '=', 'courses.id')
-            ->where('attendances.course_id', $request->course_id)
+            // course_idのクエリパラメータがある時のみ、条件にcourse_idを含める
+            ->when($courseId, function ($query) use ($courseId) {
+                $query->where('attendances.course_id', $courseId);
+            })
             // ログインしている講師IDを検索
-            ->where('courses.instructor_id', $request->instructor_id)
+            ->where('courses.instructor_id', $loginId)
             ->whereNull('attendances.deleted_at')
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
             ->when($inputText, function ($query) use ($inputText) {

--- a/app/Http/Requests/Instructor/StudentIndexRequest.php
+++ b/app/Http/Requests/Instructor/StudentIndexRequest.php
@@ -24,7 +24,7 @@ class StudentIndexRequest extends FormRequest
      */
     public function rules()
     {
-        return [ 
+        return [
             'course_id' => ['integer', 'exists:courses,id'],
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],

--- a/app/Http/Requests/Instructor/StudentIndexRequest.php
+++ b/app/Http/Requests/Instructor/StudentIndexRequest.php
@@ -7,13 +7,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StudentIndexRequest extends FormRequest
 {
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'course_id' => $this->route('course_id'),
-        ]);
-    }
-
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -31,8 +24,8 @@ class StudentIndexRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'course_id' => ['required', 'integer', 'exists:courses,id'],
+        return [ 
+            'course_id' => ['integer', 'exists:courses,id'],
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
             'sort_by' => ['string', new IndexSortByRule],

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources\Instructor;
 
-use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
 

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -23,11 +23,6 @@ class StudentIndexResource extends JsonResource
         $data = $this->resource['data'];
 
         return [
-            'course' => [
-                'course_id' => $course->id,
-                'image' => $course->image,
-                'title' => $course->title,
-            ],
             'pagination' => [
                 'page' => $data->currentPage(),
                 'total' => $data->total(),
@@ -36,14 +31,13 @@ class StudentIndexResource extends JsonResource
         ];
     }
 
-    private function mapStudents(Collection $results, Course $course)
+    private function mapStudents(Collection $results)
     {
-        return $results->map(function ($result) use ($course) {
+        return $results->map(function ($result) {
             return [
                 'student_id' => $result->student_id,
                 'nick_name' => $result->nick_name,
                 'email' => $result->email,
-                'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
                     'attendance_id' => $result->attendance_id,

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -27,7 +27,7 @@ class StudentIndexResource extends JsonResource
                 'page' => $data->currentPage(),
                 'total' => $data->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection(), $course),
+            'students' => $this->mapStudents($data->getCollection()),
         ];
     }
 

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Collection;
 
 class StudentIndexResource extends JsonResource
 {
+    /** @var \Illuminate\Pagination\LengthAwarePaginator */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *
@@ -15,18 +18,12 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-        /** @var \App\Model\Course $course */
-        $course = $this->resource['course'];
-
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
-        $data = $this->resource['data'];
-
         return [
             'pagination' => [
-                'page' => $data->currentPage(),
-                'total' => $data->total(),
+                'page' => $this->resource->currentPage(),
+                'total' => $this->resource->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection()),
+            'students' => $this->mapStudents($this->resource->getCollection()),
         ];
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -102,11 +102,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         });
                     });
 
-                    // 講師-講座-生徒
-                    Route::prefix('student')->group(function () {
-                        Route::get('index', 'Api\Instructor\StudentController@index');
-                    });
-
                     // 講師-講座-お知らせ
                     Route::prefix('notification')->group(function () {
                         Route::post('/', 'Api\Instructor\NotificationController@store');
@@ -133,6 +128,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
             // 講師-生徒
             Route::prefix('student')->group(function () {
+                // 講師-講座-生徒
+                Route::get('index', 'Api\Instructor\StudentController@index');
                 Route::get('{student_id}', 'Api\Instructor\StudentController@show');
                 Route::post('/', 'Api\Instructor\StudentController@store');
             });

--- a/tests/Feature/Api/Instructor/Student/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Student/IndexTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Student;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index?course_id=1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index?course_id=2');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index?course_id=aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes
#JKA-1091 Instructor/StudentControllerのindexメソッドの改修

## 概要
- 講師の主キーをwhere文に含め、その講師以外の講座は取得できなくなるようにする。

## 動作確認手順
- テストケース1
URL：http://localhost:8080/api/v1/instructor/course/:course_id/student/index?instructor_id=1
course_idが1の場合
instructor_idが1の場合（ログインしている講師）
student_idが1と2の生徒の情報が出力される
- テストケース2
URL：http://localhost:8080/api/v1/instructor/course/:course_id/student/index?instructor_id=2
course_idが1の場合
instructor_idが2の場合（ログインしていない講師）
レスポンスは通っているが、生徒は１つも出力されていない

レビュー修正後の動作確認
- テストケース1
URL：http://localhost:8080/api/v1/instructor/student/index?course_id=1
instructor_idが1でログイン
テスト結果：
student_idが1と2の生徒の情報が出力される

- テストケース2
URL：http://localhost:8080/api/v1/instructor/student/index?course_id=1
instructor_idが2でログイン
テスト結果：
"result": false,
"message": "Not authorized."
が出力される

- テストケース3
URL：http://localhost:8080/api/v1/instructor/student/index?per_page=10
instructor_idが1でログイン
course_idがなくても正常に動作できる
テスト結果：
student_idが1と2の生徒の情報が出力される

## 考慮して欲しいこと
## 確認して欲しいこと