### PR TITLE
JKA-1070 AttendanceControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（櫻井）

### DIFF
--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -57,7 +57,7 @@ class StudentController extends Controller
             $courseId = (int) $courseId;
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
-                throw new AuthorizationException('Forbidden, not allowed to access this course.');
+                throw new AuthorizationException('Forbidden, invalid course_id.');
             }
         }
 
@@ -122,7 +122,7 @@ class StudentController extends Controller
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();
         if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
-            throw new AuthorizationException('Forbidden, not allowed to access this course.');
+            throw new AuthorizationException('Forbidden, invalid instructor.');
         }
 
         return new StudentShowResource($student);

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -57,7 +57,7 @@ class StudentController extends Controller
             $courseId = (int) $courseId;
             if (! in_array($courseId, $courseIds, true)) {
                 // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
-                throw new AuthorizationException('Forbidden, invalid course_id.');
+                throw new AuthorizationException('Forbidden, not allowed to access this course.');
             }
         }
 
@@ -122,7 +122,7 @@ class StudentController extends Controller
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();
         if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
-            throw new AuthorizationException('Not authorized.');
+            throw new AuthorizationException('Forbidden, not allowed to access this course.');
         }
 
         return new StudentShowResource($student);

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -15,6 +15,7 @@ use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class StudentController extends Controller
 {
@@ -50,11 +51,7 @@ class StudentController extends Controller
         $course = Course::find($request->course_id);
 
         if (! in_array($course->id, $courseIds, true)) {
-            // リクエストされた講座が自身または配下の講師の講座に所属しているか確認
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized.',
-            ], 403);
+            throw new AuthorizationException('Not authorized.');
         }
 
         $results = DB::table('attendances')
@@ -121,10 +118,7 @@ class StudentController extends Controller
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();
         if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized to access this student.',
-            ], 403);
+            throw new AuthorizationException('Not authorized.');
         }
 
         return new StudentShowResource($student);

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -14,6 +14,7 @@ use App\Model\Student;
 use App\Services\Student\QueryService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -38,7 +39,7 @@ class StudentController extends Controller
 
         // 配下のinstructor情報を取得
         $manager = Instructor::with('managings')->findOrFail($instructorId);
-        
+
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
@@ -48,14 +49,16 @@ class StudentController extends Controller
             ->pluck('id')
             ->toArray();
 
-        $course = Course::find($request->course_id);
+        // クエリパラメータからcourse_idを取得
+        $courseId = $request->query('course_id');
 
-        if (! in_array($course->id, $courseIds, true)) {
-            // リクエストされた講座が自身または配下の講師の講座に所属しているか確認
-            return response()->json([
-                'result' => false,
-                'message' => 'Not authorized.',
-            ], 403);
+        // クエリパラメータにcourse_idが存在する場合の処理
+        if ($courseId !== null) {
+            $courseId = (int) $courseId;
+            if (! in_array($courseId, $courseIds, true)) {
+                // 指定されたcourse_idが自分または配下の講師の講座に所属しているか確認
+                throw new AuthorizationException('Forbidden, invalid course_id.');
+            }
         }
 
         $results = DB::table('attendances')
@@ -69,9 +72,11 @@ class StudentController extends Controller
                 'attendances.created_at as attendanced_at'
             )
             ->join('students', 'attendances.student_id', '=', 'students.id')
-            ->where('attendances.course_id', $request->course_id)
+            ->when($courseId, function (Builder $query) use ($courseId) {
+                $query->where('attendances.course_id', $courseId);
+            })
             // 受講生名検索（ニックネーム/メールアドレス/姓名）
-            ->when($inputText, function ($query) use ($inputText) {
+            ->when($inputText, function (Builder $query) use ($inputText) {
                 $inputText = preg_replace('/[　\s]/u', '', $inputText);
                 $query->where(function ($query) use ($inputText) {
                     $query->orWhere('students.nick_name', 'LIKE', "%{$inputText}%")
@@ -80,22 +85,17 @@ class StudentController extends Controller
                 });
             })
             // 日付検索
-            ->when($startDate, function ($query) use ($startDate) {
+            ->when($startDate, function (Builder $query) use ($startDate) {
                 $query->where('attendances.created_at', '>=', $startDate);
             })
-            ->when($endDate, function ($query) use ($endDate) {
+            ->when($endDate, function (Builder $query) use ($endDate) {
                 $query->where('attendances.created_at', '<=', $endDate);
             })
             // ソート
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        $course = Course::find($request->course_id);
-
-        return new StudentIndexResource([
-            'course' => $course,
-            'data' => $results,
-        ]);
+        return new StudentIndexResource($results);
     }
 
     /**
@@ -122,11 +122,11 @@ class StudentController extends Controller
         // 受講生が講師の講座に所属しているか確認
         $studentCourseIds = $student->attendances->pluck('course_id')->unique();
         if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
-            throw new AuthorizationException('Forbidden, not allowed to access this course.');
-    }
+            throw new AuthorizationException('Not authorized.');
+        }
 
-    return new StudentShowResource($student);
-}
+        return new StudentShowResource($student);
+    }
 
     /**
      * 受講生登録API

--- a/tests/Feature/Api/Manager/Student/ShowTest.php
+++ b/tests/Feature/Api/Manager/Student/ShowTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Student;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_生徒取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_許可がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/bbb');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'student_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
#JKA-1070 講師とマネジャーのAttendanceControllerの未対応部分にthrow new AuthorizationExceptionとthrow $eの適用
## テスト
### Postmanにて確認

#### 受講生一覧取得API
- 取得できた状態
URL：http://localhost:8080/api/v1/manager/course/1/student/index
 Origin → http://localhost:3000/
 Referer → http://localhost:3000/
 course_id → 1

 - 取得できない状態をテスト入力して確認
 - URL：http://localhost:8080/api/v1/manager/course/4/student/index
 Origin → http://localhost:3000/
 Referer → http://localhost:3000/
 course_id → 1
"message": "Not authorized.",


#### 受講生詳細取得API
- 取得できた状態
URL：http://localhost:8080/api/v1/manager/student/1
 Origin → http://localhost:3000/
 Referer → http://localhost:3000/
 X-XSRF-TOKEN → {{XSRF-TOKEN}}
 student_id → 1

 - 取得できない状態をテスト入力して確認
URL：http://localhost:8080/api/v1/manager/student/4
 Origin → http://localhost:3000/
 Referer → http://localhost:3000/
 course_id → 1
"message": "Not authorized.",
