### PR TITLE
JKA-1074: Instructor/InstructorControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用 (Shinya)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -7,8 +7,8 @@ use App\Exceptions\DuplicateAuthorizationTokenException;
 use App\Exceptions\ExpiredAuthorizationCodeException;
 use App\Exceptions\TryCountOverAuthorizationCodeException;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\InstructorPatchRequest;
 use App\Http\Requests\Instructor\InstructorPostRequest;
+use App\Http\Requests\Instructor\InstructorUpdateRequest;
 use App\Http\Requests\Instructor\UserAuthenticationRequest;
 use App\Http\Resources\Instructor\InstructorShowResource;
 use App\Mail\AuthenticationConfirmationMail;
@@ -114,7 +114,7 @@ class InstructorController extends Controller
     /**
      * 講師更新API
      */
-    public function update(InstructorPatchRequest $request): JsonResponse
+    public function update(InstructorUpdateRequest $request): JsonResponse
     {
         try {
             $instructor = Auth::user();

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -2,34 +2,35 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use App\Exceptions\DuplicateAuthorizationCodeException;
-use App\Exceptions\DuplicateAuthorizationTokenException;
-use App\Exceptions\ExpiredAuthorizationCodeException;
-use App\Exceptions\TryCountOverAuthorizationCodeException;
-use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\InstructorPatchRequest;
-use App\Http\Requests\Instructor\InstructorPostRequest;
-use App\Http\Requests\Instructor\UserAuthenticationRequest;
-use App\Http\Resources\Instructor\InstructorShowResource;
-use App\Mail\AuthenticationConfirmationMail;
-use App\Model\Instructor;
-use App\Model\ManageInstructor;
-use App\Model\TemporaryInstructor;
-use App\Services\Auth\CredentialGeneratorService;
-use App\Services\Instructor\QueryService;
-use App\Services\Instructor\VerifyCodeService;
-use Carbon\CarbonImmutable;
 use Exception;
-use Illuminate\Http\JsonResponse;
+use RuntimeException;
+use App\Model\Instructor;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
+use App\Model\ManageInstructor;
+use Illuminate\Http\JsonResponse;
+use App\Model\TemporaryInstructor;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
-use RuntimeException;
+use App\Services\Instructor\QueryService;
+use App\Mail\AuthenticationConfirmationMail;
+use App\Services\Instructor\VerifyCodeService;
+use App\Services\Auth\CredentialGeneratorService;
+use Illuminate\Auth\Access\AuthorizationException;
+use App\Exceptions\ExpiredAuthorizationCodeException;
+use App\Exceptions\DuplicateAuthorizationCodeException;
+use App\Http\Requests\Instructor\InstructorPostRequest;
+use App\Exceptions\DuplicateAuthorizationTokenException;
+use App\Http\Requests\Instructor\InstructorPatchRequest;
+use App\Http\Resources\Instructor\InstructorShowResource;
+use App\Exceptions\TryCountOverAuthorizationCodeException;
+use App\Http\Requests\Instructor\UserAuthenticationRequest;
 
 class InstructorController extends Controller
 {
@@ -92,19 +93,11 @@ class InstructorController extends Controller
         } catch (DuplicateAuthorizationCodeException $e) {
             DB::rollBack();
             Log::error($e->getMessage().' email: '.$request->email);
-
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to generate unique authorization code.',
-            ], 400);
+            throw $e;
         } catch (DuplicateAuthorizationTokenException $e) {
             DB::rollBack();
             Log::error($e->getMessage().' email: '.$request->email);
-
-            return response()->json([
-                'result' => false,
-                'message' => 'Failed to generate unique authorization token.',
-            ], 400);
+            throw $e;
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
@@ -149,10 +142,7 @@ class InstructorController extends Controller
             ]);
         } catch (RuntimeException $e) {
             Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+            throw $e;
         }
     }
 
