### PR TITLE
api.phpをLaravel11系ドキュメントに合わせた記述に変更

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,10 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\Manager\LessonController;
+use App\Http\Controllers\Api\Manager\NotificationController;
+use App\Http\Controllers\Api\Manager\StudentController;
 
 /*
 |--------------------------------------------------------------------------
@@ -188,23 +192,21 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::delete('/', [App\Http\Controllers\Api\Manager\ChapterController::class, 'delete']);
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
                                 // マネージャー-講座-チャプター-レッスン
-                                Route::prefix('lesson')->group(function () {
-                                    Route::post('/', 'Api\Manager\LessonController@store');
-                                    Route::post('sort', 'Api\Manager\LessonController@sort');
-                                    Route::put('status', 'Api\Manager\LessonController@putStatus');
-                                    Route::delete('/', 'Api\Manager\LessonController@bulkDelete');
-                                    Route::delete('all', 'Api\Manager\LessonController@deleteAll');
-                                    Route::prefix('{lesson_id}')->group(function () {
-                                        Route::put('/', 'Api\Manager\LessonController@put');
-                                        Route::delete('/', 'Api\Manager\LessonController@delete');
-                                        Route::patch('status', 'Api\Manager\LessonController@updateStatus');
-                                        Route::patch('title', 'Api\Manager\LessonController@updateTitle');
+                                Route::group(['prefix' => 'lesson'], function () {
+                                    Route::post('/', [LessonController::class, 'store']);
+                                    Route::post('sort', [LessonController::class, 'sort']);
+                                    Route::put('status', [LessonController::class, 'putStatus']);
+                                    Route::delete('/', [LessonController::class, 'bulkDelete']);
+                                    Route::delete('all', [LessonController::class, 'deleteAll']);
+
+                                    Route::group(['prefix' => '{lesson_id}'], function () {
+                                        Route::put('/', [LessonController::class, 'put']);
+                                        Route::delete('/', [LessonController::class, 'delete']);
+                                        Route::patch('status', [LessonController::class, 'updateStatus']);
+                                        Route::patch('title', [LessonController::class, 'updateTitle']);
                                     });
                                 });
                             });
-                        });
-                        Route::prefix('notification')->group(function () {
-                            Route::post('/', 'Api\Manager\NotificationController@store');
                         });
                         //マネージャー生徒学習状況
                         Route::prefix('attendance')->group(function () {
@@ -226,21 +228,23 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     });
                 });
                 // マネージャー-生徒
-                Route::prefix('student')->group(function () {
+                Route::group(['prefix' => 'student'], function () {
                     // マネージャー-講座-生徒
-                    Route::get('index', 'Api\Manager\StudentController@index');
-                    Route::get('{student_id}', 'Api\Manager\StudentController@show');
-                    Route::post('/', 'Api\Manager\StudentController@store');
+                    Route::get('index', [StudentController::class, 'index']);
+                    Route::get('{student_id}', [StudentController::class, 'show']);
+                    Route::post('/', [StudentController::class, 'store']);
                 });
                 // マネージャー-お知らせ
-                Route::prefix('notification')->group(function () {
-                    Route::get('index', 'Api\Manager\NotificationController@index');
-                    Route::put('type/{notification_type}', 'Api\Manager\NotificationController@updateType');
-                    Route::delete('/', 'Api\Manager\NotificationController@bulkDelete');
-                    Route::prefix('{notification_id}')->group(function () {
-                        Route::get('/', 'Api\Manager\NotificationController@show');
-                        Route::patch('/', 'Api\Manager\NotificationController@update');
-                        Route::delete('/', 'Api\Manager\NotificationController@delete');
+                Route::group(['prefix' => 'notification'], function () {
+                    Route::post('/', [NotificationController::class, 'store']);
+                    Route::get('index', [NotificationController::class, 'index']);
+                    Route::put('type/{notification_type}', [NotificationController::class, 'updateType']);
+                    Route::delete('/', [NotificationController::class, 'bulkDelete']);
+
+                    Route::group(['prefix' => '{notification_id}'], function () {
+                        Route::get('/', [NotificationController::class, 'show']);
+                        Route::patch('/', [NotificationController::class, 'update']);
+                        Route::delete('/', [NotificationController::class, 'delete']);
                     });
                 });
             });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\Manager\LessonController;
 use App\Http\Controllers\Api\Manager\NotificationController;
 use App\Http\Controllers\Api\Manager\StudentController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,6 @@
 <?php
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Api\Manager\LessonController;
-use App\Http\Controllers\Api\Manager\NotificationController;
-use App\Http\Controllers\Api\Manager\StudentController;
 
 /*
 |--------------------------------------------------------------------------
@@ -192,21 +188,23 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::delete('/', [App\Http\Controllers\Api\Manager\ChapterController::class, 'delete']);
                                 Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
                                 // マネージャー-講座-チャプター-レッスン
-                                Route::group(['prefix' => 'lesson'], function () {
-                                    Route::post('/', [LessonController::class, 'store']);
-                                    Route::post('sort', [LessonController::class, 'sort']);
-                                    Route::put('status', [LessonController::class, 'putStatus']);
-                                    Route::delete('/', [LessonController::class, 'bulkDelete']);
-                                    Route::delete('all', [LessonController::class, 'deleteAll']);
-
-                                    Route::group(['prefix' => '{lesson_id}'], function () {
-                                        Route::put('/', [LessonController::class, 'put']);
-                                        Route::delete('/', [LessonController::class, 'delete']);
-                                        Route::patch('status', [LessonController::class, 'updateStatus']);
-                                        Route::patch('title', [LessonController::class, 'updateTitle']);
+                                Route::prefix('lesson')->group(function () {
+                                    Route::post('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'store']);
+                                    Route::post('sort', [App\Http\Controllers\Api\Manager\LessonController::class, 'sort']);
+                                    Route::put('status', [App\Http\Controllers\Api\Manager\LessonController::class, 'putStatus']);
+                                    Route::delete('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'bulkDelete']);
+                                    Route::delete('all', [App\Http\Controllers\Api\Manager\LessonController::class, 'deleteAll']);
+                                    Route::prefix('{lesson_id}')->group(function () {
+                                        Route::put('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'put']);
+                                        Route::delete('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'delete']);
+                                        Route::patch('status', [App\Http\Controllers\Api\Manager\LessonController::class, 'updateStatus']);
+                                        Route::patch('title', [App\Http\Controllers\Api\Manager\LessonController::class, 'updateTitle']);
                                     });
                                 });
                             });
+                        });
+                        Route::prefix('notification')->group(function () {
+                            Route::post('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'store']);
                         });
                         //マネージャー生徒学習状況
                         Route::prefix('attendance')->group(function () {
@@ -228,23 +226,22 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     });
                 });
                 // マネージャー-生徒
-                Route::group(['prefix' => 'student'], function () {
+                Route::prefix('student')->group(function () {
                     // マネージャー-講座-生徒
-                    Route::get('index', [StudentController::class, 'index']);
-                    Route::get('{student_id}', [StudentController::class, 'show']);
-                    Route::post('/', [StudentController::class, 'store']);
+                    Route::get('index', [App\Http\Controllers\Api\Manager\StudentController::class, 'index']);
+                    Route::get('{student_id}', [App\Http\Controllers\Api\Manager\StudentController::class, 'show']);
+                    Route::post('/', [App\Http\Controllers\Api\Manager\StudentController::class, 'store']);
                 });
                 // マネージャー-お知らせ
-                Route::group(['prefix' => 'notification'], function () {
-                    Route::post('/', [NotificationController::class, 'store']);
-                    Route::get('index', [NotificationController::class, 'index']);
-                    Route::put('type/{notification_type}', [NotificationController::class, 'updateType']);
-                    Route::delete('/', [NotificationController::class, 'bulkDelete']);
+                Route::prefix('notification')->group(function () {
+                    Route::get('index', [App\Http\Controllers\Api\Manager\NotificationController::class, 'index']);
+                    Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
+                    Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
 
-                    Route::group(['prefix' => '{notification_id}'], function () {
-                        Route::get('/', [NotificationController::class, 'show']);
-                        Route::patch('/', [NotificationController::class, 'update']);
-                        Route::delete('/', [NotificationController::class, 'delete']);
+                    Route::prefix('{notification_id}')->group(function () {
+                        Route::get('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'show']);
+                        Route::patch('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'update']);
+                        Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'delete']);
                     });
                 });
             });


### PR DESCRIPTION
## issue
Manager/LessonController.php, Manager/NotificationController.php, Manager/StudentController.phpに関わるルーティングの書き方をLaravel11系に合わせた書き方に変更

## 概要
api.phpをLaravel１１系ドキュメントに合わせた記述に変更

https://laravel.com/docs/11.x/routing#the-default-route-files 

たとえば、下記のような書き方に変更する。
`Route::patch('lesson_attendance/{lesson_attendance_id}', [App\Http\Controllers\Api\Student\LessonAttendanceController::class, 'patchStatus']);`



量が多いので、今回の変更の対象としてはコントローラの

https://github.com/yukihiroLaravel/juko_laravel/blob/develop/app/Http/Controllers/Api/Manager/LessonController.php 

https://github.com/yukihiroLaravel/juko_laravel/blob/develop/app/Http/Controllers/Api/Manager/NotificationController.php 

https://github.com/yukihiroLaravel/juko_laravel/blob/develop/app/Http/Controllers/Api/Manager/StudentController.php 

に記載のメソッドに対応するルーティングとする。

## 動作確認テスト
Postmanにて修正箇所に対する動作確認を実施。

例）
instructor_id=1でログイン
URL：http://localhost:8080/api/v1/manager/notification/index
HTTPメソッド：GET
結果：200 OK
以下、キャプチャのようになっていればOKです。

<img width="848" alt="スクリーンショット 2025-02-03 11 44 59" src="https://github.com/user-attachments/assets/18cfb7da-3aad-49ab-859a-8c8c4c6973ff" />