### PR TITLE
JKA-1075：Manager/Instructor/CourseControllerとManager/Instructor/InstructorControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -29,10 +29,7 @@ class CourseController extends Controller
 
         // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
         if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Forbidden.',
-            ], 403);
+            throw new AuthorizationException('Forbidden.');
         }
 
         $courses = $queryService->getPaginatedCoursesByInstructorId($request->instructor_id, 5);

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -7,9 +7,9 @@ use App\Http\Requests\Manager\InstructorCourseIndexRequest;
 use App\Http\Resources\Manager\InstructorCourseIndexResource;
 use App\Model\Instructor;
 use App\Services\Course\QueryService;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class CourseController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -9,6 +9,7 @@ use App\Model\Instructor;
 use App\Services\Course\QueryService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class CourseController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers\Api\Manager\Instructor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\InstructorCourseIndexRequest;
 use App\Http\Resources\Manager\InstructorCourseIndexResource;
+use App\Model\Course;
 use App\Model\Instructor;
-use App\Services\Course\QueryService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
@@ -15,25 +15,24 @@ class CourseController extends Controller
 {
     /**
      * 講師-講座情報一覧取得API
-     *
-     * @return InstructorCourseIndexResource|JsonResponse
      */
-    public function index(InstructorCourseIndexRequest $request, QueryService $queryService)
+    public function index(InstructorCourseIndexRequest $request): InstructorCourseIndexResource|JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得
-        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->findOrFail($managerId);
+        assert($manager instanceof Instructor);
+
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
         // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
         if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
-        $courses = $queryService->getPaginatedCoursesByInstructorId($request->instructor_id, 5);
+        $courses = Course::where('instructor_id', $request->instructor_id)->paginate(5);
 
         return new InstructorCourseIndexResource($courses);
     }

--- a/tests/Feature/Api/Manager/Instructor/Course/IndexTest.php
+++ b/tests/Feature/Api/Manager/Instructor/Course/IndexTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Instructor\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師講座一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/2/course/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_配下の講師でない_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/2/course/index');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/aaa/course/index');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'instructor_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1075：Manager/Instructor/CourseControllerとManager/Instructor/InstructorControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 動作確認テスト
Postmanにて修正箇所に対する動作確認を実施。

### Manager/Instructor/CourseController
### indexメソッド
1. 正常：指定した講師IDがログイン中の講師または配下の講師と一致する場合、講座情報を取得できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/instructor/1/course/index
 - HTTPメソッド：GET
 - 結果：200 OK

2. 異常：指定した講師IDがログイン中の講師または配下の講師と一致しない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/instructor/4/course/index
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
"message": "Forbidden."
***
### Manager/Instructor/InstructorController
こちらのファイルは修正対象となる箇所がありませんでした。