### PR TITLE
app/Http/Requestsディレクトリが肥大化しているための整理(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\AttendanceDeleteRequest;
+use App\Http\Requests\Instructor\Attendance\DeleteRequest;
 use App\Http\Requests\Instructor\AttendanceShowRequest;
 use App\Http\Requests\Instructor\AttendanceShowStatusRequest;
 use App\Http\Requests\Instructor\AttendanceStatusRequest;
@@ -93,7 +93,7 @@ class AttendanceController extends Controller
     /**
      * 受講状況削除API
      */
-    public function delete(AttendanceDeleteRequest $request): JsonResponse
+    public function delete(DeleteRequest $request): JsonResponse
     {
         DB::beginTransaction();
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -103,7 +103,7 @@ class AttendanceController extends Controller
 
             if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
                 throw new AuthorizationException(
-                    'Unauthorized: The authenticated instructor does not have permission to delete this attendance record.'
+                    'Forbidden, invalid instructor_id.'
                 );
             }
 

--- a/app/Http/Requests/Instructor/Attendance/DeleteRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/DeleteRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Requests\Instructor;
+namespace App\Http\Requests\Instructor\Attendance;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttendanceDeleteRequest extends FormRequest
+class DeleteRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/tests/Feature/Api/Instructor/Attendance/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/DeleteTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/attendance/1');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+
+        // 論理削除されているか確認
+        $this->assertSoftDeleted('attendances', [
+            'id' => 1,
+        ]);
+        $this->assertSoftDeleted('lesson_attendances', [
+            'attendance_id' => 1,
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/attendance/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/attendance/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'attendance_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes
#JKA-1101 app/Http/Requestsディレクトリが肥大化しているための整理

## 概要
- ディレクトリを現在より細かく分け、Requestクラス名にはコントローラーのメソッド名を使用するように修正

## 動作確認手順
全てstudents_idは1でログインしています。

- テストケース1（正常系）
URL：http://localhost:8080/api/v1/instructor/attendance/:attendance_id
attendance_idが6
course_idが1（ログインしている講師の講座）
「"result": true」が出力されて削除されていることを確認

- テストケース2（異常系）
URL：http://localhost:8080/api/v1/instructor/attendance/:attendance_id
attendance_idが7
course_idが2（ログインしている講師の講座ではない）
「"message": "Unauthorized: The authenticated instructor does not have permission to delete this attendance record."」
が出力されて削除されていないことを確認

## 考慮して欲しいこと
## 確認して欲しいこと