### PR TITLE
JKA-1121：ロジックの作成（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -21,6 +21,8 @@ use App\Services\Student\Attendance\ShowService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class AttendanceController extends Controller
 {
@@ -124,9 +126,27 @@ class AttendanceController extends Controller
     /**
      * 全チャプター完了API
      */
-    public function completeAllChapters()
+    public function completeAllChapters(Request $request): JsonResponse
     {
-        return response()->json([]);
+        $studentId = Auth::id();
+
+        $attendance = Attendance::findOrFail($request->attendance_id);
+
+        if ($studentId !== $attendance->student_id) {
+            // ログインしている生徒が受講している講座ではない場合エラー応答
+            throw new AuthorizationException('Not authorized.');
+        }
+
+        $lessonAttendanceIds = LessonAttendance::where('attendance_id', $attendance->id)
+            ->pluck('id')
+            ->toArray();
+
+        LessonAttendance::whereIn('id', $lessonAttendanceIds)
+            ->update(['status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE]);
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -19,10 +19,10 @@ use App\Model\LessonAttendance;
 use App\Services\Student\Attendance\IndexService;
 use App\Services\Student\Attendance\ShowService;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 
 class AttendanceController extends Controller
 {

--- a/tests/Feature/Api/Student/Attendance/CompleteAllChaptersTest.php
+++ b/tests/Feature/Api/Student/Attendance/CompleteAllChaptersTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Api\Student;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompleteAllChaptersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_全チャプター完了_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->putJson('/api/v1/attendance/1/complete');
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('lesson_attendances', [
+            'attendance_id' => 1,
+            'status' => 'completed_attendance',
+        ]);
+    }
+
+    public function test_権限がない生徒_失敗(): void
+    {
+        // arrange
+        $student = Student::find(2);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->putJson('/api/v1/attendance/1/complete');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Not authorized.',
+        ]);
+    }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $student = Student::find(1);
+    //     $this->actingAs($student);
+
+    //     // act
+    //     $response = $this->getJson('/api/v1/attendance/abc/progress');
+
+    //     // assert
+    //     $response->assertStatus(422);
+    // }
+}


### PR DESCRIPTION
## issue
JKA-1121:ロジックの作成

## 概要
JKA-1121：受講生側 チャプター&レッスン一覧画面 全Chapter完了機能API作成にて、ロジックを作成。

## 動作確認
Postmanにて動作確認を実施。

1. 正常
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/1/complete
 - HTTPメソッド：PUT
 - 結果：200 OK  
"result": true

2. 異常（ログインしている受講生が受講している講座ではない場合、エラー応答）
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/2/complete
 - HTTPメソッド：PUT
 - 結果：403 Forbidden  
"message": "Not authorized."