### PR TITLE
JKA-1134：マネージャー側お知らせ一覧APIに各お知らせの講師名を追加（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -42,7 +42,7 @@ class NotificationController extends Controller
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        $notifications = Notification::with(['course'])
+        $notifications = Notification::with(['course', 'instructor'])
             ->whereIn('instructor_id', $instructorIds)
             ->paginate($perPage, ['*'], 'page', $page);
 

--- a/app/Http/Resources/Instructor/InstructorResource.php
+++ b/app/Http/Resources/Instructor/InstructorResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources\Instructor;
+
+use App\Model\Instructor;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InstructorResource extends JsonResource
+{
+    /** @var Instructor */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'instructor_id' => $this->resource->id,
+            'nick_name' => $this->resource->nick_name,
+            'last_name' => $this->resource->last_name,
+            'first_name' => $this->resource->first_name,
+            'email' => $this->resource->email,
+            'profile_image' => $this->resource->profile_image,
+        ];
+    }
+}

--- a/app/Http/Resources/Manager/NotificationIndexResource.php
+++ b/app/Http/Resources/Manager/NotificationIndexResource.php
@@ -45,6 +45,7 @@ class NotificationIndexResource extends JsonResource
                 'title' => $notification->title,
                 'content' => $notification->content,
                 'type' => $notification->type,
+                'nick_name' => $notification->instructor->nick_name,
                 'start_date' => $notification->start_date,
                 'end_date' => $notification->end_date,
             ];

--- a/app/Http/Resources/Manager/NotificationIndexResource.php
+++ b/app/Http/Resources/Manager/NotificationIndexResource.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Resources\Manager;
 
+use App\Http\Resources\Instructor\InstructorResource;
 use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
-use App\Http\Resources\Instructor\InstructorResource;
 
 class NotificationIndexResource extends JsonResource
 {

--- a/app/Http/Resources/Manager/NotificationIndexResource.php
+++ b/app/Http/Resources/Manager/NotificationIndexResource.php
@@ -6,6 +6,7 @@ use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
+use App\Http\Resources\Instructor\InstructorResource;
 
 class NotificationIndexResource extends JsonResource
 {
@@ -45,7 +46,7 @@ class NotificationIndexResource extends JsonResource
                 'title' => $notification->title,
                 'content' => $notification->content,
                 'type' => $notification->type,
-                'nick_name' => $notification->instructor->nick_name,
+                'instructor' => new InstructorResource($notification->instructor),
                 'start_date' => $notification->start_date,
                 'end_date' => $notification->end_date,
             ];

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -97,4 +97,14 @@ class Notification extends Model
     {
         return $this->belongsTo(Course::class, 'course_id');
     }
+
+    /**
+     * 講師を取得
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function instructor()
+    {
+        return $this->belongsTo(Instructor::class, 'instructor_id');
+    }
 }

--- a/tests/Feature/Api/Manager/Notification/IndexTest.php
+++ b/tests/Feature/Api/Manager/Notification/IndexTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/notification/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_お知らせ登録_権限エラー(): void
+    {
+        // arrange
+        $unauthorizedInstructor = Instructor::find(2);
+        $this->actingAs($unauthorizedInstructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/notification/index');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1134：マネージャー側お知らせ一覧APIに各お知らせの講師名を追加

## 概要
Manager/NotificationController.phpのindexメソッドを変更し、お知らせ一覧APIに各お知らせの講師名（nick_name）を追加。

## 動作確認
Postmanにて動作確認を実施。

 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/manager/notification/index
 - HTTPメソッド：GET
 - 結果：200 OK  
以下のレスポンスを確認。
```
"data": {
    "notifications": [
        {
            "notification_id": 1,
            "course_id": 1,
            "course_title": "PHP入門講座",
            "title": "レッスン「変数とは？」閲覧について",
            "content": "10月1日〜10日の間、レッスン「変数とは？」がメンテナンスにつき閲覧できなくなります。",
            "type": "always",
            "nick_name": "Yamada",
            "start_date": "2023-08-01 00:00:00",
            "end_date": "2025-03-10 20:06:51"
        },
        {
            "notification_id": 2,
            "course_id": 2,
            "course_title": "Laravel入門講座",
            "title": "お知らせ機能が追加されました",
            "content": "受講生管理画面にお知らせ機能が追加されました。講座ごとにお知らせをお送りします。",
            "type": "once",
            "nick_name": "Hanako",
            "start_date": "2023-08-01 00:00:00",
            "end_date": "2025-03-10 20:06:51"
        }
    ],
    "pagination": {
        "page": 1,
        "total": 2
    }
}
```