### PR TITLE
講座一覧画面の全講座完了機能ロジック作成

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -228,7 +228,7 @@ class AttendanceController extends Controller
     }
 
     /**
-     * 講座一覧画面の全講座を完了にする
+     * 全講座を完了にする
      */
     public function completeAllCourses(): JsonResponse
     {

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -54,7 +54,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
+            Log::error($e->getMessage()."\n".$e->getTraceAsString());
             throw $e;
         }
     }

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -21,6 +21,8 @@ use App\Services\Student\Attendance\ShowService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class AttendanceController extends Controller
 {
@@ -53,7 +55,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage()."\n".$e->getTraceAsString());
+            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
             throw $e;
         }
     }
@@ -229,8 +231,28 @@ class AttendanceController extends Controller
     /**
      * 講座一覧画面の全講座を完了にする
      */
-    public function completeAllCourses()
+    public function completeAllCourses(Request $request): JsonResponse
     {
-        return response()->json([]);
+        Log::info('Requested attendance_id: ' . $request->attendance_id);
+
+        $authId = Auth::id();
+        $attendance = Attendance::with(['lessonAttendances'])->find($request->attendance_id);
+
+        if (!$attendance) {
+            return response()->json(['error' => 'Attendance not found.'], 404);
+        }
+
+        if ($authId !== $attendance->student_id) {
+            throw new AuthorizationException('Not authorized.');
+        }
+
+        // 全ての講座を完了に更新
+        $attendance->lessonAttendances()->update([
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+        ]);
+
+        return response()->json([
+            'message' => 'All lessons have been marked as completed.',
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -54,7 +54,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
+            Log::error($e->getMessage()."\n".$e->getTraceAsString());
             throw $e;
         }
     }
@@ -246,7 +246,7 @@ class AttendanceController extends Controller
             ->pluck('id')
             ->toArray();
 
-        if (!empty($lessonAttendanceIds)) {
+        if (! empty($lessonAttendanceIds)) {
             // 取得した ID のレコードを一括更新
             LessonAttendance::whereIn('id', $lessonAttendanceIds)
                 ->update(['status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE]);

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -54,7 +54,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
+            Log::error($e->getMessage()."\n".$e->getTraceAsString());
             throw $e;
         }
     }
@@ -246,7 +246,7 @@ class AttendanceController extends Controller
             ->pluck('id')
             ->toArray();
 
-        if (!empty($lessonAttendanceIds)) {
+        if (! empty($lessonAttendanceIds)) {
             throw new AuthorizationException('There is no lesson attendance.');
         }
 

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -247,10 +247,12 @@ class AttendanceController extends Controller
             ->toArray();
 
         if (!empty($lessonAttendanceIds)) {
-            // 取得した ID のレコードを一括更新
-            LessonAttendance::whereIn('id', $lessonAttendanceIds)
-                ->update(['status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE]);
+            throw new AuthorizationException('There is no lesson attendance.');
         }
+
+        // 取得した ID のレコードを一括更新
+        LessonAttendance::whereIn('id', $lessonAttendanceIds)
+            ->update(['status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE]);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -19,10 +19,10 @@ use App\Model\LessonAttendance;
 use App\Services\Student\Attendance\IndexService;
 use App\Services\Student\Attendance\ShowService;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 
 class AttendanceController extends Controller
 {
@@ -55,7 +55,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
+            Log::error($e->getMessage()."\n".$e->getTraceAsString());
             throw $e;
         }
     }
@@ -233,12 +233,12 @@ class AttendanceController extends Controller
      */
     public function completeAllCourses(Request $request): JsonResponse
     {
-        Log::info('Requested attendance_id: ' . $request->attendance_id);
+        Log::info('Requested attendance_id: '.$request->attendance_id);
 
         $authId = Auth::id();
         $attendance = Attendance::with(['lessonAttendances'])->find($request->attendance_id);
 
-        if (!$attendance) {
+        if (! $attendance) {
             return response()->json(['error' => 'Attendance not found.'], 404);
         }
 
@@ -248,7 +248,7 @@ class AttendanceController extends Controller
 
         // 全ての講座を完了に更新
         $attendance->lessonAttendances()->update([
-            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
         ]);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -54,7 +54,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage()."\n".$e->getTraceAsString());
+            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
             throw $e;
         }
     }
@@ -235,22 +235,25 @@ class AttendanceController extends Controller
         $studentId = Auth::id();
 
         // 受講生が受講している全てのAttendanceを取得
-        $attendances = Attendance::where('student_id', $studentId)->with('lessonAttendances')->get();
+        $attendances = Attendance::where('student_id', $studentId)->get();
 
         if ($attendances->isEmpty()) {
-            throw new AuthorizationException('Not authorized.');
+            throw new AuthorizationException('There is no attendance.');
         }
 
-        // 全ての講座を完了に更新
-        foreach ($attendances as $attendance) {
-            $attendance->lessonAttendances()->update([
-                'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
-            ]);
+        // attendance_id に一致する lesson_attendance の ID をまとめて取得
+        $lessonAttendanceIds = LessonAttendance::whereIn('attendance_id', $attendances->pluck('id'))
+            ->pluck('id')
+            ->toArray();
+
+        if (!empty($lessonAttendanceIds)) {
+            // 取得した ID のレコードを一括更新
+            LessonAttendance::whereIn('id', $lessonAttendanceIds)
+                ->update(['status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE]);
         }
 
         return response()->json([
             'result' => true,
-            'message' => 'All lessons have been marked as completed.',
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -55,7 +55,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage()."\n".$e->getTraceAsString());
+            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
             throw $e;
         }
     }
@@ -231,27 +231,26 @@ class AttendanceController extends Controller
     /**
      * 講座一覧画面の全講座を完了にする
      */
-    public function completeAllCourses(Request $request): JsonResponse
+    public function completeAllCourses(): JsonResponse
     {
-        Log::info('Requested attendance_id: '.$request->attendance_id);
+        $studentId = Auth::id();
 
-        $authId = Auth::id();
-        $attendance = Attendance::with(['lessonAttendances'])->find($request->attendance_id);
+        // 受講生が受講している全てのAttendanceを取得
+        $attendances = Attendance::where('student_id', $studentId)->with('lessonAttendances')->get();
 
-        if (! $attendance) {
-            return response()->json(['error' => 'Attendance not found.'], 404);
-        }
-
-        if ($authId !== $attendance->student_id) {
+        if ($attendances->isEmpty()) {
             throw new AuthorizationException('Not authorized.');
         }
 
         // 全ての講座を完了に更新
-        $attendance->lessonAttendances()->update([
-            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
-        ]);
+        foreach ($attendances as $attendance) {
+            $attendance->lessonAttendances()->update([
+                'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+            ]);
+        }
 
         return response()->json([
+            'result' => true,
             'message' => 'All lessons have been marked as completed.',
         ]);
     }

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -234,24 +234,11 @@ class AttendanceController extends Controller
     {
         $studentId = Auth::id();
 
-        // 受講生が受講している全てのAttendanceを取得
-        $attendances = Attendance::where('student_id', $studentId)->get();
+        // 受講生が受講している全てのAttendanceのIDを取得
+        $attendanceIds = Attendance::where('student_id', $studentId)->pluck('id');
 
-        if ($attendances->isEmpty()) {
-            throw new AuthorizationException('There is no attendance.');
-        }
-
-        // attendance_id に一致する lesson_attendance の ID をまとめて取得
-        $lessonAttendanceIds = LessonAttendance::whereIn('attendance_id', $attendances->pluck('id'))
-            ->pluck('id')
-            ->toArray();
-
-        if (!empty($lessonAttendanceIds)) {
-            throw new AuthorizationException('There is no lesson attendance.');
-        }
-
-        // 取得した ID のレコードを一括更新
-        LessonAttendance::whereIn('id', $lessonAttendanceIds)
+        // lesson_attendances を attendance_id で一括更新
+        LessonAttendance::whereIn('attendance_id', $attendanceIds)
             ->update(['status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE]);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -20,7 +20,6 @@ use App\Services\Student\Attendance\IndexService;
 use App\Services\Student\Attendance\ShowService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
@@ -55,7 +54,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
+            Log::error($e->getMessage()."\n".$e->getTraceAsString());
             throw $e;
         }
     }
@@ -245,7 +244,7 @@ class AttendanceController extends Controller
         // 全ての講座を完了に更新
         foreach ($attendances as $attendance) {
             $attendance->lessonAttendances()->update([
-                'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+                'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
             ]);
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         // 受講生-受講
         Route::prefix('attendance')->group(function () {
             Route::get('index', 'Api\Student\AttendanceController@index');
+            Route::put('course/complete', [App\Http\Controllers\Api\Student\AttendanceController::class, 'completeAllCourses']);
             Route::prefix('{attendance_id}')->group(function () {
                 Route::get('/', 'Api\Student\AttendanceController@show');
                 Route::get('progress', 'Api\Student\AttendanceController@progress');
@@ -43,7 +44,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     });
                 });
             });
-            Route::put('complete', [App\Http\Controllers\Api\Student\AttendanceController::class, 'completeAllCourses']);
         });
 
         // 受講生-レッスン受講

--- a/tests/Feature/Api/Student/Attendance/CompleteAllCoursesTest.php
+++ b/tests/Feature/Api/Student/Attendance/CompleteAllCoursesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Api\Student\Attendance;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompleteAllCoursesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_すべての講座を完了_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->putJson('/api/v1/attendance/course/complete');
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('lesson_attendances', [
+            'attendance_id' => 1,
+            'status' => 'completed_attendance',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1122：空の配列を返すルーターとコントローラ実装

## 概要
受講生側 講座一覧画面 全講座完了機能API作成に伴い、空の配列を返すようルーターとコントローラーを実装。

## 動作確認
postmanにて動作確認を実施。

student_id=1でログイン
URL：http://localhost:8080/api/v1/attendance/complete
HTTPメソッド：PUT
結果：200 OK

<img width="852" alt="スクリーンショット 2025-02-07 14 49 57" src="https://github.com/user-attachments/assets/782d278a-7d3b-4d2c-a263-3f1a97d03011" />


キャプチャのように、「"All lessons have been marked as completed."」と返されたことが確認できればOKです。