@@ -176,28 +166,18 @@ class InstructorController extends Controller
                     code: $request->code
                 );
                 if (! $result) {
-                    // 認証コード不一致
-                    return response()->json([
-                        'result' => false,
-                        'message' => 'Not match authentication code.',
-                    ], 400);
+                    throw new AuthorizationException(
+                        'Not match authentication code.'
+                    );
                 }
             } catch (ExpiredAuthorizationCodeException $e) {
                 // 仮登録情報を物理削除
                 $temporaryInstructor->delete();
-
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Expired authorization period.',
-                ], 400);
+                throw $e;
             } catch (TryCountOverAuthorizationCodeException $e) {
                 // 仮登録情報を物理削除
                 $temporaryInstructor->delete();
-
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Not match authorization code three times.',
-                ], 400);
+                throw $e;
             }
 
             // 認証成功

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -2,35 +2,34 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use App\Exceptions\DuplicateAuthorizationCodeException;
-use App\Exceptions\DuplicateAuthorizationTokenException;
-use App\Exceptions\ExpiredAuthorizationCodeException;
-use App\Exceptions\TryCountOverAuthorizationCodeException;
-use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\InstructorPatchRequest;
-use App\Http\Requests\Instructor\InstructorPostRequest;
-use App\Http\Requests\Instructor\UserAuthenticationRequest;
-use App\Http\Resources\Instructor\InstructorShowResource;
-use App\Mail\AuthenticationConfirmationMail;
-use App\Model\Instructor;
-use App\Model\ManageInstructor;
-use App\Model\TemporaryInstructor;
-use App\Services\Auth\CredentialGeneratorService;
-use App\Services\Instructor\QueryService;
-use App\Services\Instructor\VerifyCodeService;
-use Carbon\CarbonImmutable;
 use Exception;
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Http\JsonResponse;
+use RuntimeException;
+use App\Model\Instructor;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
+use App\Model\ManageInstructor;
+use Illuminate\Http\JsonResponse;
+use App\Model\TemporaryInstructor;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
-use RuntimeException;
+use App\Services\Instructor\QueryService;
+use App\Mail\AuthenticationConfirmationMail;
+use App\Services\Instructor\VerifyCodeService;
+use App\Services\Auth\CredentialGeneratorService;
+use App\Exceptions\ExpiredAuthorizationCodeException;
+use App\Exceptions\DuplicateAuthorizationCodeException;
+use App\Http\Requests\Instructor\InstructorPostRequest;
+use App\Exceptions\DuplicateAuthorizationTokenException;
+use App\Http\Requests\Instructor\InstructorPatchRequest;
+use App\Http\Resources\Instructor\InstructorShowResource;
+use App\Exceptions\TryCountOverAuthorizationCodeException;
+use App\Http\Requests\Instructor\UserAuthenticationRequest;
 
 class InstructorController extends Controller
 {
@@ -93,11 +92,17 @@ class InstructorController extends Controller
         } catch (DuplicateAuthorizationCodeException $e) {
             DB::rollBack();
             Log::error($e->getMessage().' email: '.$request->email);
-            throw $e;
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to generate unique authorization code.',
+            ], 400);
         } catch (DuplicateAuthorizationTokenException $e) {
             DB::rollBack();
             Log::error($e->getMessage().' email: '.$request->email);
-            throw $e;
+            return response()->json([
+                'result' => false,
+                'message' => 'Failed to generate unique authorization token.',
+            ], 400);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
@@ -140,7 +145,7 @@ class InstructorController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
         }
