### PR TITLE
JKA-1114：講師側の app/Http/Controllers/Api/Instructor/AttendanceController.php において、講師 ID が一致しない講座でも処理が実行される問題の解消（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -46,8 +46,8 @@ class AttendanceController extends Controller
         if (Attendance::where('course_id', $request->course_id)
             ->where('student_id', $request->student_id)
             ->exists()) {
-                // 受講状況が存在する場合はエラーを返す
-                throw new AuthorizationException('Attendance record already exists.');
+            // 受講状況が存在する場合はエラーを返す
+            throw new AuthorizationException('Attendance record already exists.');
         }
 
         DB::beginTransaction();

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -32,14 +32,22 @@ class AttendanceController extends Controller
      */
     public function store(StoreRequest $request): JsonResponse
     {
-        $attendance = Attendance::where('course_id', $request->course_id)
-            ->where('student_id', $request->student_id)
-            ->first();
+        $instructorId = Auth::guard('instructor')->user()->id;
 
-        if ($attendance) {
-            throw new AuthorizationException(
-                'Attendance record already exists.'
-            );
+        $courseIds = Course::where('instructor_id', $instructorId)
+            ->pluck('id')
+            ->toArray();
+
+        if (! in_array($request->course_id, $courseIds, true)) {
+            // 講師の所有する講座でない場合はエラーを返す
+            throw new AuthorizationException('Forbidden.');
+        }
+
+        if (Attendance::where('course_id', $request->course_id)
+            ->where('student_id', $request->student_id)
+            ->exists()) {
+                // 受講状況が存在する場合はエラーを返す
+                throw new AuthorizationException('Attendance record already exists.');
         }
 
         DB::beginTransaction();
@@ -76,7 +84,14 @@ class AttendanceController extends Controller
      */
     public function show(ShowRequest $request): AttendanceShowResource
     {
+        $instructorId = Auth::guard('instructor')->user()->id;
         $courseId = $request->course_id;
+        $course = Course::findOrFail($courseId);
+
+        if ($course->instructor_id !== $instructorId) {
+            // ログインしている講師の講座でない場合はエラーを返す
+            throw new AuthorizationException('Forbidden.');
+        }
 
         /** @var Collection<int, Chapter> */
         $chapters = Chapter::with('lessons.lessonAttendances')->where('course_id', $courseId)->get();
@@ -167,7 +182,16 @@ class AttendanceController extends Controller
      */
     public function showStatus(ShowStatusRequest $request): JsonResponse
     {
-        $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $request->course_id)->get();
+        $instructorId = Auth::guard('instructor')->user()->id;
+        $courseId = $request->course_id;
+        $course = Course::findOrFail($courseId);
+
+        if ($course->instructor_id !== $instructorId) {
+            // ログインしている講師の講座でない場合はエラーを返す
+            throw new AuthorizationException('Forbidden.');
+        }
+
+        $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $courseId)->get();
         $period = $request->period;
 
         // 指定期間内に完了したレッスンの個数を取得

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -40,7 +40,7 @@ class AttendanceController extends Controller
 
         if (! in_array($request->course_id, $courseIds, true)) {
             // 講師の所有する講座でない場合はエラーを返す
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         if (Attendance::where('course_id', $request->course_id)
@@ -90,7 +90,7 @@ class AttendanceController extends Controller
 
         if ($course->instructor_id !== $instructorId) {
             // ログインしている講師の講座でない場合はエラーを返す
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         /** @var Collection<int, Chapter> */
@@ -188,7 +188,7 @@ class AttendanceController extends Controller
 
         if ($course->instructor_id !== $instructorId) {
             // ログインしている講師の講座でない場合はエラーを返す
-            throw new AuthorizationException('Forbidden.');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         $attendances = Attendance::with('lessonAttendances.lesson.chapter.course')->where('course_id', $courseId)->get();


### PR DESCRIPTION
## issue
JKA-1114：講師側の app/Http/Controllers/Api/Instructor/AttendanceController.php において、講師 ID が一致しない講座でも処理が実行される問題の解消

## 概要
講師IDが一致しない講座の場合、処理が実行されないよう修正する。

## 動作確認
### storeメソッド（受講状況の登録）
1. 正常：指定された講座に紐づく講師IDとログイン中の講師が一致する場合、処理が実行される
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance
 - HTTPメソッド：POST
 - 結果：200 OK  
"result": true

2. 異常：指定された講座に紐づく講師IDとログイン中の講師が一致しない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance
 - HTTPメソッド：POST
 - body例
```
{
  "student_id": 3,
  "course_id": 2
}
```
 - 結果：403 Forbidden  
"message": "Forbidden, invalid instructor_id."

3. 異常：既に受講状況が存在する場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/attendance
 - HTTPメソッド：POST
 - body例
```
{
  "student_id": 1,
  "course_id": 1
}
```
 - 結果：403 Forbidden  
"message": "Attendance record already exists."

### showメソッド（受講状況取得）
1. 正常：指定された講座に紐づく講師IDとログイン中の講師が一致する場合、処理が実行される
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/attendance/status
 - HTTPメソッド：GET
 - 結果：200 OK

2. 異常：指定された講座に紐づく講師IDとログイン中の講師が一致しない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/attendance/status
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
"message": "Forbidden, invalid instructor_id."

### showStatusメソッド（完了済みレッスン数と完了済みチャプター数取得）
1. 正常：指定された講座に紐づく講師IDとログイン中の講師が一致する場合、処理が実行される
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/1/attendance/status/month
 - HTTPメソッド：GET
 - 結果：200 OK

2. 異常：指定された講座に紐づく講師IDとログイン中の講師が一致しない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/2/attendance/status/month
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
"message": "Forbidden, invalid instructor_id."