### PR TITLE
JKA-1093(親:1040)リクエストフォームの作成(西山しょうこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
+use App\Http\Requests\Manager\AttendanceShowStatusRequest;
 use App\Http\Requests\Manager\AttendanceStatusRequest;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\LoginRateRequest;
@@ -220,7 +221,7 @@ class AttendanceController extends Controller
     /**
      * 完了済みレッスン数と完了済みチャプター数取得API
      */
-    public function showStatus(Request $request, int $course_id, string $period)
+    public function showStatus(AttendanceShowStatusRequest $request): JsonResponse
     {
         // 現在ログインしているinstructorのidを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -230,7 +231,7 @@ class AttendanceController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
-        $course = Course::findOrFail($course_id);
+        $course = Course::findOrFail($request->course_id);
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             // 自分と配下の講師の講座でない場合はエラーを返す
             throw new AuthorizationException(
@@ -239,7 +240,8 @@ class AttendanceController extends Controller
         }
 
         // 出席情報（関連する情報を含む）を取得
-        $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $course_id)->get();
+        $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+        $period = $request->period;
 
         // 完了したレッスンの数を取得
         $completedLessonsCount = $attendances->flatMap(function (Attendance $attendance) use ($period) {

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\AttendanceDeleteRequest;
-use App\Http\Requests\Manager\AttendanceShowStatusRequest;
 use App\Http\Requests\Manager\AttendanceShowRequest;
+use App\Http\Requests\Manager\AttendanceShowStatusRequest;
 use App\Http\Requests\Manager\AttendanceStatusRequest;
 use App\Http\Requests\Manager\AttendanceStoreRequest;
 use App\Http\Requests\Manager\LoginRateRequest;
@@ -20,7 +20,6 @@ use App\Model\LessonAttendance;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;

--- a/app/Rules/LessonAttendancePeriodRule.php
+++ b/app/Rules/LessonAttendancePeriodRule.php
@@ -3,31 +3,23 @@
 namespace App\Rules;
 
 use App\Model\LessonAttendance;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class LessonAttendancePeriodRule implements Rule
+class LessonAttendancePeriodRule implements ValidationRule
 {
     /**
-     * Create a new rule instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (
-            in_array(
+            !in_array(
                 $value,
                 [
                     LessonAttendance::PERIOD_TODAY,
@@ -36,19 +28,7 @@ class LessonAttendancePeriodRule implements Rule
                 true
             )
         ) {
-            return true;
+            $fail('Invalid Period.');
         }
-
-        return false;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'Invalid Period.';
     }
 }

--- a/app/Rules/LessonAttendancePeriodRule.php
+++ b/app/Rules/LessonAttendancePeriodRule.php
@@ -25,7 +25,7 @@ class LessonAttendancePeriodRule implements ValidationRule
                 true
             )
         ) {
-            $fail('Invalid Period.');
+            $fail('The :attribute must be a valid attendance period.');
         }
     }
 }

--- a/app/Rules/LessonAttendancePeriodRule.php
+++ b/app/Rules/LessonAttendancePeriodRule.php
@@ -11,15 +11,12 @@ class LessonAttendancePeriodRule implements ValidationRule
     /**
      * Run the validation rule.
      *
-     * @param  string  $attribute
-     * @param  mixed  $value
      * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
-     * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (
-            !in_array(
+            ! in_array(
                 $value,
                 [
                     LessonAttendance::PERIOD_TODAY,

--- a/tests/Feature/Api/Manager/Attendance/ShowStatusTest.php
+++ b/tests/Feature/Api/Manager/Attendance/ShowStatusTest.php
@@ -50,9 +50,39 @@ class ShowStatusTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->getJson('/api/v1/manager/course/1/attendance/status/invalid');
+        $response = $this->getJson('/api/v1/manager/course/1000/attendance/status/invalid');
 
         // assert
-        $response->assertStatus(500);
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'period',
+        ]);
+    }
+
+    public function test_配下ではない講師の講座_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/4/attendance/status/today');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_マネージャーではない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/2/attendance/status/today');
+
+        // assert
+        $response->assertStatus(403);
     }
 }


### PR DESCRIPTION
## issue
- JKA-1093：リクエストフォームの作成
**- 【追加】LessonAttendancePeriodRuleをLaravel11の書き方へ変更**

## 概要
- 「親タスクJKA-1040：マネージャー側 本日or当月のレッスン・チャプター完了数の取得APIを統合して１つにする」　のリクエストフォームを作成
**- 【追加】LessonAttendancePeriodRuleをLaravel11の書き方へ変更**

## 動作確認テスト

**【追加】LessonAttendancePeriodRuleの記載を変更後に、下記テストを同様に行い、同様の結果を得ました。**

Postmanにて動作確認を実施。（前回タスクjka-1092と同じテスト）

### **1. 正常系**

- 正しいコースidと期間でテスト
- instructor_id=1（マネージャー）でログイン
- マネージャー作成course（ID：1）でtodayとmonthのテスト。管理下のインストラクター作成course（ID：2）でtodayとmonthのテスト。

URL：[http://localhost:8080/api/v1/manager/course/1/attendance/status/today](http://localhost:8080/api/v1/manager/course/1/attendance/status/month)

URL：http://localhost:8080/api/v1/manager/course/1/attendance/status/month

URL：[http://localhost:8080/api/v1/manager/course/2/attendance/status/today](http://localhost:8080/api/v1/manager/course/1/attendance/status/month)

URL：[http://localhost:8080/api/v1/manager/course/2/attendance/status/month](http://localhost:8080/api/v1/manager/course/1/attendance/status/month)

- HTTPメソッド：GET
- 結果：　全て　200 OK

```json
{
    "completed_lessons_count": 4,
    "completed_chapters_count": 2
}

```
など。


### **2. 異常系**

**①管理下でない講師が作成したコースでテスト**

- courseID：4で、指定期間は正しいものを入力

URL：http://localhost:8080/api/v1/manager/course/4/attendance/status/month

- HTTPメソッド：GET
- 結果：403 Forbidden   "message": "Forbidden, not allowed to access this course."

**②指定期間外の値を渡してテスト**

- コースは正しい値を入力し、期間は指定外のものを入力

URL：[http://localhost:8080/api/v1/manager/course/1/attendance/status/yesterday](http://localhost:8080/api/v1/manager/course/4/attendance/status/month)

- HTTPメソッド：GET
- 結果：　 422  Unprocessable content  
    ~~"message": "Invalid period"~~
**"message": "The period must be a valid attendance period."**