### PR TITLE
JKA-1102:Instructor/AttendanceController.phpに関わるルーティングの書き方をLaravel11系に合わせた書き方に変更（こみやま）

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -109,20 +109,20 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
                     // 講師-講座-受講
                     Route::prefix('attendance')->group(function () {
-                        Route::get('status', 'Api\Instructor\AttendanceController@show');
-                        Route::get('{period}', 'Api\Instructor\AttendanceController@loginRate');
-                        Route::get('status/{period}', 'Api\Instructor\AttendanceController@showStatus');
+                        Route::get('status', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'show']);
+                        Route::get('{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'loginRate']);
+                        Route::get('status/{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'showStatus']);
                     });
                 });
             });
 
             // 講師-受講
             Route::prefix('attendance')->group(function () {
-                Route::post('/', 'Api\Instructor\AttendanceController@store');
+                Route::post('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'store']);
                 // 講師-生徒学習状況
                 Route::prefix('{attendance_id}')->group(function () {
-                    Route::get('status', 'Api\Instructor\AttendanceController@status');
-                    Route::delete('/', 'Api\Instructor\AttendanceController@delete');
+                    Route::get('status', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'status']);
+                    Route::delete('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'delete']);
                 });
             });
 


### PR DESCRIPTION
## issue
JKA-1102:Instructor/AttendanceController.phpに関わるルーティングの書き方をLaravel11系に合わせた書き方に変更

## 概要
Instructor/AttendanceController.phpに関わるルーティングを以下のように変更。
```
Route::post('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'store']);
```

## 動作確認
PostmanにてInstructor\AttendanceControllerの各メソッドで動作確認を実施。

### storeメソッド：受講状況登録API
1. 正常：受講登録ができる
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance
 - HTTPメソッド：POST
 - サンプルの値
```
{
  "student_id": 1,
  "course_id": 2
}
```
 - 結果：200 OK

2. 異常：すでに受講登録がある場合は登録できない
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance
 - HTTPメソッド：POST
 - サンプルの値
```
{
  "student_id": 1,
  "course_id": 2
}
```
 - 結果：403 Forbidden  
"message": "Attendance record already exists.
***
### showメソッド：講座の受講状況取得API
1. 正常：指定した講座の受講状況を取得できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/attendance/status
 - HTTPメソッド：GET
 - 結果：200 OK
***
### deleteメソッド：受講状況削除API
1. 正常：受講状況を削除できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance/1
 - HTTPメソッド：DELETE
 - 結果：200 OK

2. 異常：指定した受講IDがログインしている講師の講座と紐づいていない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance/2
 - HTTPメソッド：DELETE
 - 結果：403 Forbidden  
"message": "Unauthorized: The authenticated instructor does not have permission to delete this attendance record.”
***
### loginRateメソッド：講座を受講中の受講生ログイン率取得API
1. 正常：講座を受講している受講生のログイン率を取得できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/attendance/month
 - HTTPメソッド：GET
 - 結果：200 OK  
"login_rate": 100

2. 異常：指定した講座とログイン中の講師が紐づかない場合、エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/attendance/month
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
"message": "Forbidden, not allowed to access this course.”
***
### showStatusメソッド：完了済みレッスン数と完了済みチャプター数取得API
1. 正常：完了済みレッスン数と完了済みチャプター数を取得できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/attendance/status/month
 - HTTPメソッド：GET
 - 結果：200 OK  
```
{
    "completed_lessons_count": 4,
    "completed_chapters_count": 2
}
```
***
### statusメソッド：受講状況取得API
1. 正常：受講生の受講状況を取得できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance/1/status
 - HTTPメソッド：GET
 - 結果：200 OK  

2. 異常：指定した受講IDに紐づく講座がログイン中の講師が持つ講座と一致しない場合はエラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance/1/status
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
"message": "Forbidden, not allowed to access this course.” 