### PR TITLE
講師側 複数のチャプター削除APIでチャプターだけでなく配下のレッスンも削除するようにする（川原）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -223,10 +223,12 @@ class ChapterController extends Controller
                 throw new AuthorizationException('Forbidden, this lesson has attendance.');
             }
 
+            // チャプターに紐づくレッスンを削除
+            Lesson::whereIn('chapter_id', $chapters->pluck('id'))->delete();
+
             // チャプターを一括で削除
             Chapter::whereIn('id', $chapters->pluck('id'))->delete();
 
-            // TODO レッスンも削除する必要がある。
             return response()->json([
                 'result' => true,
             ]);

--- a/tests/Feature/Api/Instructor/Chapter/BulkDeleteTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/BulkDeleteTest.php
@@ -36,6 +36,9 @@ class BulkDeleteTest extends TestCase
         $this->assertSoftDeleted('chapters', [
             'id' => 6,
         ]);
+        $this->assertSoftDeleted('lessons', [
+            'chapter_id' => 6,
+        ]);
     }
 
     public function test_講師が一致しない_失敗(): void


### PR DESCRIPTION
## issue
JKA-1144 講師側 複数のチャプター削除APIでチャプターだけでなく配下のレッスンも削除するようにする

## 概要
講師側 複数のチャプター削除APIでチャプターだけでなく、
配下のレッスンも削除するようにする。
app/Http/Controllers/Api/Instructor/ChapterController.php
bulkDeleteメソッドの
// TODO レッスンも削除する必要がある。
周辺に配下のレッスン削除のロジックを記述する。

## 動作確認手順
**Adminerにてchapterに紐づくlessonも削除されているかを確認する**

・今回テストを行った該当データ
　①chaptersテーブルのchapter_id 6
　②lessonsテーブルのlesson_id 9,10
　※lesson_id 9は事前に編集し、chapter_idを6に変更

Postmanにてテスト
URL = http://localhost:8080/api/v1//instructor/course/{course_id}/chapter
HTTP = DELETE

Params : course_id = 5
body : 
{
    "chapters": [6]
}