### PR TITLE
JKA-1069 Manager/NotificationControlle未対応部分にthrow new AuthorizationExceptionとthrow $eの適用（竹内）

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "managings"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "cSpell.words": [
-        "managings"
-    ]
-}

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -99,7 +99,7 @@ class NotificationController extends Controller
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
-        
+
         DB::beginTransaction();
         try {
             Notification::create([
@@ -116,7 +116,7 @@ class NotificationController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
             throw $e;
@@ -150,20 +150,20 @@ class NotificationController extends Controller
 
         DB::beginTransaction();
         try {
-        $notification->fill([
-            'type' => $request->type,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-            'title' => $request->title,
-            'content' => $request->content,
-        ])
-            ->save();
-        DB::commit();
+            $notification->fill([
+                'type' => $request->type,
+                'start_date' => $request->start_date,
+                'end_date' => $request->end_date,
+                'title' => $request->title,
+                'content' => $request->content,
+            ])
+                ->save();
+            DB::commit();
 
-        return response()->json([
-            'result' => true,
-        ]);
-        }catch(Exception $e) {
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);
             throw $e;

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -99,20 +99,28 @@ class NotificationController extends Controller
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
+        
+        DB::beginTransaction();
+        try {
+            Notification::create([
+                'course_id' => $request->course_id,
+                'instructor_id' => Auth::guard('instructor')->user()->id,
+                'title' => $request->title,
+                'type' => $request->type,
+                'start_date' => $request->start_date,
+                'end_date' => $request->end_date,
+                'content' => $request->content,
+            ]);
+            DB::commit();
 
-        Notification::create([
-            'course_id' => $request->course_id,
-            'instructor_id' => Auth::guard('instructor')->user()->id,
-            'title' => $request->title,
-            'type' => $request->type,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-            'content' => $request->content,
-        ]);
-
-        return response()->json([
-            'result' => true,
-        ]);
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch(Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
     }
 
     /**
@@ -133,14 +141,15 @@ class NotificationController extends Controller
 
         // 指定されたお知らせIDでお知らせを取得
         /** @var Notification $notification */
-        $notification = Notification::with(['course'])
-            ->findOrFail($request->notification_id);
+        $notification = Notification::with('course')->findOrFail($request->notification_id);
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
 
+        DB::beginTransaction();
+        try {
         $notification->fill([
             'type' => $request->type,
             'start_date' => $request->start_date,
@@ -149,10 +158,16 @@ class NotificationController extends Controller
             'content' => $request->content,
         ])
             ->save();
+        DB::commit();
 
         return response()->json([
             'result' => true,
         ]);
+        }catch(Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -27,10 +27,8 @@ class NotificationController extends Controller
 {
     /**
      * お知らせ一覧取得API
-     *
-     * @return NotificationIndexResource
      */
-    public function index(NotificationIndexRequest $request)
+    public function index(NotificationIndexRequest $request): NotificationIndexResource
     {
         $perPage = $request->input('per_page', 20);
         $page = $request->input('page', 1);
@@ -53,10 +51,8 @@ class NotificationController extends Controller
 
     /**
      * お知らせ詳細
-     *
-     * @return NotificationShowResource|\Illuminate\Http\JsonResponse
      */
-    public function show(NotificationShowRequest $request)
+    public function show(NotificationShowRequest $request): NotificationShowResource
     {
         // ユーザーID取得
         $instructorId = $request->user()->id;
@@ -81,21 +77,19 @@ class NotificationController extends Controller
 
     /**
      * お知らせ登録API
-     *
-     * @return \Illuminate\Http\JsonResponse
      */
-    public function store(NotificationStoreRequest $request)
+    public function store(NotificationStoreRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 配下のインストラクター情報を取得
-        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
+        assert($manager instanceof Instructor);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        /** @var Course $course */
         $course = Course::findOrFail($request->course_id);
+        assert($course instanceof Course);
         if (! in_array($course->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
@@ -125,23 +119,21 @@ class NotificationController extends Controller
 
     /**
      * お知らせ更新API
-     *
-     * @return \Illuminate\Http\JsonResponse
      */
-    public function update(NotificationUpdateRequest $request)
+    public function update(NotificationUpdateRequest $request): JsonResponse
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得
-        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
+        assert($manager instanceof Instructor);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
         // 指定されたお知らせIDでお知らせを取得
-        /** @var Notification $notification */
         $notification = Notification::with('course')->findOrFail($request->notification_id);
+        assert($notification instanceof Notification);
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {
@@ -172,23 +164,21 @@ class NotificationController extends Controller
 
     /**
      * お知らせ削除
-     *
-     * @return \Illuminate\Http\JsonResponse
      */
-    public function delete(NotificationDeleteRequest $request)
+    public function delete(NotificationDeleteRequest $request): JsonResponse
     {
         // 認証している講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得
-        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
+        assert($manager instanceof Instructor);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
         // 指定されたお知らせを取得
-        /** @var Notification $notification */
         $notification = Notification::findOrFail($request->notification_id);
+        assert($notification instanceof Notification);
 
         // アクセス権限のチェック
         if (! in_array($notification->instructor_id, $instructorIds, true)) {

--- a/app/Http/Requests/Manager/NotificationStoreRequest.php
+++ b/app/Http/Requests/Manager/NotificationStoreRequest.php
@@ -17,6 +17,13 @@ class NotificationStoreRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -2,12 +2,18 @@
 
 namespace App\Model;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Notification extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\NotificationFactory::new();
+    }
 
     /**
      * モデルと関連しているテーブル

--- a/database/factories/NotificationFactory.php
+++ b/database/factories/NotificationFactory.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class NotificationFactory extends Factory
 {
     protected $model = Notification::class;
+
     /**
      * Define the model's default state.
      *

--- a/database/factories/NotificationFactory.php
+++ b/database/factories/NotificationFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Model\Notification;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Notification>
+ */
+class NotificationFactory extends Factory
+{
+    protected $model = Notification::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'course_id' => 1,
+            'instructor_id' => 1,
+            'title' => $this->faker->sentence,
+            'type' => 'once',
+            'start_date' => $this->faker->dateTimeBetween('-1 week', '+1 week'),
+            'end_date' => $this->faker->dateTimeBetween('+1 week', '+2 week'),
+            'content' => $this->faker->paragraph,
+        ];
+    }
+}

--- a/tests/Feature/Api/Manager/Notification/StoreTest.php
+++ b/tests/Feature/Api/Manager/Notification/StoreTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Model\Instructor;
+use App\Model\Course;
+use App\Model\Notification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(); 
+    }
+
+    public function test_お知らせ登録_成功(): void
+    {   
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $course = Course::find(1);
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/' . $course->id . '/notification', [
+            'title' => 'test',
+            'type' => 'once',
+            'start_date' => '2025-01-01 10:00:00',
+            'end_date' => '2025-01-01 18:00:00',
+            'content' => 'これはテストの内容です',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'result' => true,
+        ]);
+        $this->assertDatabaseHas('notifications', [
+            'title' => 'test',
+            'type' => Notification::TYPE_ONCE_INT,
+            'course_id' => $course->id,
+        ]);
+    }
+
+    public function test_お知らせ登録_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $course = Course::find(1);
+
+        //act
+        $response = $this->postJson('/api/v1/manager/course/' . $course->id . '/notification', [
+            'title' => '', // 空
+            'type' => '',  // 空
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'title',
+            'type',
+            'start_date',
+            'end_date',
+            'content',
+        ]);
+    }
+
+    public function test_お知らせ登録_権限エラー(): void
+    {
+        // arrange
+        $unauthorizedInstructor = Instructor::find(2);
+        $this->actingAs($unauthorizedInstructor, 'instructor');
+    
+        $course = Course::find(1);
+        
+        // act
+        $response = $this->postJson('/api/v1/manager/course/' . $course->id . '/notification', [
+            'title' => '権限なしテスト',
+            'type' => 'once',
+            'start_date' => '2025-01-01 10:00:00',
+            'end_date' => '2025-01-10 18:00:00',
+            'content' => 'これはテストの内容です。',
+        ]);
+    
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Notification/StoreTest.php
+++ b/tests/Feature/Api/Manager/Notification/StoreTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use App\Model\Instructor;
 use App\Model\Course;
+use App\Model\Instructor;
 use App\Model\Notification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -15,11 +15,11 @@ class StoreTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(); 
+        $this->seed();
     }
 
     public function test_お知らせ登録_成功(): void
-    {   
+    {
         // arrange
         $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
@@ -27,7 +27,7 @@ class StoreTest extends TestCase
         $course = Course::find(1);
 
         // act
-        $response = $this->postJson('/api/v1/manager/course/' . $course->id . '/notification', [
+        $response = $this->postJson('/api/v1/manager/course/'.$course->id.'/notification', [
             'title' => 'test',
             'type' => 'once',
             'start_date' => '2025-01-01 10:00:00',
@@ -56,7 +56,7 @@ class StoreTest extends TestCase
         $course = Course::find(1);
 
         //act
-        $response = $this->postJson('/api/v1/manager/course/' . $course->id . '/notification', [
+        $response = $this->postJson('/api/v1/manager/course/'.$course->id.'/notification', [
             'title' => '', // 空
             'type' => '',  // 空
         ]);
@@ -77,18 +77,18 @@ class StoreTest extends TestCase
         // arrange
         $unauthorizedInstructor = Instructor::find(2);
         $this->actingAs($unauthorizedInstructor, 'instructor');
-    
+
         $course = Course::find(1);
-        
+
         // act
-        $response = $this->postJson('/api/v1/manager/course/' . $course->id . '/notification', [
+        $response = $this->postJson('/api/v1/manager/course/'.$course->id.'/notification', [
             'title' => '権限なしテスト',
             'type' => 'once',
             'start_date' => '2025-01-01 10:00:00',
             'end_date' => '2025-01-10 18:00:00',
             'content' => 'これはテストの内容です。',
         ]);
-    
+
         // assert
         $response->assertStatus(403);
         $response->assertJson([

--- a/tests/Feature/Api/Manager/Notification/UpdateTest.php
+++ b/tests/Feature/Api/Manager/Notification/UpdateTest.php
@@ -14,11 +14,11 @@ class UpdateTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed(); 
+        $this->seed();
     }
 
     public function test_お知らせ更新_成功(): void
-    {   
+    {
         // arrange
         $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
         ]);
 
         // act
-        $response = $this->patchJson('/api/v1/manager/notification/' . $notification->id, [
+        $response = $this->patchJson('/api/v1/manager/notification/'.$notification->id, [
             'title' => 'update',
             'type' => 'once',
             'start_date' => '2025-01-01 10:00:00',
@@ -59,7 +59,7 @@ class UpdateTest extends TestCase
         ]);
 
         // act
-        $response = $this->patchJson('/api/v1/manager/notification/' . $notification->id, [
+        $response = $this->patchJson('/api/v1/manager/notification/'.$notification->id, [
             'title' => '', // 空
             'type' => '',  // 空
         ]);
@@ -80,20 +80,20 @@ class UpdateTest extends TestCase
         // arrange
         $unauthorizedInstructor = Instructor::find(2);
         $this->actingAs($unauthorizedInstructor, 'instructor');
-    
+
         $notification = Notification::factory()->create([
             'instructor_id' => 1,
         ]);
 
         // act
-        $response = $this->patchJson('/api/v1/manager/notification/' . $notification->id, [
+        $response = $this->patchJson('/api/v1/manager/notification/'.$notification->id, [
             'title' => '権限なしテスト',
             'type' => 'once',
             'start_date' => '2025-01-01 10:00:00',
             'end_date' => '2025-01-10 18:00:00',
             'content' => 'これはテストの内容です。',
         ]);
-    
+
         // assert
         $response->assertStatus(403);
         $response->assertJson([

--- a/tests/Feature/Api/Manager/Notification/UpdateTest.php
+++ b/tests/Feature/Api/Manager/Notification/UpdateTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Model\Instructor;
+use App\Model\Notification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(); 
+    }
+
+    public function test_お知らせ更新_成功(): void
+    {   
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $notification = Notification::factory()->create([
+            'instructor_id' => $instructor->id,
+        ]);
+
+        // act
+        $response = $this->patchJson('/api/v1/manager/notification/' . $notification->id, [
+            'title' => 'update',
+            'type' => 'once',
+            'start_date' => '2025-01-01 10:00:00',
+            'end_date' => '2025-01-01 18:00:00',
+            'content' => 'updateテスト',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'result' => true,
+        ]);
+        $this->assertDatabaseHas('notifications', [
+            'title' => 'update',
+            'type' => Notification::TYPE_ONCE_INT,
+            'content' => 'updateテスト',
+        ]);
+    }
+
+    public function test_お知らせ更新_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $notification = Notification::factory()->create([
+            'instructor_id' => $instructor->id,
+        ]);
+
+        // act
+        $response = $this->patchJson('/api/v1/manager/notification/' . $notification->id, [
+            'title' => '', // 空
+            'type' => '',  // 空
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'title',
+            'type',
+            'start_date',
+            'end_date',
+            'content',
+        ]);
+    }
+
+    public function test_お知らせ更新_権限エラー(): void
+    {
+        // arrange
+        $unauthorizedInstructor = Instructor::find(2);
+        $this->actingAs($unauthorizedInstructor, 'instructor');
+    
+        $notification = Notification::factory()->create([
+            'instructor_id' => 1,
+        ]);
+
+        // act
+        $response = $this->patchJson('/api/v1/manager/notification/' . $notification->id, [
+            'title' => '権限なしテスト',
+            'type' => 'once',
+            'start_date' => '2025-01-01 10:00:00',
+            'end_date' => '2025-01-10 18:00:00',
+            'content' => 'これはテストの内容です。',
+        ]);
+    
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+}


### PR DESCRIPTION
### issue
## Manager/NotificationControlle未対応部分にthrow new AuthorizationExceptionとthrow $eの適用
※以前作成したブランチ（feature/takeuchi/jka-1069/Manager/NotificationController_error_correct）の使用をやめ、
新しくブランチを作成しました。

## 動作確認手順

### Manager/NotificationController
### storeメソッド
1. 正常：自分(マネージャー)と配下の講座の場合、お知らせを登録できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/1/notification
 - HTTPメソッド：POST
 - 結果：200 OK

2. 異常：自分(マネージャー)と配下の講座ではない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/course/4/notification
 - HTTPメソッド：POST
 - 結果：403 Forbidden  
"message": "Invalid instructor_id."

3. try {} の{}の中に一時的に書いて、テストする（テスト後は削除する）
- instructor_id=1でログイン
- URL：http://localhost:8080/api/v1/manager/course/1/notification
- HTTPメソッド：POST
- 結果：500　Internal Server Error
"message": "テスト用の例外が発生しました"


### updateメソッド
1. 正常：自分(マネージャー)と配下の講座の場合、お知らせを更新できる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/notification/1
 - HTTPメソッド：PATCH
 - 結果：200 OK

2. 異常：自分(マネージャー)と配下の講座ではない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/notification/3
 - HTTPメソッド：PATCH
 - 結果：403 Forbidden  
"message": "Invalid instructor_id."

3. try {} の{}の中に一時的に書いて、テストする（テスト後は削除する）
- instructor_id=1でログイン
- URL：http://localhost:8080/api/v1/manager/notification/1
- HTTPメソッド：PATCH
- 結果：500　Internal Server Error
"message": "テスト用の例外が発生しました"


## 確認して欲しい点
1. `git cherry-pick`コマンドで以下のコミットを取得しました。

- fc41c17415deba995d2f8240719477dcec35bd3a
- 764aebb28de7749d0a78aa84715c896f27696f20
- b2d824cbd842e4f8a72ccf4e58c8078603725a3f

2. vscodeをバージョン管理の対象から外すためgitignoreに.vscode/settings.jsonを記述しました。