### PR TITLE
空の配列を返すルーターとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -226,7 +226,13 @@ class AttendanceController extends Controller
         return $youngestUnCompletedLesson;
     }
 
-    public function putStatus()
+    /**
+     * 講座一覧画面の全講座を完了にする
+     *
+     * @param  \Illuminate\Http\Request  $request  リクエストオブジェクト（attendance_idが含まれる）
+     * @return \Illuminate\Http\JsonResponse 完了メッセージまたはエラーメッセージを含むJSONレスポンス
+     */
+    public function completeAllCourses()
     {
         return response()->json([]);
     }

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -53,7 +53,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage()."\n".$e->getTraceAsString());
+            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
             throw $e;
         }
     }
@@ -228,9 +228,6 @@ class AttendanceController extends Controller
 
     /**
      * 講座一覧画面の全講座を完了にする
-     *
-     * @param  \Illuminate\Http\Request  $request  リクエストオブジェクト（attendance_idが含まれる）
-     * @return \Illuminate\Http\JsonResponse 完了メッセージまたはエラーメッセージを含むJSONレスポンス
      */
     public function completeAllCourses()
     {

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -53,7 +53,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage()."\n".$e->getTraceAsString());
+            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
             throw $e;
         }
     }
@@ -224,5 +224,10 @@ class AttendanceController extends Controller
         }
 
         return $youngestUnCompletedLesson;
+    }
+
+    public function putStatus()
+    {
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -53,7 +53,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
+            Log::error($e->getMessage()."\n".$e->getTraceAsString());
             throw $e;
         }
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,6 +43,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     });
                 });
             });
+            Route::put('complete', [App\Http\Controllers\Api\Student\AttendanceController::class, 'putStatus']);
         });
 
         // 受講生-レッスン受講

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,7 +43,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     });
                 });
             });
-            Route::put('complete', [App\Http\Controllers\Api\Student\AttendanceController::class, 'putStatus']);
+            Route::put('complete', [App\Http\Controllers\Api\Student\AttendanceController::class, 'completeAllCourses']);
         });
 
         // 受講生-レッスン受講


### PR DESCRIPTION
## issue
JKA-1122：空の配列を返すルーターとコントローラ実装

## 概要
受講生側 講座一覧画面 全講座完了機能API作成に伴い、空の配列を返すようルーターとコントローラーを実装。

## 動作確認
postmanにて動作確認を実施。

student_id=1でログイン
URL：http://localhost:8080/api/v1/attendance/complete
HTTPメソッド：PUT
結果：200 OK
正常に空の配列が返されたことが確認できればOKです。