### PR TITLE
JKA-1142：受講生側 講座一覧APIで、講座の進捗率を表示されるように修正（西山しょうこ）

### DIFF
--- a/app/Http/Resources/Student/AttendanceIndexResource.php
+++ b/app/Http/Resources/Student/AttendanceIndexResource.php
@@ -29,6 +29,7 @@ class AttendanceIndexResource extends JsonResource
                         'email' => $value->course->instructor->email,
                         'profile_image' => $value->course->instructor->profile_image,
                     ],
+                    'progress_percentage' => $value->course->progress_percentage,
                 ],
             ];
         });

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property bool $has_active_students
+ * @property int $progress_percentage
  */
 class Course extends Model
 {

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -18,10 +18,10 @@ class IndexService
     {
         // 受講情報を関連情報と一緒に取得
         $attendances = Attendance::with([
-                'course.instructor',
-                'course.chapters.lessons',
-                'lessonAttendances',
-            ])
+            'course.instructor',
+            'course.chapters.lessons',
+            'lessonAttendances',
+        ])
             ->where('student_id', $indexDto->getStudentId())
             ->whereHas('course', function (Builder $query) use ($indexDto) {
                 $query->when(! $indexDto->getSearchWord(), function ($query) {
@@ -33,7 +33,7 @@ class IndexService
             })->get();
 
         // 各受講情報ごとにチャプター単位の進捗率を計算
-        foreach ($attendances as $attendance){
+        foreach ($attendances as $attendance) {
             $completedChaptersCount = $this->getCompletedChaptersCount($attendance);
             $totalChaptersCount = $this->getTotalChaptersCount($attendance);
             $progressPercentage = ($totalChaptersCount > 0) ? round(($completedChaptersCount / $totalChaptersCount) * 100) : 0;

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -5,6 +5,7 @@ namespace App\Services\Student\Attendance;
 use App\Dto\Student\Attendance\IndexDto;
 use App\Model\Attendance;
 use App\Model\Course;
+use App\Model\LessonAttendance;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -13,10 +14,14 @@ class IndexService
     /**
      * @return Collection<Attendance>
      */
-    public function __invoke(
-        IndexDto $indexDto
-    ): Collection {
-        return Attendance::with('course.instructor')
+    public function __invoke(IndexDto $indexDto)
+    {
+        // 受講情報を関連情報と一緒に取得
+        $attendances = Attendance::with([
+                'course.instructor',
+                'course.chapters.lessons',
+                'lessonAttendances',
+            ])
             ->where('student_id', $indexDto->getStudentId())
             ->whereHas('course', function (Builder $query) use ($indexDto) {
                 $query->when(! $indexDto->getSearchWord(), function ($query) {
@@ -26,5 +31,51 @@ class IndexService
                         ->where('status', Course::STATUS_PUBLIC);
                 });
             })->get();
+
+        // 各受講情報ごとにチャプター単位の進捗率を計算
+        foreach ($attendances as $attendance){
+            $completedChaptersCount = $this->getCompletedChaptersCount($attendance);
+            $totalChaptersCount = $this->getTotalChaptersCount($attendance);
+            $progressPercentage = ($totalChaptersCount > 0) ? round(($completedChaptersCount / $totalChaptersCount) * 100) : 0;
+            $attendance->course->progress_percentage = $progressPercentage;
+        }
+
+        return $attendances;
+    }
+
+    /**
+     * 完了済みのチャプター数を取得する
+     *
+     * @param  Attendance  $attendance
+     * @return int
+     */
+    private function getCompletedChaptersCount($attendance)
+    {
+        return $attendance->course->chapters->filter(function ($chapter) use ($attendance) {
+            $isCompleted = false;
+            // 全てのレッスンが完了済みかどうかをチェック
+            $chapter->lessons->each(function ($lesson) use ($attendance, &$isCompleted) {
+                $lessonAttendance = $attendance->lessonAttendances->where('lesson_id', $lesson->id)->first();
+                if ($lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
+                    $isCompleted = false;
+
+                    return false;
+                }
+                $isCompleted = true;
+            });
+
+            return $isCompleted;
+        })->count();
+    }
+
+    /**
+     * チャプター合計を取得する
+     *
+     * @param  Attendance  $attendance
+     * @return int
+     */
+    private function getTotalChaptersCount($attendance)
+    {
+        return $attendance->course->chapters->count();
     }
 }

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -14,7 +14,7 @@ class IndexService
     /**
      * @return Collection<Attendance>
      */
-    public function __invoke(IndexDto $indexDto) : Collection
+    public function __invoke(IndexDto $indexDto): Collection
     {
         // 受講情報を関連情報と一緒に取得
         $attendances = Attendance::with([
@@ -44,18 +44,19 @@ class IndexService
     }
 
     // 完了済みのチャプター数を取得する
-    private function getCompletedChaptersCount(Attendance $attendance) : int
+    private function getCompletedChaptersCount(Attendance $attendance): int
     {
         return $attendance->course->chapters->filter(function ($chapter) use ($attendance) {
             return $chapter->lessons->every(function ($lesson) use ($attendance) {
                 $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
+
                 return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
             });
         })->count();
     }
 
     // チャプター合計を取得する
-    private function getTotalChaptersCount(Attendance $attendance) : int
+    private function getTotalChaptersCount(Attendance $attendance): int
     {
         return $attendance->course->chapters->count();
     }

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -4,7 +4,9 @@ namespace App\Services\Student\Attendance;
 
 use App\Dto\Student\Attendance\IndexDto;
 use App\Model\Attendance;
+use App\Model\Chapter;
 use App\Model\Course;
+use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -43,11 +45,13 @@ class IndexService
         return $attendances;
     }
 
-    // 完了済みのチャプター数を取得する
+    /**
+     * 完了済みのチャプター数を取得する
+     */
     private function getCompletedChaptersCount(Attendance $attendance): int
     {
-        return $attendance->course->chapters->filter(function ($chapter) use ($attendance) {
-            return $chapter->lessons->every(function ($lesson) use ($attendance) {
+        return $attendance->course->chapters->filter(function (Chapter $chapter) use ($attendance) {
+            return $chapter->lessons->every(function (Lesson $lesson) use ($attendance) {
                 $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
 
                 return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
@@ -55,7 +59,9 @@ class IndexService
         })->count();
     }
 
-    // チャプター合計を取得する
+    /**
+     * チャプター合計を取得する
+     */
     private function getTotalChaptersCount(Attendance $attendance): int
     {
         return $attendance->course->chapters->count();

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -33,12 +33,12 @@ class IndexService
             })->get();
 
         // 各受講情報ごとにチャプター単位の進捗率を計算
-        foreach ($attendances as $attendance) {
+        $attendances->each(function ($attendance) {
             $completedChaptersCount = $this->getCompletedChaptersCount($attendance);
             $totalChaptersCount = $this->getTotalChaptersCount($attendance);
             $progressPercentage = ($totalChaptersCount > 0) ? round(($completedChaptersCount / $totalChaptersCount) * 100) : 0;
             $attendance->course->progress_percentage = $progressPercentage;
-        }
+        });
 
         return $attendances;
     }

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -14,7 +14,7 @@ class IndexService
     /**
      * @return Collection<Attendance>
      */
-    public function __invoke(IndexDto $indexDto)
+    public function __invoke(IndexDto $indexDto) : Collection
     {
         // 受講情報を関連情報と一緒に取得
         $attendances = Attendance::with([
@@ -33,7 +33,7 @@ class IndexService
             })->get();
 
         // 各受講情報ごとにチャプター単位の進捗率を計算
-        $attendances->each(function ($attendance) {
+        $attendances->each(function (Attendance $attendance) {
             $completedChaptersCount = $this->getCompletedChaptersCount($attendance);
             $totalChaptersCount = $this->getTotalChaptersCount($attendance);
             $progressPercentage = ($totalChaptersCount > 0) ? round(($completedChaptersCount / $totalChaptersCount) * 100) : 0;
@@ -43,38 +43,19 @@ class IndexService
         return $attendances;
     }
 
-    /**
-     * 完了済みのチャプター数を取得する
-     *
-     * @param  Attendance  $attendance
-     * @return int
-     */
-    private function getCompletedChaptersCount($attendance)
+    // 完了済みのチャプター数を取得する
+    private function getCompletedChaptersCount(Attendance $attendance) : int
     {
         return $attendance->course->chapters->filter(function ($chapter) use ($attendance) {
-            $isCompleted = false;
-            // 全てのレッスンが完了済みかどうかをチェック
-            $chapter->lessons->each(function ($lesson) use ($attendance, &$isCompleted) {
-                $lessonAttendance = $attendance->lessonAttendances->where('lesson_id', $lesson->id)->first();
-                if ($lessonAttendance->status !== LessonAttendance::STATUS_COMPLETED_ATTENDANCE) {
-                    $isCompleted = false;
-
-                    return false;
-                }
-                $isCompleted = true;
+            return $chapter->lessons->every(function ($lesson) use ($attendance) {
+                $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
+                return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
             });
-
-            return $isCompleted;
         })->count();
     }
 
-    /**
-     * チャプター合計を取得する
-     *
-     * @param  Attendance  $attendance
-     * @return int
-     */
-    private function getTotalChaptersCount($attendance)
+    // チャプター合計を取得する
+    private function getTotalChaptersCount(Attendance $attendance) : int
     {
         return $attendance->course->chapters->count();
     }

--- a/tests/Feature/Api/Student/Attendance/IndexTest.php
+++ b/tests/Feature/Api/Student/Attendance/IndexTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Api\Student\Attendance;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講一覧を取得_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## issue

JKA-1142：受講生側 講座一覧APIで、講座の進捗率を表示されるように修正

## 概要

受講生側 講座一覧APIで講座の進捗率を表示されるように修正　のタスクに伴い、２つのファイルを修正
・AttendanceIndexResource.php
・IndexService.php

## 動作確認
postmanにて動作確認を実施。

- student_id=2でログイン
- URL：http://localhost:8080/api/v1/attendance/index
- HTTPメソッド：GET
- 結果：200 OK
- 進捗率が表示されるようになったことを確認
- 実際にAdminerでstatusをいくつか変更してみて、進捗率がきちんと反映（変更）されるかを試した

![スクリーンショット 2025-02-16 215014](https://github.com/user-attachments/assets/99382173-7233-4dfd-8765-59ece626f821)

## ご確認いただきたいこと
getCompletedChaptersCountメソッドとgetTotalChaptersCountメソッドは、AttendanceControllerファイル内にある既存のコードをまるまるコピーしてServiceファイルにペーストしています。
Postmanでのテストでうまくいったので、大丈夫かなと思いますがよろしくお願いいたします。
