### PR TITLE
JKA-1128(親1120)：空の配列を返すルーターとコントローラの作成（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -122,6 +122,14 @@ class AttendanceController extends Controller
     }
 
     /**
+     * チャプター&レッスン一覧画面 全Lesson完了機能
+     */
+    public function completeAllLessons()
+    {
+        return response()->json([]);
+    }
+
+    /**
      * 完了済みのチャプター数を取得する
      *
      * @param  Attendance  $attendance

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,6 +32,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('{attendance_id}')->group(function () {
                 Route::get('/', 'Api\Student\AttendanceController@show');
                 Route::get('progress', 'Api\Student\AttendanceController@progress');
+                Route::put('chapter/{chapter_id}/complete', [App\Http\Controllers\Api\Student\AttendanceController::class, 'completeAllLessons']);
                 Route::prefix('course')->group(function () {
                     Route::prefix('{course_id}')->group(function () {
                         Route::prefix('chapter')->group(function () {


### PR DESCRIPTION
## issue
JKA-1128：空の配列を返すルーターとコントローラ実装

## 概要
受講生側 チャプター&レッスン一覧画面 全Lesson完了機能APIの新規作成に伴い、空の配列を返すようルーターとコントローラーを実装。

## 動作確認
postmanにて動作確認を実施。
 - student_id=1でログイン
 - attendance_id=1, course_id=1  となり、複数のレッスンが設定されている chapter_id=2 で実施
 - URL：http://localhost:8080/api/v1/attendance/1/chapter/2/complete
 - HTTPメソッド：PUT
 - 結果：200 OK  
正常に空の配列が返された。