### PR TITLE
JKA-1097：Manager/StudentControllerのindexメソッドの改修（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -14,6 +14,7 @@ use App\Model\Student;
 use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -71,11 +72,11 @@ class StudentController extends Controller
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
-            ->when($courseId, function ($query) use ($courseId) {
+            ->when($courseId, function (Builder $query) use ($courseId) {
                 $query->where('attendances.course_id', $courseId);
             })
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
-            ->when($inputText, function ($query) use ($inputText) {
+            ->when($inputText, function (Builder $query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
                 $query->where(function ($query) use ($inputText) {
                     $query->orWhere('students.nick_name', 'LIKE', "%{$inputText}%")
@@ -84,10 +85,10 @@ class StudentController extends Controller
                 });
             })
             // 日付検索
-            ->when($startDate, function ($query) use ($startDate) {
+            ->when($startDate, function (Builder $query) use ($startDate) {
                 $query->where('attendances.created_at', '>=', $startDate);
             })
-            ->when($endDate, function ($query) use ($endDate) {
+            ->when($endDate, function (Builder $query) use ($endDate) {
                 $query->where('attendances.created_at', '<=', $endDate);
             })
             // ソート

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -57,7 +57,7 @@ class StudentController extends Controller
             $courseId = (int) $courseId;
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
-                throw new AuthorizationException('Not authorized.');
+                throw new AuthorizationException('Forbidden, invalid course_id.');
             }
         }
 

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -47,14 +47,23 @@ class StudentController extends Controller
             ->pluck('id')
             ->toArray();
 
-        $course = Course::find($request->course_id);
+        // クエリパラメータからcourse_idを取得
+        $courseId = (int)$request->query('course_id');
 
-        if (! in_array($course->id, $courseIds, true)) {
-            // リクエストされた講座が自身または配下の講師の講座に所属しているか確認
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized.',
-            ], 403);
+        \Log::info('Instructor ID:', ['instructor_id' => $instructorId]);
+        \Log::info('Instructor IDs (including managings):', ['instructor_ids' => $instructorIds]);
+        \Log::info('Course IDs:', ['course_ids' => $courseIds]);
+        \Log::info('Requested Course ID:', ['course_id' => $courseId]);
+
+        // クエリパラメータにcourse_idが存在する場合の処理
+        if ($courseId) {
+            if (! in_array($courseId, $courseIds, true)) {
+                // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Not authorized.',
+                ], 403);
+            }
         }
 
         $results = DB::table('attendances')
@@ -68,7 +77,9 @@ class StudentController extends Controller
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
-            ->where('attendances.course_id', $request->course_id)
+            ->when($courseId, function ($query) use ($courseId) {
+                $query->where('attendances.course_id', $courseId);
+            })
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
             ->when($inputText, function ($query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
@@ -89,10 +100,7 @@ class StudentController extends Controller
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        $course = Course::find($request->course_id);
-
         return new StudentIndexResource([
-            'course' => $course,
             'data' => $results,
         ]);
     }

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -48,7 +48,7 @@ class StudentController extends Controller
             ->toArray();
 
         // クエリパラメータからcourse_idを取得
-        $courseId = (int)$request->query('course_id');
+        $courseId = (int) $request->query('course_id');
 
         \Log::info('Instructor ID:', ['instructor_id' => $instructorId]);
         \Log::info('Instructor IDs (including managings):', ['instructor_ids' => $instructorIds]);

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -15,6 +15,7 @@ use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class StudentController extends Controller
 {
@@ -50,19 +51,11 @@ class StudentController extends Controller
         // クエリパラメータからcourse_idを取得
         $courseId = (int) $request->query('course_id');
 
-        \Log::info('Instructor ID:', ['instructor_id' => $instructorId]);
-        \Log::info('Instructor IDs (including managings):', ['instructor_ids' => $instructorIds]);
-        \Log::info('Course IDs:', ['course_ids' => $courseIds]);
-        \Log::info('Requested Course ID:', ['course_id' => $courseId]);
-
         // クエリパラメータにcourse_idが存在する場合の処理
         if ($courseId) {
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Not authorized.',
-                ], 403);
+                throw new AuthorizationException('Not authorized.');
             }
         }
 

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -13,9 +13,9 @@ use App\Model\Instructor;
 use App\Model\Student;
 use App\Services\Student\QueryService;
 use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class StudentController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -49,10 +49,11 @@ class StudentController extends Controller
             ->toArray();
 
         // クエリパラメータからcourse_idを取得
-        $courseId = (int) $request->query('course_id');
+        $courseId = $request->query('course_id');
 
         // クエリパラメータにcourse_idが存在する場合の処理
-        if ($courseId) {
+        if ($courseId !== null) {
+            $courseId = (int) $courseId;
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
                 throw new AuthorizationException('Not authorized.');
@@ -93,9 +94,7 @@ class StudentController extends Controller
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        return new StudentIndexResource([
-            'data' => $results,
-        ]);
+        return new StudentIndexResource($results);
     }
 
     /**

--- a/app/Http/Requests/Manager/StudentIndexRequest.php
+++ b/app/Http/Requests/Manager/StudentIndexRequest.php
@@ -10,7 +10,7 @@ class StudentIndexRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
-            'course_id' => $this->route('course_id'),
+            'course_id' => $this->query('course_id'),
         ]);
     }
 
@@ -32,7 +32,7 @@ class StudentIndexRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'course_id' => ['nullable', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
             'sort_by' => ['string', new IndexSortByRule],

--- a/app/Http/Requests/Manager/StudentIndexRequest.php
+++ b/app/Http/Requests/Manager/StudentIndexRequest.php
@@ -7,13 +7,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StudentIndexRequest extends FormRequest
 {
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'course_id' => $this->query('course_id'),
-        ]);
-    }
-
     /**
      * Determine if the user is authorized to make this request.
      *

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -16,7 +16,7 @@ class StudentIndexResource extends JsonResource
     public function toArray($request)
     {
         /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
-        $data = $this->resource['data'];
+        $data = $this->resource;
 
         return [
             'pagination' => [

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Collection;
 
 class StudentIndexResource extends JsonResource
 {
+    /** @var \Illuminate\Pagination\LengthAwarePaginator */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *
@@ -15,15 +18,12 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
-        $data = $this->resource;
-
         return [
             'pagination' => [
-                'page' => $data->currentPage(),
-                'total' => $data->total(),
+                'page' => $this->resource->currentPage(),
+                'total' => $this->resource->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection()),
+            'students' => $this->mapStudents($this->resource->getCollection()),
         ];
     }
 

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -16,35 +16,26 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-        /** @var \App\Model\Course $course */
-        $course = $this->resource['course'];
-
         /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
         $data = $this->resource['data'];
 
         return [
-            'course' => [
-                'course_id' => $course->id,
-                'image' => $course->image,
-                'title' => $course->title,
-            ],
             'pagination' => [
                 'page' => $data->currentPage(),
                 'total' => $data->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection(), $course),
+            'students' => $this->mapStudents($data->getCollection()),
         ];
     }
 
-    private function mapStudents(Collection $results, Course $course)
+    private function mapStudents(Collection $results)
     {
-        return $results->map(function ($result) use ($course) {
+        return $results->map(function ($result) {
             return [
                 'student_id' => $result->student_id,
                 'nick_name' => $result->nick_name,
                 'email' => $result->email,
                 'profile_image' => $result->profile_image,
-                'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
                     'attendance_id' => $result->attendance_id,

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources\Manager;
 
-use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -175,10 +175,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\CourseController@show');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
-                        // マネージャー-講座-生徒
-                        Route::prefix('student')->group(function () {
-                            Route::get('index', 'Api\Manager\StudentController@index');
-                        });
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
                             Route::post('sort', 'Api\Manager\ChapterController@sort');
@@ -233,6 +229,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 });
                 // マネージャー-生徒
                 Route::prefix('student')->group(function () {
+                    // マネージャー-講座-生徒
+                    Route::get('index', 'Api\Manager\StudentController@index');
                     Route::get('{student_id}', 'Api\Manager\StudentController@show');
                     Route::post('/', 'Api\Manager\StudentController@store');
                 });

--- a/tests/Feature/Api/Manager/Student/IndexTest.php
+++ b/tests/Feature/Api/Manager/Student/IndexTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Student;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index?course_id=1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index?course_id=4');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index?course_id=aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1097：Manager/StudentControllerのindexメソッドの改修

## 概要
マネージャーアカウントでの受講生一覧取得について、course_idをパスパラメータではなくクエリパラメータで取得するように変更。  
以下の修正を実行しました。
 - Manager/StudentControllerの修正
 - ルーティングパスをapi/v1/manager/student/indexに修正
 - SutudentIndexRequestの修正
 - StudentIndexResourceの修正

## 動作確認テスト
Postmanにて修正箇所に対する動作確認を実施。

1. 正常：ログイン中の講師とその配下の講師の講座を受講している受講生一覧の取得
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/student/index
 - HTTPメソッド：GET
 - 結果：200 OK

2. 正常：ログイン中の講師とその配下の講師の講座の中のリクエストした講座を受講している受講生一覧の取得
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/student/index?course_id=1
 - HTTPメソッド：GET
 - 結果：200 OK

3. 異常：ログイン中の講師とその配下の講師の講座の中にリクエストした講座が存在しない場合
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/student/index?course_id=4
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
"message": "Not authorized.”