### PR TITLE
JKA-1099 Instructor/NotificationControlle未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（竹内）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -6,10 +6,10 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\NotificationBulkDeleteRequest;
 use App\Http\Requests\Instructor\NotificationDeleteRequest;
 use App\Http\Requests\Instructor\NotificationIndexRequest;
+use App\Http\Requests\Instructor\NotificationPutRequest;
 use App\Http\Requests\Instructor\NotificationPutTypeRequest;
 use App\Http\Requests\Instructor\NotificationShowRequest;
 use App\Http\Requests\Instructor\NotificationStoreRequest;
-use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Model\Course;
@@ -65,7 +65,7 @@ class NotificationController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         if ($course->instructor_id !== Auth::guard('instructor')->user()->id) {
-            throw new AuthorizationException('Invalid instructor_id.');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         DB::beginTransaction();
@@ -94,12 +94,12 @@ class NotificationController extends Controller
     /**
      * お知らせ更新API
      */
-    public function update(NotificationUpdateRequest $request): JsonResponse
+    public function put(NotificationPutRequest $request): JsonResponse
     {
         $notification = Notification::findOrFail($request->notification_id);
 
         if ($notification->instructor_id !== Auth::guard('instructor')->user()->id) {
-            throw new AuthorizationException('Invalid instructor_id.');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         DB::beginTransaction();

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Http\Resources\Instructor\NotificationShowResource;
 use App\Model\Notification;
+use App\Model\Course;
 use App\Model\ViewedOnceNotification;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -61,19 +62,33 @@ class NotificationController extends Controller
      */
     public function store(NotificationStoreRequest $request): JsonResponse
     {
-        Notification::create([
-            'course_id' => $request->course_id,
-            'instructor_id' => Auth::guard('instructor')->user()->id,
-            'title' => $request->title,
-            'type' => $request->type,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-            'content' => $request->content,
-        ]);
+        $course = Course::findOrFail($request->course_id);
 
-        return response()->json([
-            'result' => true,
-        ]);
+        if ($course->instructor_id !== Auth::guard('instructor')->user()->id) {
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
+        DB::beginTransaction();
+        try {
+            Notification::create([
+                'course_id' => $request->course_id,
+                'instructor_id' => Auth::guard('instructor')->user()->id,
+                'title' => $request->title,
+                'type' => $request->type,
+                'start_date' => $request->start_date,
+                'end_date' => $request->end_date,
+                'content' => $request->content,
+            ]);
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch(Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
     }
 
     /**
@@ -82,18 +97,31 @@ class NotificationController extends Controller
     public function update(NotificationUpdateRequest $request): JsonResponse
     {
         $notification = Notification::findOrFail($request->notification_id);
-        $notification->fill([
-            'type' => $request->type,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-            'title' => $request->title,
-            'content' => $request->content,
-        ])
-            ->save();
 
-        return response()->json([
-            'result' => true,
-        ]);
+        if ($notification->instructor_id !== Auth::guard('instructor')->user()->id) {
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
+        DB::beginTransaction();
+        try {
+            $notification->fill([
+                'type' => $request->type,
+                'start_date' => $request->start_date,
+                'end_date' => $request->end_date,
+                'title' => $request->title,
+                'content' => $request->content,
+            ])
+                ->save();
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch(Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -12,8 +12,8 @@ use App\Http\Requests\Instructor\NotificationStoreRequest;
 use App\Http\Requests\Instructor\NotificationUpdateRequest;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Http\Resources\Instructor\NotificationShowResource;
-use App\Model\Notification;
 use App\Model\Course;
+use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -84,7 +84,7 @@ class NotificationController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
             throw $e;
@@ -117,7 +117,7 @@ class NotificationController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
             throw $e;

--- a/app/Http/Requests/Instructor/NotificationPutRequest.php
+++ b/app/Http/Requests/Instructor/NotificationPutRequest.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests\Instructor;
 use App\Rules\NotificationUpdateStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 
-class NotificationUpdateRequest extends FormRequest
+class NotificationPutRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,7 +144,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::delete('/', 'Api\Instructor\NotificationController@bulkDelete');
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', 'Api\Instructor\NotificationController@show');
-                    Route::patch('/', 'Api\Instructor\NotificationController@update');
+                    Route::put('/', 'Api\Instructor\NotificationController@put');
                     Route::delete('/', 'Api\Instructor\NotificationController@delete');
                 });
             });

--- a/tests/Feature/Api/Instructor/Notification/PutTest.php
+++ b/tests/Feature/Api/Instructor/Notification/PutTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/1', [
+            'title' => 'title',
+            'type' => 'once',
+            'start_date' => '2024-01-01 00:00:00',
+            'end_date' => '2024-01-02 00:00:00',
+            'content' => 'content',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('notifications', [
+            'id' => 1,
+            'title' => 'title',
+            'type' => 2,
+            'start_date' => '2024-01-01 00:00:00',
+            'end_date' => '2024-01-02 00:00:00',
+            'content' => 'content',
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/1', [
+            'title' => 'title',
+            'type' => 'once',
+            'start_date' => '2024-01-01 00:00:00',
+            'end_date' => '2024-01-02 00:00:00',
+            'content' => 'content',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/aaaa', [
+            'title' => '',
+            'type' => '',
+            'start_date' => '',
+            'end_date' => '',
+            'content' => '',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'notification_id',
+            'title',
+            'type',
+            'start_date',
+            'end_date',
+            'content',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Notification/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Notification/StoreTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/notification', [
+            'title' => 'title',
+            'type' => 'always',
+            'start_date' => '2022-01-01 00:00:00',
+            'end_date' => '2022-01-02 00:00:00',
+            'content' => 'content',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('notifications', [
+            'course_id' => 1,
+            'title' => 'title',
+            'type' => 1,
+            'start_date' => '2022-01-01 00:00:00',
+            'end_date' => '2022-01-02 00:00:00',
+            'content' => 'content',
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/notification', [
+            'title' => 'title',
+            'type' => 'always',
+            'start_date' => '2022-01-01 00:00:00',
+            'end_date' => '2022-01-02 00:00:00',
+            'content' => 'content',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/aaa/notification', [
+            'title' => '',
+            'type' => '',
+            'start_date' => '',
+            'end_date' => '',
+            'content' => '',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'title',
+            'type',
+            'start_date',
+            'end_date',
+            'content',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
Instructor/NotificationControlle未対応部分にthrow new AuthorizationExceptionとthrow $eの適用

## 動作確認手順

### Instructor/NotificationController
### storeメソッド
1. 正常：自分の講座の場合、お知らせを登録できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/notification
 - HTTPメソッド：POST
 - 結果：200 OK

2. 異常：自分の講座ではない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/notification
 - HTTPメソッド：POST
 - 結果：403 Forbidden  
"message": "Invalid instructor_id."

3. try {} の{}の中に一時的に書いて、テストする（テスト後は削除する）
- instructor_id=1でログイン
- URL：http://localhost:8080/api/v1/instructor/course/1/notification
- HTTPメソッド：POST
- 結果：500　Internal Server Error
"message": "テスト用の例外が発生しました"


### updateメソッド
1. 正常：自分の講座の場合、お知らせを更新できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/notification/1
 - HTTPメソッド：PATCH
 - 結果：200 OK

2. 異常：自分の講座ではない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/notification/1
 - HTTPメソッド：PATCH
 - 結果：403 Forbidden  
"message": "Invalid instructor_id."

3. try {} の{}の中に一時的に書いて、テストする（テスト後は削除する）
- instructor_id=1でログイン
- URL：http://localhost:8080/api/v1/instructor/notification/1
- HTTPメソッド：PATCH
- 結果：500　Internal Server Error
"message": "テスト用の例外が発生しました"