### PR TITLE
app/Http/RequestsディレクトリのLoginRateRequestが肥大化しているための整理(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -4,11 +4,11 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Attendance\DeleteRequest;
+use App\Http\Requests\Instructor\Attendance\LoginRateRequest;
 use App\Http\Requests\Instructor\Attendance\ShowRequest;
 use App\Http\Requests\Instructor\Attendance\ShowStatusRequest;
 use App\Http\Requests\Instructor\Attendance\StatusRequest;
 use App\Http\Requests\Instructor\Attendance\StoreRequest;
-use App\Http\Requests\Instructor\Attendance\LoginRateRequest;
 use App\Http\Resources\Instructor\AttendanceShowResource;
 use App\Http\Resources\Instructor\AttendanceStatusResource;
 use App\Model\Attendance;

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -8,7 +8,7 @@ use App\Http\Requests\Instructor\Attendance\ShowRequest;
 use App\Http\Requests\Instructor\Attendance\ShowStatusRequest;
 use App\Http\Requests\Instructor\Attendance\StatusRequest;
 use App\Http\Requests\Instructor\Attendance\StoreRequest;
-use App\Http\Requests\Instructor\LoginRateRequest;
+use App\Http\Requests\Instructor\Attendance\LoginRateRequest;
 use App\Http\Resources\Instructor\AttendanceShowResource;
 use App\Http\Resources\Instructor\AttendanceStatusResource;
 use App\Model\Attendance;

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -8,7 +8,7 @@ use App\Http\Requests\Manager\Attendance\ShowRequest;
 use App\Http\Requests\Manager\Attendance\ShowStatusRequest;
 use App\Http\Requests\Manager\Attendance\StatusRequest;
 use App\Http\Requests\Manager\Attendance\StoreRequest;
-use App\Http\Requests\Manager\LoginRateRequest;
+use App\Http\Requests\Manager\Attendance\LoginRateRequest;
 use App\Http\Resources\Manager\AttendanceShowResource;
 use App\Http\Resources\Manager\AttendanceStatusResource;
 use App\Model\Attendance;

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -4,11 +4,11 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Attendance\DeleteRequest;
+use App\Http\Requests\Manager\Attendance\LoginRateRequest;
 use App\Http\Requests\Manager\Attendance\ShowRequest;
 use App\Http\Requests\Manager\Attendance\ShowStatusRequest;
 use App\Http\Requests\Manager\Attendance\StatusRequest;
 use App\Http\Requests\Manager\Attendance\StoreRequest;
-use App\Http\Requests\Manager\Attendance\LoginRateRequest;
 use App\Http\Resources\Manager\AttendanceShowResource;
 use App\Http\Resources\Manager\AttendanceStatusResource;
 use App\Model\Attendance;

--- a/app/Http/Requests/Instructor/Attendance/LoginRateRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/LoginRateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\Instructor;
+namespace App\Http\Requests\Instructor\Attendance;
 
 use App\Rules\AttendancePeriodRule;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/Manager/Attendance/LoginRateRequest.php
+++ b/app/Http/Requests/Manager/Attendance/LoginRateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\Manager;
+namespace App\Http\Requests\Manager\Attendance;
 
 use App\Rules\AttendancePeriodRule;
 use Illuminate\Foundation\Http\FormRequest;


### PR DESCRIPTION
## issue
- Closes
#JKA-1101 app/Http/Requests/InstructorとManagerディレクトリのloginRateが肥大化しているための整理

## 概要
- ディレクトリを現在より細かく分け、Requestクラス名にはコントローラーのメソッド名を使用するように修正

## 動作確認手順
### Instructor/AttendanceController
- loginRateメソッド
テストケース1（正常系：講座のログイン率を取得）
URL：http://localhost:8080/api/v1/instructor/course/:course_id/attendance/:period
ログイン：
instructor_id = 1
パラメータ：
course_id = 1
period = month
結果：
```
{
    "login_rate": 100
}
```

テストケース2（異常系：ログインしていない講師の講座）
URL：http://localhost:8080/api/v1/instructor/course/:course_id/attendance/:period
ログイン：
instructor_id = 1
パラメータ：
course_id = 2
period = month
結果：
```
"message": "Forbidden, not allowed to access this course."
```

### Manager/AttendanceController
- loginRateメソッド
テストケース1（正常系：講座のログイン率を取得）
URL：http://localhost:8080/api/v1/manager/course/:course_id/attendance/:period
ログイン：
instructor_id = 1
パラメータ：
course_id = 1
period = month
結果：
```
{
    "login_rate": 100
}
```

テストケース2（異常系：マネージャの権限がない講師）
URL：http://localhost:8080/api/v1/manager/course/:course_id/attendance/:period
ログイン：
instructor_id = 1
パラメータ：
course_id = 4
period = month
結果：
```
"message": "Forbidden, not allowed to access this course."
```

## 考慮して欲しいこと
## 確認して欲しいこと