### PR TITLE
JKA-1129（親1120）：ロジックの作成（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -140,7 +140,7 @@ class AttendanceController extends Controller
         if ($attendance->student_id !== $studentId) {
             throw new AuthorizationException('Forbidden, invalid student.');
         }
-        
+
         // 該当チャプターを取得
         $chapter = Chapter::with('lessons')->findOrFail($chapter_id);
 

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -18,11 +18,11 @@ use App\Model\Chapter;
 use App\Model\LessonAttendance;
 use App\Services\Student\Attendance\IndexService;
 use App\Services\Student\Attendance\ShowService;
-use Illuminate\Auth\Access\AuthorizationException;
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Http\Request;
 
 class AttendanceController extends Controller
 {
@@ -125,7 +125,7 @@ class AttendanceController extends Controller
 
     /**
      * チャプター&レッスン一覧画面 全Lesson完了機能
-     * 
+     *
      * @return \Illuminate\Http\JsonResponse
      */
     public function completeAllLessons(Request $request, int $attendance_id, int $chapter_id)
@@ -136,26 +136,26 @@ class AttendanceController extends Controller
         // 受講レコードと関連データ（コース、チャプター、レッスン、受講状況）を取得
         $attendance = Attendance::with([
             'course.chapters.lessons',
-            'lessonAttendances'
+            'lessonAttendances',
         ])->findOrFail($attendance_id);
-    
+
         // 認証チェック: この生徒が対象の受講レコードにアクセスできるか
         if ($attendance->student_id !== $studentId) {
             throw new AuthorizationException('Forbidden, invalid student.');
         }
-    
+
         // 該当チャプターを取得
         $chapter = $attendance->course->chapters->firstWhere('id', $chapter_id);
-        if (!$chapter) {
+        if (! $chapter) {
             throw new Exception('Forbidden, invalid chapter.');
         }
-    
+
         try {
             // 該当チャプターに含まれる全レッスンの受講状況を更新
             LessonAttendance::whereIn('lesson_id', $chapter->lessons->pluck('id'))
                 ->where('attendance_id', $attendance_id)
                 ->update([
-                    'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+                    'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
                 ]);
 
             return response()->json([

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -124,7 +124,7 @@ class AttendanceController extends Controller
     }
 
     /**
-     * チャプター&レッスン一覧画面 全Lesson完了機能
+     * 全レッスン完了
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -146,7 +146,7 @@ class AttendanceController extends Controller
 
         // $chapter が $attendance に紐づくか確認
         if ($chapter->course_id !== $attendance->course_id) {
-            throw new Exception('Forbidden, invalid chapter.');
+            throw new AuthorizationException('Forbidden, invalid chapter.');
         }
 
         try {

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -133,20 +133,19 @@ class AttendanceController extends Controller
         // ログイン中の生徒ID
         $studentId = Auth::id();
 
-        // 受講レコードと関連データ（コース、チャプター、レッスン、受講状況）を取得
-        $attendance = Attendance::with([
-            'course.chapters.lessons',
-            'lessonAttendances',
-        ])->findOrFail($attendance_id);
+        // 受講レコードと関連データを取得
+        $attendance = Attendance::findOrFail($attendance_id);
 
         // 認証チェック: この生徒が対象の受講レコードにアクセスできるか
         if ($attendance->student_id !== $studentId) {
             throw new AuthorizationException('Forbidden, invalid student.');
         }
-
+        
         // 該当チャプターを取得
-        $chapter = $attendance->course->chapters->firstWhere('id', $chapter_id);
-        if (! $chapter) {
+        $chapter = Chapter::with('lessons')->findOrFail($chapter_id);
+
+        // $chapter が $attendance に紐づくか確認
+        if ($chapter->course_id !== $attendance->course_id) {
             throw new Exception('Forbidden, invalid chapter.');
         }
 

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -19,8 +19,10 @@ use App\Model\LessonAttendance;
 use App\Services\Student\Attendance\IndexService;
 use App\Services\Student\Attendance\ShowService;
 use Illuminate\Auth\Access\AuthorizationException;
+use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Http\Request;
 
 class AttendanceController extends Controller
 {
@@ -123,10 +125,46 @@ class AttendanceController extends Controller
 
     /**
      * チャプター&レッスン一覧画面 全Lesson完了機能
+     * 
+     * @return \Illuminate\Http\JsonResponse
      */
-    public function completeAllLessons()
+    public function completeAllLessons(Request $request, int $attendance_id, int $chapter_id)
     {
-        return response()->json([]);
+        // ログイン中の生徒ID
+        $studentId = Auth::id();
+
+        // 受講レコードと関連データ（コース、チャプター、レッスン、受講状況）を取得
+        $attendance = Attendance::with([
+            'course.chapters.lessons',
+            'lessonAttendances'
+        ])->findOrFail($attendance_id);
+    
+        // 認証チェック: この生徒が対象の受講レコードにアクセスできるか
+        if ($attendance->student_id !== $studentId) {
+            throw new AuthorizationException('Forbidden, invalid student.');
+        }
+    
+        // 該当チャプターを取得
+        $chapter = $attendance->course->chapters->firstWhere('id', $chapter_id);
+        if (!$chapter) {
+            throw new Exception('Forbidden, invalid chapter.');
+        }
+    
+        try {
+            // 該当チャプターに含まれる全レッスンの受講状況を更新
+            LessonAttendance::whereIn('lesson_id', $chapter->lessons->pluck('id'))
+                ->where('attendance_id', $attendance_id)
+                ->update([
+                    'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+                ]);
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            Log::error($e);
+            throw $e;
+        }
     }
 
     /**

--- a/tests/Feature/Api/Student/Attendance/CompleteAllLessonsTest.php
+++ b/tests/Feature/Api/Student/Attendance/CompleteAllLessonsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Api\Student;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompleteAllLessonsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_指定したチャプターのレッスンを全て完了_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->putJson('/api/v1/attendance/1/chapter/2/complete');
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('lesson_attendances', [
+            'attendance_id' => 2,
+            'lesson_id' => 2,
+            'status' => 'completed_attendance',
+        ]);
+    }
+
+    public function test_権限がない生徒_失敗(): void
+    {
+        // arrange
+        $student = Student::find(2);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->putJson('/api/v1/attendance/1/chapter/2/complete');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid student.',
+        ]);
+    }
+
+    public function test_権限がないチャプター_失敗(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->putJson('/api/v1/attendance/1/chapter/4/complete');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid chapter.',
+        ]);
+    }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $student = Student::find(1);
+    //     $this->actingAs($student);
+
+    //     // act
+    //     $response = $this->putJson('/api/v1/attendance/aaa/chapter/bbb/complete');
+
+    //     // assert
+    //     $response->assertStatus(422);
+    //     $response->assertJsonValidationErrors([
+    //         'attendance_id',
+    //         'chapter_id',
+    //     ]);
+    // }
+}


### PR DESCRIPTION
## issue

JKA-1129：ロジックの作成

## 概要

受講生側 チャプター&レッスン一覧画面 全Lesson完了機能APIの新規作成（JKA-1120）に伴い、ロジックの作成を実装。

## 動作確認

postmanにて動作確認を実施。
**①正常系**

- student_id=1でログイン
- attendance_id=1, course_id=1 となり、複数のレッスンが設定されている chapter_id=2 で実施
- URL：http://localhost:8080/api/v1/attendance/1/chapter/2/complete
- HTTPメソッド：PUT
- 結果：200 OK
- Adminerで、statusが全て completed_attendance になったことを確認

**②異常系**

ログイン中の生徒のattendance_idではない場合

- student_id=1でログイン
- attendance_id=2　でテスト
- URL :　http://localhost:8080/api/v1/attendance/2/chapter/2/complete
- HTTPメソッド：PUT
- 結果：403　Forbidden　"message": "Forbidden, invalid student.”

**【変更】存在しない** ~~受講していない~~チャプターをURLに含めた場合

- student_id=1でログイン
- 正しいattendance_id = 1,  受講していないchapter_id =8 でテスト
- URL:　http://localhost:8080/api/v1/attendance/1/chapter/8/complete
- HTTPメソッド：PUT
- ~~結果：500サーバーエラー　"message": "Forbidden, invalid chapter.”~~
- **結果：404 NotFound**  **←「該当チャプターを取得する」部分のコードをfindOrFailを使った書き方に変更し、ifのエラー文を削除。**

**【追加】** 存在する受講していないチャプターをURLに含めた場合

- student_id=1でログイン
- 正しいattendance_id = 1,  受講していないchapter_id =5 でテスト
- URL:　http://localhost:8080/api/v1/attendance/1/chapter/5/complete
- HTTPメソッド：PUT
- 結果：~~500サーバーエラー~~  **403　Forbidden**　"message": "Forbidden, invalid chapter.”


try構文の中に例外を発生させcatchされるかのテスト

- student_id=1でログイン
- attendance_id=1, chapter_id=2 で実施
- try構文の中に　throw new Exception('テスト');　を記述
- URL：http://localhost:8080/api/v1/attendance/1/chapter/2/complete
- HTTPメソッド：PUT
- 結果：500サーバーエラー　"message": "テスト”