### PR TITLE
app/Http/Requests/Instructor/Attendanceディレクトリが肥大化しているための整理(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -227,15 +227,13 @@ class AttendanceController extends Controller
 
     /**
      * 受講状況API
-     *
-     * @return AttendanceStatusResource|JsonResponse
      */
-    public function status(StatusRequest $request)
+    public function status(StatusRequest $request): AttendanceStatusResource
     {
         $attendanceId = $request->attendance_id;
 
-        /** @var Attendance */
         $attendance = Attendance::with(['course.chapters.lessons.lessonAttendances'])->findOrFail($attendanceId);
+        assert($attendance instanceof Attendance);
 
         if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
             throw new AuthorizationException(

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -4,10 +4,10 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Attendance\DeleteRequest;
-use App\Http\Requests\Instructor\AttendanceShowRequest;
-use App\Http\Requests\Instructor\AttendanceShowStatusRequest;
-use App\Http\Requests\Instructor\AttendanceStatusRequest;
-use App\Http\Requests\Instructor\AttendanceStoreRequest;
+use App\Http\Requests\Instructor\Attendance\ShowRequest;
+use App\Http\Requests\Instructor\Attendance\ShowStatusRequest;
+use App\Http\Requests\Instructor\Attendance\StatusRequest;
+use App\Http\Requests\Instructor\Attendance\StoreRequest;
 use App\Http\Requests\Instructor\LoginRateRequest;
 use App\Http\Resources\Instructor\AttendanceShowResource;
 use App\Http\Resources\Instructor\AttendanceStatusResource;
@@ -30,7 +30,7 @@ class AttendanceController extends Controller
     /**
      * 受講状況登録API
      */
-    public function store(AttendanceStoreRequest $request): JsonResponse
+    public function store(StoreRequest $request): JsonResponse
     {
         $attendance = Attendance::where('course_id', $request->course_id)
             ->where('student_id', $request->student_id)
@@ -74,7 +74,7 @@ class AttendanceController extends Controller
     /**
      * 受講状況取得API
      */
-    public function show(AttendanceShowRequest $request): AttendanceShowResource
+    public function show(ShowRequest $request): AttendanceShowResource
     {
         $courseId = $request->course_id;
 
@@ -165,7 +165,7 @@ class AttendanceController extends Controller
     /**
      * 完了済みレッスン数と完了済みチャプター数取得API
      */
-    public function showStatus(AttendanceShowStatusRequest $request): JsonResponse
+    public function showStatus(ShowStatusRequest $request): JsonResponse
     {
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
         $period = $request->period;
@@ -230,7 +230,7 @@ class AttendanceController extends Controller
      *
      * @return AttendanceStatusResource|JsonResponse
      */
-    public function status(AttendanceStatusRequest $request)
+    public function status(StatusRequest $request)
     {
         $attendanceId = $request->attendance_id;
 

--- a/app/Http/Requests/Instructor/Attendance/ShowRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/ShowRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Requests\Instructor;
+namespace App\Http\Requests\Instructor\Attendance;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttendanceStatusRequest extends FormRequest
+class ShowRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -24,14 +24,14 @@ class AttendanceStatusRequest extends FormRequest
     public function rules()
     {
         return [
-            'attendance_id' => ['required', 'integer', 'exists:attendances,id,deleted_at,NULL'],
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
         ];
     }
 
     protected function prepareForValidation()
     {
         $this->merge([
-            'attendance_id' => $this->route('attendance_id'),
+            'course_id' => $this->route('course_id'),
         ]);
     }
 }

--- a/app/Http/Requests/Instructor/Attendance/ShowStatusRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/ShowStatusRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Http\Requests\Instructor;
+namespace App\Http\Requests\Instructor\Attendance;
 
 use App\Rules\LessonAttendancePeriodRule;
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttendanceShowStatusRequest extends FormRequest
+class ShowStatusRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/Instructor/Attendance/StatusRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/StatusRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Requests\Instructor;
+namespace App\Http\Requests\Instructor\Attendance;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttendanceStoreRequest extends FormRequest
+class StatusRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -24,8 +24,14 @@ class AttendanceStoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'exists:courses,id,deleted_at,NULL', 'integer'],
-            'student_id' => ['required', 'exists:students,id,deleted_at,NULL', 'integer'],
+            'attendance_id' => ['required', 'integer', 'exists:attendances,id,deleted_at,NULL'],
         ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'attendance_id' => $this->route('attendance_id'),
+        ]);
     }
 }

--- a/app/Http/Requests/Instructor/Attendance/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/StoreRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Requests\Instructor;
+namespace App\Http\Requests\Instructor\Attendance;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttendanceShowRequest extends FormRequest
+class StoreRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -24,14 +24,8 @@ class AttendanceShowRequest extends FormRequest
     public function rules()
     {
         return [
-            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'course_id' => ['required', 'exists:courses,id,deleted_at,NULL', 'integer'],
+            'student_id' => ['required', 'exists:students,id,deleted_at,NULL', 'integer'],
         ];
-    }
-
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'course_id' => $this->route('course_id'),
-        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -109,9 +109,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
                     // 講師-講座-受講
                     Route::prefix('attendance')->group(function () {
-                        Route::get('status', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'show']);
+                        Route::prefix('status')->group(function () {
+                            Route::get('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'show']);
+                            Route::get('{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'showStatus']);
+                        });
                         Route::get('{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'loginRate']);
-                        Route::get('status/{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'showStatus']);
                     });
                 });
             });
