### PR TITLE
JKA-1086 Ruleで非推奨の警告対処分

### DIFF
--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -15,9 +15,10 @@ class AttendancePeriodRule implements ValidationRule
      * @param  \Closure  $fail
      * @return void
      */
-    public function validate($attribute, $value, $fail): void
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
     {
-        if (!in_array(
+        if (
+            !in_array(
             $value,
             [
                 Attendance::PERIOD_WEEK,

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -10,24 +10,19 @@ class AttendancePeriodRule implements ValidationRule
 {
     /**
      * バリデーションの実行。
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  Closure  $fail
-     * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (
-            !in_array(
-            $value,
-            [
-                Attendance::PERIOD_WEEK,
-                Attendance::PERIOD_MONTH,
-                Attendance::PERIOD_YEAR,
-            ],
-            true
-        )) {
+            ! in_array(
+                $value,
+                [
+                    Attendance::PERIOD_WEEK,
+                    Attendance::PERIOD_MONTH,
+                    Attendance::PERIOD_YEAR,
+                ],
+                true
+            )) {
             // エラーを返す
             $fail('The :attribute must be a valid attendance period.');
         }

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -3,18 +3,12 @@
 namespace App\Rules;
 
 use App\Model\Attendance;
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
 class AttendancePeriodRule implements ValidationRule
 {
-    /**
-     * バリデーションの実行。
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  \Closure  $fail
-     */
-    public function validate($attribute, $value, $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! in_array(
             $value,

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -3,20 +3,10 @@
 namespace App\Rules;
 
 use App\Model\Attendance;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Validation\Rule;
 
 class AttendancePeriodRule implements Rule
 {
-    /**
-     * Create a new rule instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
     /**
      * Determine if the validation rule passes.
      *
@@ -26,21 +16,15 @@ class AttendancePeriodRule implements Rule
      */
     public function passes($attribute, $value)
     {
-        if (
-            in_array(
-                $value,
-                [
-                    Attendance::PERIOD_WEEK,
-                    Attendance::PERIOD_MONTH,
-                    Attendance::PERIOD_YEAR,
-                ],
-                true
-            )
-        ) {
-            return true;
-        }
-
-        return false;
+        return in_array(
+            $value,
+            [
+                Attendance::PERIOD_WEEK,
+                Attendance::PERIOD_MONTH,
+                Attendance::PERIOD_YEAR,
+            ],
+            true
+        );
     }
 
     /**

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -13,11 +13,10 @@ class AttendancePeriodRule implements ValidationRule
      * @param  string  $attribute
      * @param  mixed  $value
      * @param  \Closure  $fail
-     * @return void
      */
     public function validate($attribute, $value, $fail): void
     {
-        if (!in_array(
+        if (! in_array(
             $value,
             [
                 Attendance::PERIOD_WEEK,

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -27,7 +27,8 @@ class AttendancePeriodRule implements ValidationRule
                 Attendance::PERIOD_YEAR,
             ],
             true
-        )) {
+            )
+        ) {
             // エラーを返す
             $fail('The :attribute must be a valid attendance period.');
         }

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -3,20 +3,21 @@
 namespace App\Rules;
 
 use App\Model\Attendance;
-use Illuminate\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class AttendancePeriodRule implements Rule
+class AttendancePeriodRule implements ValidationRule
 {
     /**
-     * Determine if the validation rule passes.
+     * バリデーションの実行。
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  \Closure  $fail
+     * @return void
      */
-    public function passes($attribute, $value)
+    public function validate($attribute, $value, $fail): void
     {
-        return in_array(
+        if (!in_array(
             $value,
             [
                 Attendance::PERIOD_WEEK,
@@ -24,16 +25,9 @@ class AttendancePeriodRule implements Rule
                 Attendance::PERIOD_YEAR,
             ],
             true
-        );
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'Invalid Period.';
+        )) {
+            // エラーを返す
+            $fail('The :attribute must be a valid attendance period.');
+        }
     }
 }

--- a/app/Rules/AttendancePeriodRule.php
+++ b/app/Rules/AttendancePeriodRule.php
@@ -14,14 +14,14 @@ class AttendancePeriodRule implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (
-            !in_array(
-            $value,
-            [
-                Attendance::PERIOD_WEEK,
-                Attendance::PERIOD_MONTH,
-                Attendance::PERIOD_YEAR,
-            ],
-            true
+            ! in_array(
+                $value,
+                [
+                    Attendance::PERIOD_WEEK,
+                    Attendance::PERIOD_MONTH,
+                    Attendance::PERIOD_YEAR,
+                ],
+                true
             )
         ) {
             // エラーを返す

--- a/tests/Feature/Api/Manager/Attendance/LoginRateTest.php
+++ b/tests/Feature/Api/Manager/Attendance/LoginRateTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LoginRateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_ログイン率取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/1/attendance/week');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/1/attendance/week');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/aaa/attendance/bbb');
+
+        $response->dump();
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'period',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
「AttendancePeriodRule.php」の「class AttendancePeriodRule implements Rule」のRuleで非推奨の警告がエディタ上で出ているので対処する。

## 動作確認テスト
・エディタの問題に非推奨の警告などが出ていないことを確認する。
・Postmanでも以下を確認する。

1. バリデーションに失敗するケース
無効なデータを送信し、適切なエラーメッセージ（例: "Invalid Period"）が返されることを確認。

2. バリデーションに成功するケース
有効なデータを送信し、正常なレスポンスが返されることを確認。