### PR TITLE
JKA-1104 Manager内のcontrollerにおいてQueryServiceを使わない形に変更する (Shinya)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\AttendanceDeleteRequest;
+use App\Http\Requests\Instructor\Attendance\DeleteRequest;
 use App\Http\Requests\Instructor\AttendanceShowRequest;
 use App\Http\Requests\Instructor\AttendanceShowStatusRequest;
 use App\Http\Requests\Instructor\AttendanceStatusRequest;
@@ -93,7 +93,7 @@ class AttendanceController extends Controller
     /**
      * 受講状況削除API
      */
-    public function delete(AttendanceDeleteRequest $request): JsonResponse
+    public function delete(DeleteRequest $request): JsonResponse
     {
         DB::beginTransaction();
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -103,7 +103,7 @@ class AttendanceController extends Controller
 
             if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
                 throw new AuthorizationException(
-                    'Unauthorized: The authenticated instructor does not have permission to delete this attendance record.'
+                    'Forbidden, invalid instructor_id.'
                 );
             }
 

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -46,6 +46,8 @@ class StudentController extends Controller
         $results = DB::table('attendances')
             ->select(
                 'attendances.student_id',
+                'attendances.course_id',
+                'courses.instructor_id',
                 'students.nick_name',
                 'students.email',
                 'students.profile_image',
@@ -54,7 +56,10 @@ class StudentController extends Controller
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
+            ->join('courses', 'attendances.course_id', '=', 'courses.id')
             ->where('attendances.course_id', $request->course_id)
+            // ログインしている講師IDを検索
+            ->where('courses.instructor_id', $request->instructor_id)
             ->whereNull('attendances.deleted_at')
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
             ->when($inputText, function ($query) use ($inputText) {

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -12,6 +12,8 @@ use App\Model\Course;
 use App\Model\Student;
 use App\Services\Student\QueryService;
 use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -20,10 +22,8 @@ class StudentController extends Controller
 {
     /**
      * 受講生一覧取得API
-     *
-     * @return StudentIndexResource|JsonResponse
      */
-    public function index(StudentIndexRequest $request)
+    public function index(StudentIndexRequest $request): StudentIndexResource
     {
         $perPage = $request->input('per_page', 10);
         $page = $request->input('page', 1);
@@ -39,10 +39,7 @@ class StudentController extends Controller
         if ($courseId !== null) {
             $instructorId = Course::findOrFail($request->course_id)->instructor_id;
             if ($loginId !== $instructorId) {
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Not authorized.',
-                ], 403);
+                throw new AuthorizationException('Forbidden, invalid course_id.');
             }
         }
 
@@ -61,38 +58,33 @@ class StudentController extends Controller
             ->join('students', 'attendances.student_id', '=', 'students.id')
             ->join('courses', 'attendances.course_id', '=', 'courses.id')
             // course_idのクエリパラメータがある時のみ、条件にcourse_idを含める
-            ->when($courseId, function ($query) use ($courseId) {
+            ->when($courseId, function (Builder $query) use ($courseId) {
                 $query->where('attendances.course_id', $courseId);
             })
             // ログインしている講師IDを検索
             ->where('courses.instructor_id', $loginId)
             ->whereNull('attendances.deleted_at')
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
-            ->when($inputText, function ($query) use ($inputText) {
+            ->when($inputText, function (Builder $query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
-                $query->where(function ($query) use ($inputText) {
+                $query->where(function (Builder $query) use ($inputText) {
                     $query->orWhere('students.nick_name', 'LIKE', "%{$inputText}%")
                         ->orWhere('students.email', 'LIKE', "%{$inputText}%")
                         ->orWhere(DB::raw('CONCAT(students.last_name, students.first_name)'), 'LIKE', "%{$inputText}%");
                 });
             })
             // 日付検索
-            ->when($startDate, function ($query) use ($startDate) {
+            ->when($startDate, function (Builder $query) use ($startDate) {
                 $query->where('attendances.created_at', '>=', $startDate);
             })
-            ->when($endDate, function ($query) use ($endDate) {
+            ->when($endDate, function (Builder $query) use ($endDate) {
                 $query->where('attendances.created_at', '<=', $endDate);
             })
             // ソート
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        $course = Course::find($request->course_id);
-
-        return new StudentIndexResource([
-            'course' => $course,
-            'data' => $results,
-        ]);
+        return new StudentIndexResource($results);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -36,7 +36,7 @@ class StudentController extends Controller
 
         $loginId = Auth::guard('instructor')->user()->id;
 
-        if($courseId !== null){
+        if ($courseId !== null) {
             $instructorId = Course::findOrFail($request->course_id)->instructor_id;
             if ($loginId !== $instructorId) {
                 return response()->json([

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -32,15 +32,18 @@ class StudentController extends Controller
         $inputText = $request->input('input_text');
         $startDate = $request->input('start_date');
         $endDate = $request->input('end_date');
+        $courseId = $request->input('course_id');
 
         $loginId = Auth::guard('instructor')->user()->id;
-        $instructorId = Course::findOrFail($request->course_id)->instructor_id;
 
-        if ($loginId !== $instructorId) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized.',
-            ], 403);
+        if($courseId !== null){
+            $instructorId = Course::findOrFail($request->course_id)->instructor_id;
+            if ($loginId !== $instructorId) {
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Not authorized.',
+                ], 403);
+            }
         }
 
         $results = DB::table('attendances')
@@ -57,9 +60,12 @@ class StudentController extends Controller
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
             ->join('courses', 'attendances.course_id', '=', 'courses.id')
-            ->where('attendances.course_id', $request->course_id)
+            // course_idのクエリパラメータがある時のみ、条件にcourse_idを含める
+            ->when($courseId, function ($query) use ($courseId) {
+                $query->where('attendances.course_id', $courseId);
+            })
             // ログインしている講師IDを検索
-            ->where('courses.instructor_id', $request->instructor_id)
+            ->where('courses.instructor_id', $loginId)
             ->whereNull('attendances.deleted_at')
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
             ->when($inputText, function ($query) use ($inputText) {

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -66,7 +66,7 @@ class CourseController extends Controller
 
         // 自身 もしくは 配下の講師でない場合はエラー応答
         if (! in_array($course->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Invalid instructor_id.');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         return new CourseShowResource($course);

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -13,7 +13,6 @@ use App\Http\Resources\Manager\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
-use App\Services\Course\QueryService;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -29,7 +28,7 @@ class CourseController extends Controller
     /**
      * 講座一覧取得API
      */
-    public function index(QueryService $queryService): CourseIndexResource
+    public function index(): CourseIndexResource
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -40,7 +39,9 @@ class CourseController extends Controller
         $instructorIds[] = $instructorId;
 
         // 自分、または配下の講師の講座情報を取得
-        $courses = $queryService->getCoursesByInstructorIds($instructorIds);
+        $courses = Course::with('instructor')
+            ->whereIn('instructor_id', $instructorIds)
+            ->get();
 
         return new CourseIndexResource($courses);
     }
@@ -50,7 +51,7 @@ class CourseController extends Controller
      *
      * @return CourseShowResource|JsonResponse
      */
-    public function show(CourseShowRequest $request, QueryService $queryService)
+    public function show(CourseShowRequest $request)
     {
         // ログイン中の講師IDを取得
         $userId = Auth::guard('instructor')->user()->id;
@@ -60,7 +61,8 @@ class CourseController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $userId;
 
-        $course = $queryService->getCourse($request->course_id);
+        $course = Course::with(['chapters.lessons'])->findOrFail($request->course_id);
+        assert($course instanceof Course);
 
         // 自身 もしくは 配下の講師でない場合はエラー応答
         if (! in_array($course->instructor_id, $instructorIds, true)) {

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Api\Manager\Instructor;
 
+use App\Model\Course;
+use App\Model\Instructor;
+use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\Manager\InstructorCourseIndexRequest;
 use App\Http\Resources\Manager\InstructorCourseIndexResource;
-use App\Model\Instructor;
-use App\Services\Course\QueryService;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 
 class CourseController extends Controller
 {
@@ -17,7 +17,7 @@ class CourseController extends Controller
      *
      * @return InstructorCourseIndexResource|JsonResponse
      */
-    public function index(InstructorCourseIndexRequest $request, QueryService $queryService)
+    public function index(InstructorCourseIndexRequest $request)
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -35,7 +35,7 @@ class CourseController extends Controller
             ], 403);
         }
 
-        $courses = $queryService->getPaginatedCoursesByInstructorId($request->instructor_id, 5);
+        $courses = Course::where('instructor_id', $request->instructor_id)->paginate(5);
 
         return new InstructorCourseIndexResource($courses);
     }

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Api\Manager\Instructor;
 
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\InstructorCourseIndexRequest;
+use App\Http\Resources\Manager\InstructorCourseIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Http\JsonResponse;
-use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
-use App\Http\Requests\Manager\InstructorCourseIndexRequest;
-use App\Http\Resources\Manager\InstructorCourseIndexResource;
 
 class CourseController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -15,7 +15,6 @@ use App\Mail\AuthenticationConfirmationMail;
 use App\Model\Instructor;
 use App\Model\TemporaryInstructor;
 use App\Services\Auth\CredentialGeneratorService;
-use App\Services\Instructor\QueryService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -35,13 +34,14 @@ class InstructorController extends Controller
      *
      * @return InstructorShowResource|\Illuminate\Http\JsonResponse
      */
-    public function show(InstructorShowRequest $request, QueryService $queryService)
+    public function show(InstructorShowRequest $request)
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得
         /** @var Instructor $manager */
-        $manager = $queryService->getManagerWithManagings($managerId);
+        $manager = Instructor::with('managings')->findOrFail($managerId);
+        assert($manager instanceof Instructor);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
@@ -51,7 +51,8 @@ class InstructorController extends Controller
         }
 
         /** @var Instructor $instructor */
-        $instructor = $queryService->getInstructor($request->instructor_id);
+        $instructor = Instructor::findOrFail($request->instructor_id);
+        assert($instructor instanceof Instructor);
 
         return new InstructorShowResource($instructor);
     }
@@ -61,7 +62,7 @@ class InstructorController extends Controller
      *
      * @return InstructorIndexResource
      */
-    public function index(InstructorIndexRequest $request, QueryService $queryService)
+    public function index(InstructorIndexRequest $request)
     {
         // デフォルト値を設定
         $perPage = $request->input('per_page', 20);
@@ -72,13 +73,15 @@ class InstructorController extends Controller
         $managerId = Auth::guard('instructor')->user()->id;
 
         /** @var Instructor $manager */
-        $manager = $queryService->getManagerWithManagings($managerId);
+        $manager = Instructor::with('managings')->findOrFail($managerId);
 
         // 管理する講師のIDを取得
         $instructorIds = $manager->managings->pluck('id')->toArray();
 
         // 講師情報を取得
-        $instructors = $queryService->getPaginatedInstructors($instructorIds, $sortBy, $order, $perPage, $page);
+        $instructors = Instructor::whereIn('id', $instructorIds)
+            ->orderBy($sortBy, $order)
+            ->paginate($perPage, ['*'], 'page', $page);
 
         return new InstructorIndexResource($instructors);
     }

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -30,39 +30,9 @@ use RuntimeException;
 class InstructorController extends Controller
 {
     /**
-     * 講師情報取得API
-     *
-     * @return InstructorShowResource|\Illuminate\Http\JsonResponse
-     */
-    public function show(InstructorShowRequest $request)
-    {
-        $managerId = Auth::guard('instructor')->user()->id;
-
-        // 配下の講師情報を取得
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrFail($managerId);
-        assert($manager instanceof Instructor);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
-        //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
-        if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, not allowed to this instructor.');
-        }
-
-        /** @var Instructor $instructor */
-        $instructor = Instructor::findOrFail($request->instructor_id);
-        assert($instructor instanceof Instructor);
-
-        return new InstructorShowResource($instructor);
-    }
-
-    /**
      * 講師一覧取得API
-     *
-     * @return InstructorIndexResource
      */
-    public function index(InstructorIndexRequest $request)
+    public function index(InstructorIndexRequest $request): InstructorIndexResource
     {
         // デフォルト値を設定
         $perPage = $request->input('per_page', 20);
@@ -72,8 +42,8 @@ class InstructorController extends Controller
 
         $managerId = Auth::guard('instructor')->user()->id;
 
-        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->findOrFail($managerId);
+        assert($manager instanceof Instructor);
 
         // 管理する講師のIDを取得
         $instructorIds = $manager->managings->pluck('id')->toArray();
@@ -84,6 +54,30 @@ class InstructorController extends Controller
             ->paginate($perPage, ['*'], 'page', $page);
 
         return new InstructorIndexResource($instructors);
+    }
+
+    /**
+     * 講師情報取得API
+     */
+    public function show(InstructorShowRequest $request): InstructorShowResource
+    {
+        $managerId = Auth::guard('instructor')->user()->id;
+
+        // 配下の講師情報を取得
+        $manager = Instructor::with('managings')->findOrFail($managerId);
+        assert($manager instanceof Instructor);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        //指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+        if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
+
+        $instructor = Instructor::findOrFail($request->instructor_id);
+        assert($instructor instanceof Instructor);
+
+        return new InstructorShowResource($instructor);
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -14,6 +14,7 @@ use App\Model\Student;
 use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -71,11 +72,11 @@ class StudentController extends Controller
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
-            ->when($courseId, function ($query) use ($courseId) {
+            ->when($courseId, function (Builder $query) use ($courseId) {
                 $query->where('attendances.course_id', $courseId);
             })
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
-            ->when($inputText, function ($query) use ($inputText) {
+            ->when($inputText, function (Builder $query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
                 $query->where(function ($query) use ($inputText) {
                     $query->orWhere('students.nick_name', 'LIKE', "%{$inputText}%")
@@ -84,10 +85,10 @@ class StudentController extends Controller
                 });
             })
             // 日付検索
-            ->when($startDate, function ($query) use ($startDate) {
+            ->when($startDate, function (Builder $query) use ($startDate) {
                 $query->where('attendances.created_at', '>=', $startDate);
             })
-            ->when($endDate, function ($query) use ($endDate) {
+            ->when($endDate, function (Builder $query) use ($endDate) {
                 $query->where('attendances.created_at', '<=', $endDate);
             })
             // ソート

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -57,7 +57,7 @@ class StudentController extends Controller
             $courseId = (int) $courseId;
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
-                throw new AuthorizationException('Not authorized.');
+                throw new AuthorizationException('Forbidden, invalid course_id.');
             }
         }
 

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -47,14 +47,23 @@ class StudentController extends Controller
             ->pluck('id')
             ->toArray();
 
-        $course = Course::find($request->course_id);
+        // クエリパラメータからcourse_idを取得
+        $courseId = (int)$request->query('course_id');
 
-        if (! in_array($course->id, $courseIds, true)) {
-            // リクエストされた講座が自身または配下の講師の講座に所属しているか確認
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized.',
-            ], 403);
+        \Log::info('Instructor ID:', ['instructor_id' => $instructorId]);
+        \Log::info('Instructor IDs (including managings):', ['instructor_ids' => $instructorIds]);
+        \Log::info('Course IDs:', ['course_ids' => $courseIds]);
+        \Log::info('Requested Course ID:', ['course_id' => $courseId]);
+
+        // クエリパラメータにcourse_idが存在する場合の処理
+        if ($courseId) {
+            if (! in_array($courseId, $courseIds, true)) {
+                // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
+                return response()->json([
+                    'result' => false,
+                    'message' => 'Not authorized.',
+                ], 403);
+            }
         }
 
         $results = DB::table('attendances')
@@ -68,7 +77,9 @@ class StudentController extends Controller
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
-            ->where('attendances.course_id', $request->course_id)
+            ->when($courseId, function ($query) use ($courseId) {
+                $query->where('attendances.course_id', $courseId);
+            })
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
             ->when($inputText, function ($query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
@@ -89,10 +100,7 @@ class StudentController extends Controller
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        $course = Course::find($request->course_id);
-
         return new StudentIndexResource([
-            'course' => $course,
             'data' => $results,
         ]);
     }

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -48,7 +48,7 @@ class StudentController extends Controller
             ->toArray();
 
         // クエリパラメータからcourse_idを取得
-        $courseId = (int)$request->query('course_id');
+        $courseId = (int) $request->query('course_id');
 
         \Log::info('Instructor ID:', ['instructor_id' => $instructorId]);
         \Log::info('Instructor IDs (including managings):', ['instructor_ids' => $instructorIds]);

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -11,7 +11,6 @@ use App\Http\Resources\Manager\StudentShowResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Student;
-use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -102,7 +101,7 @@ class StudentController extends Controller
      *
      * @return StudentShowResource|\Illuminate\Http\JsonResponse
      */
-    public function show(StudentShowRequest $request, QueryService $queryService)
+    public function show(StudentShowRequest $request)
     {
         // 認証されたマネージャーが管理する講師のIDのリストを取得
         $authManagerId = Auth::guard('instructor')->user()->id;
@@ -116,7 +115,8 @@ class StudentController extends Controller
         $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
 
         // リクエストされた受講生を取得
-        $student = $queryService->getStudent($request->student_id);
+        $student = Student::find($request->student_id);
+        assert($student instanceof Student);
 
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -15,6 +15,7 @@ use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class StudentController extends Controller
 {
@@ -50,19 +51,11 @@ class StudentController extends Controller
         // クエリパラメータからcourse_idを取得
         $courseId = (int) $request->query('course_id');
 
-        \Log::info('Instructor ID:', ['instructor_id' => $instructorId]);
-        \Log::info('Instructor IDs (including managings):', ['instructor_ids' => $instructorIds]);
-        \Log::info('Course IDs:', ['course_ids' => $courseIds]);
-        \Log::info('Requested Course ID:', ['course_id' => $courseId]);
-
         // クエリパラメータにcourse_idが存在する場合の処理
         if ($courseId) {
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
-                return response()->json([
-                    'result' => false,
-                    'message' => 'Not authorized.',
-                ], 403);
+                throw new AuthorizationException('Not authorized.');
             }
         }
 

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -21,10 +21,8 @@ class StudentController extends Controller
 {
     /**
      * 受講生一覧取得API
-     *
-     * @return StudentIndexResource|\Illuminate\Http\JsonResponse
      */
-    public function index(StudentIndexRequest $request)
+    public function index(StudentIndexRequest $request): StudentIndexResource
     {
         $perPage = $request->input('per_page', 10);
         $page = $request->input('page', 1);
@@ -99,10 +97,8 @@ class StudentController extends Controller
 
     /**
      * 受講生詳細取得API
-     *
-     * @return StudentShowResource|\Illuminate\Http\JsonResponse
      */
-    public function show(StudentShowRequest $request)
+    public function show(StudentShowRequest $request): StudentShowResource
     {
         // 認証されたマネージャーが管理する講師のIDのリストを取得
         $authManagerId = Auth::guard('instructor')->user()->id;
@@ -122,10 +118,7 @@ class StudentController extends Controller
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();
         if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized to access this student.',
-            ], 403);
+            throw new AuthorizationException('Forbidden, invalid student_id.');
         }
 
         return new StudentShowResource($student);

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -13,9 +13,9 @@ use App\Model\Instructor;
 use App\Model\Student;
 use App\Services\Student\QueryService;
 use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class StudentController extends Controller
 {

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -49,10 +49,11 @@ class StudentController extends Controller
             ->toArray();
 
         // クエリパラメータからcourse_idを取得
-        $courseId = (int) $request->query('course_id');
+        $courseId = $request->query('course_id');
 
         // クエリパラメータにcourse_idが存在する場合の処理
-        if ($courseId) {
+        if ($courseId !== null) {
+            $courseId = (int) $courseId;
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
                 throw new AuthorizationException('Not authorized.');
@@ -93,9 +94,7 @@ class StudentController extends Controller
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        return new StudentIndexResource([
-            'data' => $results,
-        ]);
+        return new StudentIndexResource($results);
     }
 
     /**

--- a/app/Http/Requests/Instructor/Attendance/DeleteRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/DeleteRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Requests\Instructor;
+namespace App\Http\Requests\Instructor\Attendance;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttendanceDeleteRequest extends FormRequest
+class DeleteRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/Instructor/StudentIndexRequest.php
+++ b/app/Http/Requests/Instructor/StudentIndexRequest.php
@@ -24,7 +24,7 @@ class StudentIndexRequest extends FormRequest
      */
     public function rules()
     {
-        return [ 
+        return [
             'course_id' => ['integer', 'exists:courses,id'],
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],

--- a/app/Http/Requests/Instructor/StudentIndexRequest.php
+++ b/app/Http/Requests/Instructor/StudentIndexRequest.php
@@ -7,13 +7,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StudentIndexRequest extends FormRequest
 {
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'course_id' => $this->route('course_id'),
-        ]);
-    }
-
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -31,8 +24,8 @@ class StudentIndexRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'course_id' => ['required', 'integer', 'exists:courses,id'],
+        return [ 
+            'course_id' => ['integer', 'exists:courses,id'],
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
             'sort_by' => ['string', new IndexSortByRule],

--- a/app/Http/Requests/Manager/StudentIndexRequest.php
+++ b/app/Http/Requests/Manager/StudentIndexRequest.php
@@ -10,7 +10,7 @@ class StudentIndexRequest extends FormRequest
     protected function prepareForValidation()
     {
         $this->merge([
-            'course_id' => $this->route('course_id'),
+            'course_id' => $this->query('course_id'),
         ]);
     }
 
@@ -32,7 +32,7 @@ class StudentIndexRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'course_id' => ['nullable', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
             'sort_by' => ['string', new IndexSortByRule],

--- a/app/Http/Requests/Manager/StudentIndexRequest.php
+++ b/app/Http/Requests/Manager/StudentIndexRequest.php
@@ -7,13 +7,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StudentIndexRequest extends FormRequest
 {
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'course_id' => $this->query('course_id'),
-        ]);
-    }
-
     /**
      * Determine if the user is authorized to make this request.
      *

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources\Instructor;
 
-use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
 

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -23,11 +23,6 @@ class StudentIndexResource extends JsonResource
         $data = $this->resource['data'];
 
         return [
-            'course' => [
-                'course_id' => $course->id,
-                'image' => $course->image,
-                'title' => $course->title,
-            ],
             'pagination' => [
                 'page' => $data->currentPage(),
                 'total' => $data->total(),
@@ -36,14 +31,13 @@ class StudentIndexResource extends JsonResource
         ];
     }
 
-    private function mapStudents(Collection $results, Course $course)
+    private function mapStudents(Collection $results)
     {
-        return $results->map(function ($result) use ($course) {
+        return $results->map(function ($result) {
             return [
                 'student_id' => $result->student_id,
                 'nick_name' => $result->nick_name,
                 'email' => $result->email,
-                'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
                     'attendance_id' => $result->attendance_id,

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -27,7 +27,7 @@ class StudentIndexResource extends JsonResource
                 'page' => $data->currentPage(),
                 'total' => $data->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection(), $course),
+            'students' => $this->mapStudents($data->getCollection()),
         ];
     }
 

--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Collection;
 
 class StudentIndexResource extends JsonResource
 {
+    /** @var \Illuminate\Pagination\LengthAwarePaginator */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *
@@ -15,18 +18,12 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-        /** @var \App\Model\Course $course */
-        $course = $this->resource['course'];
-
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
-        $data = $this->resource['data'];
-
         return [
             'pagination' => [
-                'page' => $data->currentPage(),
-                'total' => $data->total(),
+                'page' => $this->resource->currentPage(),
+                'total' => $this->resource->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection()),
+            'students' => $this->mapStudents($this->resource->getCollection()),
         ];
     }
 

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -16,7 +16,7 @@ class StudentIndexResource extends JsonResource
     public function toArray($request)
     {
         /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
-        $data = $this->resource['data'];
+        $data = $this->resource;
 
         return [
             'pagination' => [

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Collection;
 
 class StudentIndexResource extends JsonResource
 {
+    /** @var \Illuminate\Pagination\LengthAwarePaginator */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *
@@ -15,15 +18,12 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
-        $data = $this->resource;
-
         return [
             'pagination' => [
-                'page' => $data->currentPage(),
-                'total' => $data->total(),
+                'page' => $this->resource->currentPage(),
+                'total' => $this->resource->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection()),
+            'students' => $this->mapStudents($this->resource->getCollection()),
         ];
     }
 

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -16,35 +16,26 @@ class StudentIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-        /** @var \App\Model\Course $course */
-        $course = $this->resource['course'];
-
         /** @var \Illuminate\Pagination\LengthAwarePaginator $data */
         $data = $this->resource['data'];
 
         return [
-            'course' => [
-                'course_id' => $course->id,
-                'image' => $course->image,
-                'title' => $course->title,
-            ],
             'pagination' => [
                 'page' => $data->currentPage(),
                 'total' => $data->total(),
             ],
-            'students' => $this->mapStudents($data->getCollection(), $course),
+            'students' => $this->mapStudents($data->getCollection()),
         ];
     }
 
-    private function mapStudents(Collection $results, Course $course)
+    private function mapStudents(Collection $results)
     {
-        return $results->map(function ($result) use ($course) {
+        return $results->map(function ($result) {
             return [
                 'student_id' => $result->student_id,
                 'nick_name' => $result->nick_name,
                 'email' => $result->email,
                 'profile_image' => $result->profile_image,
-                'course_title' => $course->title,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
                     'attendance_id' => $result->attendance_id,

--- a/app/Http/Resources/Manager/StudentIndexResource.php
+++ b/app/Http/Resources/Manager/StudentIndexResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources\Manager;
 
-use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -102,11 +102,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         });
                     });
 
-                    // 講師-講座-生徒
-                    Route::prefix('student')->group(function () {
-                        Route::get('index', 'Api\Instructor\StudentController@index');
-                    });
-
                     // 講師-講座-お知らせ
                     Route::prefix('notification')->group(function () {
                         Route::post('/', 'Api\Instructor\NotificationController@store');
@@ -133,6 +128,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
             // 講師-生徒
             Route::prefix('student')->group(function () {
+                // 講師-講座-生徒
+                Route::get('index', 'Api\Instructor\StudentController@index');
                 Route::get('{student_id}', 'Api\Instructor\StudentController@show');
                 Route::post('/', 'Api\Instructor\StudentController@store');
             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -175,10 +175,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', 'Api\Manager\CourseController@show');
                         Route::post('/', 'Api\Manager\CourseController@update');
                         Route::delete('/', 'Api\Manager\CourseController@delete');
-                        // マネージャー-講座-生徒
-                        Route::prefix('student')->group(function () {
-                            Route::get('index', 'Api\Manager\StudentController@index');
-                        });
                         // マネージャー-講座-チャプター
                         Route::prefix('chapter')->group(function () {
                             Route::post('sort', 'Api\Manager\ChapterController@sort');
@@ -233,6 +229,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 });
                 // マネージャー-生徒
                 Route::prefix('student')->group(function () {
+                    // マネージャー-講座-生徒
+                    Route::get('index', 'Api\Manager\StudentController@index');
                     Route::get('{student_id}', 'Api\Manager\StudentController@show');
                     Route::post('/', 'Api\Manager\StudentController@store');
                 });

--- a/tests/Feature/Api/Instructor/Attendance/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/DeleteTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/attendance/1');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+
+        // 論理削除されているか確認
+        $this->assertSoftDeleted('attendances', [
+            'id' => 1,
+        ]);
+        $this->assertSoftDeleted('lesson_attendances', [
+            'attendance_id' => 1,
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/attendance/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/attendance/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'attendance_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Student/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Student/IndexTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Student;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index?course_id=1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index?course_id=2');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/student/index?course_id=aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Course/IndexTest.php
+++ b/tests/Feature/Api/Manager/Course/IndexTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Api/Manager/Course/ShowTest.php
+++ b/tests/Feature/Api/Manager/Course/ShowTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_配下の講師の講座取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/2');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Instructor/IndexTest.php
+++ b/tests/Feature/Api/Manager/Instructor/IndexTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Instructor;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Api/Manager/Instructor/ShowTest.php
+++ b/tests/Feature/Api/Manager/Instructor/ShowTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Instructor;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/2');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_配下ではない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/2');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'instructor_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Student/IndexTest.php
+++ b/tests/Feature/Api/Manager/Student/IndexTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Student;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_受講生一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index?course_id=1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_講座id指定_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index?course_id=4');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/index?course_id=aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Student/ShowTest.php
+++ b/tests/Feature/Api/Manager/Student/ShowTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Student;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_生徒取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/2');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_配下ではない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/2');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid student_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'student_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要
- Manager内のcontrollerにおいてQueryServiceを使わない形に変更する

## 動作確認手順
- 配下のInstructorのCourse一覧が取得できることを確認。
http://localhost:8080/api/v1/manager/instructor/3/course/index
- 配下のinstructorの情報を取得できることを確認。
http://localhost:8080/api/v1/manager/instructor/2
- 配下のinstructorの一覧を取得できることを確認。
http://localhost:8080/api/v1/manager/instructor/index
- Managerとその配下のinstructorのcourse一覧を取得できることを確認。
http://localhost:8080/api/v1/manager/course/index
- Managerとその配下のinstructorのcourse情報を取得できることを確認。
http://localhost:8080/api/v1/manager/course/6
- Managerとその配下のinstructorのcourseに所属している生徒を取得できることを確認。
http://localhost:8080/api/v1/manager/student/2