@@ -206,11 +208,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         });
                         //マネージャー生徒学習状況
                         Route::prefix('attendance')->group(function () {
-                            Route::get('{period}', 'Api\Manager\AttendanceController@loginRate');
                             Route::prefix('status')->group(function () {
                                 Route::get('/', 'Api\Manager\AttendanceController@show');
                                 Route::get('{period}', 'Api\Manager\AttendanceController@showStatus');
                             });
+                            Route::get('{period}', 'Api\Manager\AttendanceController@loginRate');
                         });
                     });
                 });

--- a/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_当日の出席状況を取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/1/attendance/status/today');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_今月の出席状況を取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/1/attendance/status/month');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_無効のパラメータ(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/1000/attendance/status/invalid');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'period',
+        ]);
+    }
+
+    public function test_権限のない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/4/attendance/status/today');
+
+        // assert
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/Instructor/Attendance/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講状況取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/1/attendance/status');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/1/attendance/status');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/aaa/attendance/status');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Attendance/StatusTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/StatusTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講状況取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/attendance/1/status');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/attendance/1/status');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/attendance/aaa/status');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'attendance_id',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Attendance/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/StoreTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/attendance', [
+            'course_id' => 1,
+            'student_id' => 3,
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+    }
+
+    public function test_受講中の生徒_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/attendance', [
+            'course_id' => 1,
+            'student_id' => 1,
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/attendance', [
+            'course_id' => 2,
+            'student_id' => 3,
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/attendance', []);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'student_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes
#JKA-1101 app/Http/Requests/Instructor/Attendanceディレクトリが肥大化しているための整理

## 概要
- ディレクトリを現在より細かく分け、Requestクラス名にはコントローラーのメソッド名を使用するように修正

## 動作確認手順
全てstudents_idは1でログインしています。

- storeメソッド
テストケース1（正常系：受講済ではない）
URL：http://localhost:8080/api/v1/instructor/attendance
入力値：
```
　{
 　 "student_id": 3,
 　 "course_id": 1
　}
```
結果：
```
"result": true
```

テストケース2（異常系：受講済）
URL：http://localhost:8080/api/v1/instructor/attendance
入力値：
```
{
 　 "student_id": 2,
 　 "course_id": 1
}
```
結果：
```
"message": "Attendance record already exists."
```

- showメソッド
テストケース1（正常系：受講済のチャプター）
URL：http://localhost:8080/api/v1/instructor/course/:course_id/attendance/status
パラメータ：
```
course_id = 1
```
結果：対象のものが出力されていることを確認

- showStatusメソッド
テストケース1（正常系：完了済みレッスン数と完了済みチャプター数を取得）
URL：http://localhost:8080/api/v1/instructor/course/:course_id/attendance/status/:period
結果：
```
{
    "completed_lessons_count": 3,
    "completed_chapters_count": 1
}
```

- statusメソッド
テストケース1（正常系：ログインしている講師のチャプターを取得）
URL：http://localhost:8080/api/v1/instructor/attendance/:attendance_id/status
パラメータ：
```
attendance_id = 2
```
結果：対象のものが出力されて追加されていることを確認

テストケース2（異常系：ログインしていない講師のチャプター）
URL：http://localhost:8080/api/v1/instructor/attendance/:attendance_id/status
結果：
```
"message": "Forbidden, not allowed to access this course."
```

## 考慮して欲しいこと
## 確認して欲しいこと





































