@@ -166,18 +171,26 @@ class InstructorController extends Controller
                     code: $request->code
                 );
                 if (! $result) {
-                    throw new AuthorizationException(
-                        'Not match authentication code.'
-                    );
+                   // 認証コード不一致
+                   return response()->json([
+                    'result' => false,
+                    'message' => 'Not match authentication code.',
+                    ], 400);
                 }
             } catch (ExpiredAuthorizationCodeException $e) {
                 // 仮登録情報を物理削除
                 $temporaryInstructor->delete();
-                throw $e;
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Expired authorization period.',
+                ], 400);
             } catch (TryCountOverAuthorizationCodeException $e) {
                 // 仮登録情報を物理削除
                 $temporaryInstructor->delete();
-                throw $e;
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Not match authorization code three times.',
+                ], 400);
             }
 
             // 認証成功

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -2,34 +2,33 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use Exception;
-use RuntimeException;
-use App\Model\Instructor;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
-use App\Model\ManageInstructor;
-use Illuminate\Http\JsonResponse;
-use App\Model\TemporaryInstructor;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
+use App\Exceptions\DuplicateAuthorizationCodeException;
+use App\Exceptions\DuplicateAuthorizationTokenException;
+use App\Exceptions\ExpiredAuthorizationCodeException;
+use App\Exceptions\TryCountOverAuthorizationCodeException;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\InstructorPatchRequest;
+use App\Http\Requests\Instructor\InstructorPostRequest;
+use App\Http\Requests\Instructor\UserAuthenticationRequest;
+use App\Http\Resources\Instructor\InstructorShowResource;
+use App\Mail\AuthenticationConfirmationMail;
+use App\Model\Instructor;
+use App\Model\ManageInstructor;
+use App\Model\TemporaryInstructor;
+use App\Services\Auth\CredentialGeneratorService;
+use App\Services\Instructor\QueryService;
+use App\Services\Instructor\VerifyCodeService;
+use Carbon\CarbonImmutable;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
-use App\Services\Instructor\QueryService;
-use App\Mail\AuthenticationConfirmationMail;
-use App\Services\Instructor\VerifyCodeService;
-use App\Services\Auth\CredentialGeneratorService;
-use App\Exceptions\ExpiredAuthorizationCodeException;
-use App\Exceptions\DuplicateAuthorizationCodeException;
-use App\Http\Requests\Instructor\InstructorPostRequest;
-use App\Exceptions\DuplicateAuthorizationTokenException;
-use App\Http\Requests\Instructor\InstructorPatchRequest;
-use App\Http\Resources\Instructor\InstructorShowResource;
-use App\Exceptions\TryCountOverAuthorizationCodeException;
-use App\Http\Requests\Instructor\UserAuthenticationRequest;
+use Illuminate\Support\Str;
 
 class InstructorController extends Controller
 {
@@ -92,6 +91,7 @@ class InstructorController extends Controller
         } catch (DuplicateAuthorizationCodeException $e) {
             DB::rollBack();
             Log::error($e->getMessage().' email: '.$request->email);
+
             return response()->json([
                 'result' => false,
                 'message' => 'Failed to generate unique authorization code.',
@@ -99,6 +99,7 @@ class InstructorController extends Controller
         } catch (DuplicateAuthorizationTokenException $e) {
             DB::rollBack();
             Log::error($e->getMessage().' email: '.$request->email);
+
             return response()->json([
                 'result' => false,
                 'message' => 'Failed to generate unique authorization token.',
@@ -171,15 +172,16 @@ class InstructorController extends Controller
                     code: $request->code
                 );
                 if (! $result) {
-                   // 認証コード不一致
-                   return response()->json([
-                    'result' => false,
-                    'message' => 'Not match authentication code.',
+                    // 認証コード不一致
+                    return response()->json([
+                        'result' => false,
+                        'message' => 'Not match authentication code.',
                     ], 400);
                 }
             } catch (ExpiredAuthorizationCodeException $e) {
                 // 仮登録情報を物理削除
                 $temporaryInstructor->delete();
+
                 return response()->json([
                     'result' => false,
                     'message' => 'Expired authorization period.',
@@ -187,6 +189,7 @@ class InstructorController extends Controller
             } catch (TryCountOverAuthorizationCodeException $e) {
                 // 仮登録情報を物理削除
                 $temporaryInstructor->delete();
+
                 return response()->json([
                     'result' => false,
                     'message' => 'Not match authorization code three times.',

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -2,35 +2,35 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use Exception;
-use RuntimeException;
-use App\Model\Instructor;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
-use App\Model\ManageInstructor;
-use Illuminate\Http\JsonResponse;
-use App\Model\TemporaryInstructor;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
+use App\Exceptions\DuplicateAuthorizationCodeException;
+use App\Exceptions\DuplicateAuthorizationTokenException;
+use App\Exceptions\ExpiredAuthorizationCodeException;
+use App\Exceptions\TryCountOverAuthorizationCodeException;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\InstructorPatchRequest;
+use App\Http\Requests\Instructor\InstructorPostRequest;
+use App\Http\Requests\Instructor\UserAuthenticationRequest;
+use App\Http\Resources\Instructor\InstructorShowResource;
+use App\Mail\AuthenticationConfirmationMail;
+use App\Model\Instructor;
+use App\Model\ManageInstructor;
+use App\Model\TemporaryInstructor;
+use App\Services\Auth\CredentialGeneratorService;
+use App\Services\Instructor\QueryService;
+use App\Services\Instructor\VerifyCodeService;
+use Carbon\CarbonImmutable;
+use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
-use App\Services\Instructor\QueryService;
-use App\Mail\AuthenticationConfirmationMail;
-use App\Services\Instructor\VerifyCodeService;
-use App\Services\Auth\CredentialGeneratorService;
-use Illuminate\Auth\Access\AuthorizationException;
-use App\Exceptions\ExpiredAuthorizationCodeException;
-use App\Exceptions\DuplicateAuthorizationCodeException;
-use App\Http\Requests\Instructor\InstructorPostRequest;
-use App\Exceptions\DuplicateAuthorizationTokenException;
-use App\Http\Requests\Instructor\InstructorPatchRequest;
-use App\Http\Resources\Instructor\InstructorShowResource;
-use App\Exceptions\TryCountOverAuthorizationCodeException;
-use App\Http\Requests\Instructor\UserAuthenticationRequest;
+use Illuminate\Support\Str;
+use RuntimeException;
 
 class InstructorController extends Controller
 {

--- a/app/Http/Requests/Instructor/InstructorUpdateRequest.php
+++ b/app/Http/Requests/Instructor/InstructorUpdateRequest.php
@@ -6,7 +6,7 @@ use App\Rules\InstructorUniqueEmailRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
-class InstructorPatchRequest extends FormRequest
+class InstructorUpdateRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -16,13 +16,6 @@ class InstructorPatchRequest extends FormRequest
     public function authorize()
     {
         return true;
-    }
-
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'instructor_id' => Auth::id(),
-        ]);
     }
 
     /**
@@ -37,7 +30,6 @@ class InstructorPatchRequest extends FormRequest
             'last_name' => ['required', 'string', 'max:50'],
             'first_name' => ['required', 'string', 'max:50'],
             'email' => ['required', 'email', new InstructorUniqueEmailRule(Auth::user()->email), 'max:255'],
-            'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
             'profile_image' => ['mimes:jpg,png', 'max:2048'],
         ];
     }

--- a/database/seeders/InstructorSeeder.php
+++ b/database/seeders/InstructorSeeder.php
@@ -61,17 +61,6 @@ class InstructorSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
-            [
-                'nick_name' => 'Shin',
-                'last_name' => 'Naka',
-                'first_name' => 'Shinya',
-                'email' => 'test_instructor5@example.com',
-                'password' => Hash::make('password'),
-                'type' => 'manager',
-                'profile_image' => null,
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
-            ],
         ]);
     }
 }

--- a/database/seeders/InstructorSeeder.php
+++ b/database/seeders/InstructorSeeder.php
@@ -61,6 +61,17 @@ class InstructorSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'nick_name' => 'Shin',
+                'last_name' => 'Naka',
+                'first_name' => 'Shinya',
+                'email' => 'test_instructor5@example.com',
+                'password' => Hash::make('password'),
+                'type' => 'manager',
+                'profile_image' => null,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }

--- a/tests/Feature/Api/Instructor/UpdateTest.php
+++ b/tests/Feature/Api/Instructor/UpdateTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/instructor/update', [
+            'nick_name' => 'test',
+            'last_name' => 'test',
+            'first_name' => 'test',
+            'email' => 'test_update@exmaple.com',
+            'profile_image' => $file,
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('instructors', [
+            'id' => 1,
+            'nick_name' => 'test',
+            'last_name' => 'test',
+            'first_name' => 'test',
+            'email' => 'test_update@exmaple.com',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->post('/api/v1/instructor/update', [
+            'nick_name' => '',
+            'last_name' => '',
+            'first_name' => '',
+            'email' => '',
+            'profile_image' => '',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'nick_name',
+            'last_name',
+            'first_name',
+            'email',
+            'profile_image',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- JKA-1074: Instructor/InstructorControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 動作確認手順
- instructor/instructorController
  - storeメソッド: DuplicateAuthorizationCodeExceptionとDuplicateAuthorizationTokenExceptionを発生させ、Postmanで意図したエラーが返ることを確認。
  - update: RuntimeExceptionを発生させ、Postmanで意図したエラーが返ることを確認。
  - verifyCodeメソッド: 認証コード不一致で、Psotmanで意図したエラーが返ることを確認。ExpiredAuthorizationCodeExceptionとTryCountOverAuthorizationCodeException を発生させ、Postmanで意図したエラーが返ることを確認。
	