### PR TITLE
JKA-1132 Instructor/CourseShowResource.phpとManager/CourseShowResource.phpの修正（いずみ）

### DIFF
--- a/app/Http/Resources/Chapter/ChapterResource.php
+++ b/app/Http/Resources/Chapter/ChapterResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources\Chapter;
+
+use App\Model\Chapter;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ChapterResource extends JsonResource
+{
+    /** @var Chapter */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'chapter_id' => $this->resource->id,
+            'title' => $this->resource->title,
+            'order' => $this->resource->order,
+            'status' => $this->resource->status,
+        ];
+    }
+}

--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Resources\Instructor;
 
-use Illuminate\Http\Resources\Json\JsonResource;
 use App\Http\Resources\Chapter\ChapterResource;
 use App\Http\Resources\Lesson\LessonResource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class CourseShowResource extends JsonResource
 {
@@ -17,7 +17,7 @@ class CourseShowResource extends JsonResource
     public function toArray($request)
     {
         return [
-        'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
+            'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
                 return [
                     new ChapterResource($chapter),
                     'lessons' => LessonResource::collection($chapter->lessons),

--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -19,18 +19,20 @@ class CourseShowResource extends JsonResource
             'title' => $this->resource->title,
             'image' => $this->resource->image,
             'status' => $this->resource->status,
-            'chapters' => $this->resource->chapters->map(function ($chapter) {
+            'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
                 return [
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
+                    'order' => $chapter->order,
                     'status' => $chapter->status,
-                    'lessons' => $chapter->lessons->map(function ($lesson) {
+                    'lessons' => $chapter->lessons->sortBy('order')->map(function ($lesson) {
                         return [
                             'lesson_id' => $lesson->id,
                             'url' => $lesson->url,
                             'title' => $lesson->title,
                             'remarks' => $lesson->remarks,
                             'status' => $lesson->status,
+                            'order' => $lesson->order, 
                         ];
                     }),
                 ];

--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -3,6 +3,8 @@
 namespace App\Http\Resources\Instructor;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Chapter\ChapterResource;
+use App\Http\Resources\Lesson\LessonResource;
 
 class CourseShowResource extends JsonResource
 {
@@ -15,26 +17,10 @@ class CourseShowResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'course_id' => $this->resource->id,
-            'title' => $this->resource->title,
-            'image' => $this->resource->image,
-            'status' => $this->resource->status,
-            'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
+        'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
                 return [
-                    'chapter_id' => $chapter->id,
-                    'title' => $chapter->title,
-                    'order' => $chapter->order,
-                    'status' => $chapter->status,
-                    'lessons' => $chapter->lessons->sortBy('order')->map(function ($lesson) {
-                        return [
-                            'lesson_id' => $lesson->id,
-                            'url' => $lesson->url,
-                            'title' => $lesson->title,
-                            'remarks' => $lesson->remarks,
-                            'status' => $lesson->status,
-                            'order' => $lesson->order,
-                        ];
-                    }),
+                    new ChapterResource($chapter),
+                    'lessons' => LessonResource::collection($chapter->lessons),
                 ];
             }),
         ];

--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -17,7 +17,7 @@ class CourseShowResource extends JsonResource
     public function toArray($request)
     {
         return [
-        'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
+            'chapters' => $this->resource->chapters->map(function ($chapter) {
                 return [
                     new ChapterResource($chapter),
                     'lessons' => LessonResource::collection($chapter->lessons),

--- a/app/Http/Resources/Instructor/CourseShowResource.php
+++ b/app/Http/Resources/Instructor/CourseShowResource.php
@@ -32,7 +32,7 @@ class CourseShowResource extends JsonResource
                             'title' => $lesson->title,
                             'remarks' => $lesson->remarks,
                             'status' => $lesson->status,
-                            'order' => $lesson->order, 
+                            'order' => $lesson->order,
                         ];
                     }),
                 ];

--- a/app/Http/Resources/Lesson/LessonResource.php
+++ b/app/Http/Resources/Lesson/LessonResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources\Lesson;
+
+use App\Model\Lesson;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class LessonResource extends JsonResource
+{
+    /** @var Lesson */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'lesson_id' => $this->resource->id,
+            'url' => $this->resource->url,
+            'title' => $this->resource->title,
+            'remarks' => $this->resource->remarks,
+            'status' => $this->resource->status,
+            'order' => $this->resource->order,
+        ];
+    }
+}

--- a/app/Http/Resources/Manager/CourseShowResource.php
+++ b/app/Http/Resources/Manager/CourseShowResource.php
@@ -3,6 +3,8 @@
 namespace App\Http\Resources\Manager;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Chapter\ChapterResource;
+use App\Http\Resources\Lesson\LessonResource;
 
 class CourseShowResource extends JsonResource
 {
@@ -15,26 +17,10 @@ class CourseShowResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'course_id' => $this->resource->id,
-            'title' => $this->resource->title,
-            'image' => $this->resource->image,
-            'status' => $this->resource->status,
-            'chapters' => $this->resource->chapters->map(function ($chapter) {
+            'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
                 return [
-                    'chapter_id' => $chapter->id,
-                    'title' => $chapter->title,
-                    'order' => $chapter->order,
-                    'status' => $chapter->status,
-                    'lessons' => $chapter->lessons->sortBy('order')->map(function ($lesson) {
-                        return [
-                            'lesson_id' => $lesson->id,
-                            'title' => $lesson->title,
-                            'url' => $lesson->url,
-                            'remarks' => $lesson->remarks,
-                            'status' => $lesson->status,
-                            'order' => $lesson->order,
-                        ];
-                    }),
+                    new ChapterResource($chapter),
+                    'lessons' => LessonResource::collection($chapter->lessons),
                 ];
             }),
         ];

--- a/app/Http/Resources/Manager/CourseShowResource.php
+++ b/app/Http/Resources/Manager/CourseShowResource.php
@@ -17,7 +17,7 @@ class CourseShowResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'chapters' => $this->resource->chapters->sortBy('order')->map(function ($chapter) {
+            'chapters' => $this->resource->chapters->map(function ($chapter) {
                 return [
                     new ChapterResource($chapter),
                     'lessons' => LessonResource::collection($chapter->lessons),

--- a/app/Http/Resources/Manager/CourseShowResource.php
+++ b/app/Http/Resources/Manager/CourseShowResource.php
@@ -24,12 +24,15 @@ class CourseShowResource extends JsonResource
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
                     'order' => $chapter->order,
-                    'lessons' => $chapter->lessons->map(function ($lesson) {
+                    'status' => $chapter->status,
+                    'lessons' => $chapter->lessons->sortBy('order')->map(function ($lesson) {
                         return [
                             'lesson_id' => $lesson->id,
                             'title' => $lesson->title,
                             'url' => $lesson->url,
                             'remarks' => $lesson->remarks,
+                            'status' => $lesson->status,
+                            'order' => $lesson->order, 
                         ];
                     }),
                 ];

--- a/app/Http/Resources/Manager/CourseShowResource.php
+++ b/app/Http/Resources/Manager/CourseShowResource.php
@@ -32,7 +32,7 @@ class CourseShowResource extends JsonResource
                             'url' => $lesson->url,
                             'remarks' => $lesson->remarks,
                             'status' => $lesson->status,
-                            'order' => $lesson->order, 
+                            'order' => $lesson->order,
                         ];
                     }),
                 ];

--- a/app/Http/Resources/Manager/CourseShowResource.php
+++ b/app/Http/Resources/Manager/CourseShowResource.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Resources\Manager;
 
-use Illuminate\Http\Resources\Json\JsonResource;
 use App\Http\Resources\Chapter\ChapterResource;
 use App\Http\Resources\Lesson\LessonResource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class CourseShowResource extends JsonResource
 {

--- a/tests/Feature/Api/Manager/Course/ShowTest.php
+++ b/tests/Feature/Api/Manager/Course/ShowTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_バリデーションエラー_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['course_id']);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1132  Instructor/CourseShowResource.phpとManager/CourseShowResource.phpの修正

## 概要
**Instructor/CourseShowResource.phpの修正**
- chapterの中のorderカラムを返すようにする
- lessonの中のorderカラムを返すようにする

**Manager/CourseShowResource.phpの修正**
- chapterの中のstatusカラムを返すようにする
- lessonの中のstatusカラムを返すようにする
- lessonの中のorderカラムを返すようにする

## 動作確認手順
ポストマンにてテスト
**①Instructor/CourseShowResource.phpの修正**
URL=http://localhost:8080/api/v1/instructor/course/:course_id
HTTP=GET
Params : course_id=1
- chapterの中にorderカラムが返っているか確認
- lessonrの中にorderカラムが返っているか確認


**②Manager/CourseShowResource.phpの修正**
URL=http://localhost:8080/api/v1/manager/course/:course_id
HTTP=GET
Params : course_id=1
- chapterの中にstatusカラムが返っているか確認
- lessonの中にstatusカラムが返っているか確認
- lessonの中にorderカラムが返っているか確認

