### PR TITLE
JKA-1119 Student/AttendanceController.php, Student/LessonAttendanceController.php, Student/NotificationController.php, Student/StudentController.phpに関わるルーティングの書き方をLaravel11系に合わせた書き方に変更　竹内

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -22,22 +22,22 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     Route::middleware('student')->group(function () {
         // 受講生
         Route::prefix('student')->group(function () {
-            Route::get('/', 'Api\Student\StudentController@show');
-            Route::post('update', 'Api\Student\StudentController@update');
+            Route::get('/', [App\Http\Controllers\Api\Student\StudentController::class, 'show']); 
+            Route::post('update', [App\Http\Controllers\Api\Student\StudentController::class, 'update']);
         });
 
         // 受講生-受講
         Route::prefix('attendance')->group(function () {
-            Route::get('index', 'Api\Student\AttendanceController@index');
+            Route::get('index', [App\Http\Controllers\Api\Student\AttendanceController::class, 'index']); 
             Route::prefix('{attendance_id}')->group(function () {
-                Route::get('/', 'Api\Student\AttendanceController@show');
-                Route::get('progress', 'Api\Student\AttendanceController@progress');
+                Route::get('/', [App\Http\Controllers\Api\Student\AttendanceController::class, 'show']);
+                Route::get('progress', [App\Http\Controllers\Api\Student\AttendanceController::class, 'progress']);
                 Route::prefix('course')->group(function () {
                     Route::prefix('{course_id}')->group(function () {
                         Route::prefix('chapter')->group(function () {
                             // 受講生-受講-講座-チャプター
                             Route::prefix('{chapter_id}')->group(function () {
-                                Route::get('/', 'Api\Student\AttendanceController@showChapter');
+                                Route::get('/', [App\Http\Controllers\Api\Student\AttendanceController::class, 'showChapter']);
                             });
                         });
                     });
@@ -50,9 +50,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
         // 受講生-お知らせ
         Route::prefix('notification')->group(function () {
-            Route::get('index', 'Api\Student\NotificationController@index');
-            Route::get('read', 'Api\Student\NotificationController@read');
-            Route::get('{notification_id}', 'Api\Student\NotificationController@show');
+            Route::get('index', [App\Http\Controllers\Api\Student\NotificationController::class, 'index']);
+            Route::get('read', [App\Http\Controllers\Api\Student\NotificationController::class, 'read']);
+            Route::get('{notification_id}', [App\Http\Controllers\Api\Student\NotificationController::class, 'show']);
         });
     });
 
@@ -251,8 +251,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
 Route::prefix('v1')->group(function () {
     Route::prefix('student')->group(function () {
-        Route::post('/', 'Api\Student\StudentController@store');
-        Route::post('verification/{token}', 'Api\Student\StudentController@verifyCode');
+        Route::post('/', [App\Http\Controllers\Api\Student\StudentController::class, 'store']);
+        Route::post('verification/{token}', [App\Http\Controllers\Api\Student\StudentController::class, 'verifyCode']);
     });
     Route::prefix('instructor')->group(function () {
         Route::post('/', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,13 +22,13 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     Route::middleware('student')->group(function () {
         // 受講生
         Route::prefix('student')->group(function () {
-            Route::get('/', [App\Http\Controllers\Api\Student\StudentController::class, 'show']); 
+            Route::get('/', [App\Http\Controllers\Api\Student\StudentController::class, 'show']);
             Route::post('update', [App\Http\Controllers\Api\Student\StudentController::class, 'update']);
         });
 
         // 受講生-受講
         Route::prefix('attendance')->group(function () {
-            Route::get('index', [App\Http\Controllers\Api\Student\AttendanceController::class, 'index']); 
+            Route::get('index', [App\Http\Controllers\Api\Student\AttendanceController::class, 'index']);
             Route::prefix('{attendance_id}')->group(function () {
                 Route::get('/', [App\Http\Controllers\Api\Student\AttendanceController::class, 'show']);
                 Route::get('progress', [App\Http\Controllers\Api\Student\AttendanceController::class, 'progress']);


### PR DESCRIPTION
### issue
## Student/AttendanceController.php, Student/LessonAttendanceController.php, Student/NotificationController.php, Student/StudentController.phpに関わるルーティングの書き方をLaravel11系に合わせた書き方に変更

## 動作確認手順

### Student/AttendanceController.php
### indexメソッド
1. 正常：受講中の講座一覧取得
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/index
 - HTTPメソッド：GET
 - 結果：200 OK

### showメソッド
1. 正常：受講中の講座の詳細情報を取得
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/1
 - HTTPメソッド：GET
 - 結果：200 OK

2. 異常：ログインしているidと講座のidが一致しない場合エラー応答
 - instructor_id=2でログイン
 - URL：http://localhost:8080/api/v1/attendance/1
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
 "message": "The attendance's student ID 1 does not match User ID 2.",

### showChapterメソッド
1. 正常：受講中の講座のチャプターの詳細情報を取得
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/1/course/1/chapter
 - HTTPメソッド：GET
 - 結果：200 OK

### progresメソッド
1. 正常：受講中の講座の進捗率を取得
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/1/progress
 - HTTPメソッド：GET
 - 結果：200 OK

2. 異常：ログインしている生徒が受講しているコースでない場合エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/2/progres
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
 "message": "Not authorized."

***

### Student/NotificationController.php
### indexメソッド
1. 正常：受講中の講座一覧取得
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/notification/index
 - HTTPメソッド：GET
 - 結果：200 OK

### readメソッド
1. 正常：お知らせ既読
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/attendance/read
 - HTTPメソッド：GET
 - 結果：200 OK

### showメソッド
1. 正常：受講中の講座のお知らせを取得
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/notification/1
 - HTTPメソッド：GET
 - 結果：200 OK

2. 異常：自分のコースではない場合エラー応答
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/notification/2
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
 "message": "Forbidden, not allowed to this notification.",

***

### Student/StudentController.php
### showメソッド
1. 正常：生徒情報取得
 - student_id=1でログイン
 - URL：http://localhost:8080/api/v1/student
 - HTTPメソッド：GET
 - 結果：200 OK

### storeメソッド
1. 正常：生徒情報を登録する
 - URL：http://localhost:8080/api/student
 - HTTPメソッド：POST
 - 結果：200 OK
 - mailtrapに認証コードが送信される。

### updateメソッド
1. 正常：生徒情報を更新する
- student_id=1でログイン
 - URL：http://localhost:8080/api/student/update
 - HTTPメソッド：POST
 - 結果：200 OK

### verifyCodeメソッド
1. 正常
- URL：http://localhost:8080/api/v1/student/verification/{taken}
- temporary_studentテーブルのtokenをPostmanのURLへ入力。
- temporary_studentテーブルのcodeをPostmanのBodyへ入力。
- 結果：200 OK
<img width="338" alt="スクリーンショット 2025-02-07 9 24 11" src="https://github.com/user-attachments/assets/48ef9410-7d8a-45fe-8c29-844369ff48cd" />

## 確認して欲しいこと
1.  Student/LessonAttendanceController.php, に関わるルーティングの変更箇所がわからなかったのでご教授の程お願いします。
それか元々変更されているようにも見えるのですがいかがでしょうか？動作確認したところ問題はなさそうです。
気になるところとしましてはswaggerのURLの末尾にはidの指定がないのですがapi.phpのルーティングには、idの指定で記述されております。

***

2.  既出でしたら申し訳ないのですが、swaggerのStudent-Notificationにread以外のメソッドが記載されていないのですがこちらは仕様でしょうか？

***

3. 元々別のブランチでgit pushしていたのですが、その後vscodeで何かを上書きしてしまった影響で他のメンバーがルーティングをlaravel11仕様に修正していた箇所が元に戻ってしまっていました。（自分で修正した箇所は問題なかったです）
`git reset --hard`で元に戻ったのですが、再度pushができなくなってしまった為、
 再度新たにブランチを作成して、pushしてみたのですが、問題はないでしょうか？

お手数ですがご確認の程よろしくお願いいたします。