### PR TITLE
JKA-1106 Instructor内のcontrollerにおいてQueryServiceを使わない形に変更する (Shinya)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -13,7 +13,6 @@ use App\Http\Resources\Instructor\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
-use App\Services\Course\QueryService;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -28,10 +27,10 @@ class CourseController extends Controller
     /**
      * 講座一覧取得API
      */
-    public function index(QueryService $queryService): CourseIndexResource
+    public function index(): CourseIndexResource
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $courses = $queryService->getCoursesByInstructorId($instructorId);
+        $courses = Course::where('instructor_id', $instructorId)->get();
 
         return new CourseIndexResource($courses);
     }
@@ -39,9 +38,10 @@ class CourseController extends Controller
     /**
      * 講座取得API
      */
-    public function show(CourseShowRequest $request, QueryService $queryService): CourseShowResource
+    public function show(CourseShowRequest $request): CourseShowResource
     {
-        $course = $queryService->getCourse($request->course_id);
+        $course = Course::with(['chapters.lessons'])->findOrFail($request->course_id);
+        assert($course instanceof Course);
 
         return new CourseShowResource($course);
     }

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -16,7 +16,6 @@ use App\Model\Instructor;
 use App\Model\ManageInstructor;
 use App\Model\TemporaryInstructor;
 use App\Services\Auth\CredentialGeneratorService;
-use App\Services\Instructor\QueryService;
 use App\Services\Instructor\VerifyCodeService;
 use Carbon\CarbonImmutable;
 use Exception;
@@ -37,10 +36,11 @@ class InstructorController extends Controller
      *
      * @return InstructorShowResource
      */
-    public function show(QueryService $queryService)
+    public function show()
     {
         /** @var Instructor $instructor */
-        $instructor = $queryService->getInstructor(Auth::guard('instructor')->user()->id);
+        $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
+        assert($instructor instanceof Instructor);
 
         return new InstructorShowResource($instructor);
     }

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -99,6 +99,7 @@ class StudentController extends Controller
         // リクエストされた受講生を取得
         /** @var Student $student */
         $student = Student::find($request->student_id);
+        assert($student instanceof Student);
 
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -10,7 +10,6 @@ use App\Http\Resources\Instructor\StudentIndexResource;
 use App\Http\Resources\Instructor\StudentShowResource;
 use App\Model\Course;
 use App\Model\Student;
-use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
@@ -89,7 +88,7 @@ class StudentController extends Controller
      *
      * @return StudentShowResource|JsonResponse
      */
-    public function show(StudentShowRequest $request, QueryService $queryService)
+    public function show(StudentShowRequest $request)
     {
         // 認証ユーザー情報取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -99,7 +98,7 @@ class StudentController extends Controller
 
         // リクエストされた受講生を取得
         /** @var Student $student */
-        $student = $queryService->getStudent($request->student_id);
+        $student = Student::find($request->student_id);
 
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();

--- a/app/Services/Course/QueryService.php
+++ b/app/Services/Course/QueryService.php
@@ -17,16 +17,6 @@ class QueryService
     }
 
     /**
-     * 講師IDから講座情報を取得
-     *
-     * @return Collection<Course>
-     */
-    public function getCoursesByInstructorId(int $instructorId): Collection
-    {
-        return Course::where('instructor_id', $instructorId)->get();
-    }
-
-    /**
      * 講師IDのリストから講座情報を取得
      *
      * @param  array<int>  $instructorIds

--- a/tests/Feature/Api/Instructor/Course/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Course/IndexTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Api/Instructor/Course/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Course/ShowTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/2');
+
+        // assert
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/Instructor/ShowTest.php
+++ b/tests/Feature/Api/Instructor/ShowTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor');
+
+        // assert
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Api/Instructor/Student/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Student/ShowTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Student;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_生徒取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_生徒取得_失敗_未ログイン(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/1');
+
+        // assert
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## 概要
- Instructor内のcontrollerにおいてQueryServiceを使わない形に変更する
（ChapterController.phpの変更はJKA-1103で対応済み）

## 動作確認手順
- ログインしているinstructorが作成したCourse情報が取得できることを確認。
GET /  http://localhost:8080/api/v1/instructor/course/index
- instructorでログイン後に、Courseの詳細情報を取得できることを確認。
GET /  http://localhost:8080/api/v1/instructor/course/4
- ログインしているinstructorの詳細情報を取得できることを確認。
GET /  http://localhost:8080/api/v1/instructor
- ログインしているinstructorが作成したCourseに出席している生徒の情報を取得できることを確認。
GET /  http://localhost:8080/api/v1/instructor/student/2

## 考慮して欲しいこと
- 他のクラスが参照しているQueryServiceに関しては、削除せずにそのまま残しています。
JKA-1104/1105でQueryServiceを使用しない形に修正しながら、不要なものは削除していきます。