### PR TITLE
JKA-1148：講座分類（タグ）テーブルと講座テーブルとの中間テーブルを作成（こみやま）

### DIFF
--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -4,6 +4,7 @@ namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -112,4 +112,14 @@ class Course extends Model
         // public/を削除
         return str_replace('public/', '', $filePath);
     }
+
+    /**
+     * 講座分類（タグ）を取得
+     *
+     * @return BelongsToMany<Tag, $this>
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'course_tag', 'course_id', 'tag_id');
+    }
 }

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -3,8 +3,8 @@
 namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Tag extends Model
 {

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -8,8 +8,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Tag extends Model
 {
-    use SoftDeletes;
-
     /**
      * モデルと関連しているテーブル
      *

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Model;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Tag extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * モデルと関連しているテーブル
+     *
+     * @var string
+     */
+    protected $table = 'tags';
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'instructor_id',
+        'content',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'instructor_id' => 'int',
+    ];
+
+    /**
+     * 講座を取得
+     *
+     * @return BelongsTo<Course, $this>
+     */
+    public function courses(): BelongsTo
+    {
+        return $this->belongsTo(Course::class, 'course_tag', 'tag_id', 'course_id');
+    }
+}

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -4,7 +4,6 @@ namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Tag extends Model
 {

--- a/database/migrations/2025_02_16_144219_create_tags_table.php
+++ b/database/migrations/2025_02_16_144219_create_tags_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('instructor_id')->unsigned();
+            $table->string('content', 255);
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreign('instructor_id')->references('id')->on('instructors');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2025_02_16_144219_create_tags_table.php
+++ b/database/migrations/2025_02_16_144219_create_tags_table.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Model\Instructor;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Model\Instructor;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_02_16_144219_create_tags_table.php
+++ b/database/migrations/2025_02_16_144219_create_tags_table.php
@@ -13,11 +13,9 @@ return new class extends Migration
     {
         Schema::create('tags', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('instructor_id')->unsigned();
+            $table->foreignId('instructor_id')->constrained();
             $table->string('content', 255);
-            $table->timestamps();
-            $table->softDeletes();
-            $table->foreign('instructor_id')->references('id')->on('instructors');
+            $table->datetimes();
         });
     }
 

--- a/database/migrations/2025_02_16_144219_create_tags_table.php
+++ b/database/migrations/2025_02_16_144219_create_tags_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Model\Instructor;
 
 return new class extends Migration
 {
@@ -13,7 +14,7 @@ return new class extends Migration
     {
         Schema::create('tags', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->foreignId('instructor_id')->constrained();
+            $table->foreignIdFor(Instructor::class)->constrained();
             $table->string('content', 255);
             $table->datetimes();
         });

--- a/database/migrations/2025_02_16_145510_create_course_tag_table.php
+++ b/database/migrations/2025_02_16_145510_create_course_tag_table.php
@@ -13,11 +13,9 @@ return new class extends Migration
     {
         Schema::create('course_tag', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('course_id')->unsigned();
-            $table->bigInteger('tag_id')->unsigned();
-            $table->timestamps();
-            $table->foreign('course_id')->references('id')->on('courses');
-            $table->foreign('tag_id')->references('id')->on('tags');
+            $table->foreignId('course_id')->constrained();
+            $table->foreignId('tag_id')->constrained();
+            $table->dateTime('created_at')->nullable();
             $table->unique(['course_id', 'tag_id']);
         });
     }

--- a/database/migrations/2025_02_16_145510_create_course_tag_table.php
+++ b/database/migrations/2025_02_16_145510_create_course_tag_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('course_tag', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('course_id')->unsigned();
+            $table->bigInteger('tag_id')->unsigned();
+            $table->timestamps();
+            $table->foreign('course_id')->references('id')->on('courses');
+            $table->foreign('tag_id')->references('id')->on('tags');
+            $table->unique(['course_id', 'tag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('course_tag');
+    }
+};

--- a/database/migrations/2025_02_16_145510_create_course_tag_table.php
+++ b/database/migrations/2025_02_16_145510_create_course_tag_table.php
@@ -1,10 +1,10 @@
 <?php
 
+use App\Model\Course;
+use App\Model\Tag;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Model\Course;
-use App\Model\Tag;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_02_16_145510_create_course_tag_table.php
+++ b/database/migrations/2025_02_16_145510_create_course_tag_table.php
@@ -3,6 +3,8 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Model\Course;
+use App\Model\Tag;
 
 return new class extends Migration
 {
@@ -13,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('course_tag', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->foreignId('course_id')->constrained();
-            $table->foreignId('tag_id')->constrained();
+            $table->foreignIdFor(Course::class)->constrained();
+            $table->foreignIdFor(Tag::class)->constrained();
             $table->dateTime('created_at')->nullable();
             $table->unique(['course_id', 'tag_id']);
         });

--- a/database/seeders/CourseTagSeeder.php
+++ b/database/seeders/CourseTagSeeder.php
@@ -2,9 +2,9 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class CourseTagSeeder extends Seeder
 {

--- a/database/seeders/CourseTagSeeder.php
+++ b/database/seeders/CourseTagSeeder.php
@@ -18,43 +18,36 @@ class CourseTagSeeder extends Seeder
                 'course_id' => 1,
                 'tag_id' => 1,
                 'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],
             [
                 'course_id' => 2,
                 'tag_id' => 2,
                 'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],
             [
                 'course_id' => 3,
                 'tag_id' => 3,
                 'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],
             [
                 'course_id' => 4,
                 'tag_id' => 4,
                 'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],
             [
                 'course_id' => 5,
                 'tag_id' => 1,
                 'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],
             [
                 'course_id' => 6,
                 'tag_id' => 5,
                 'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],
             [
                 'course_id' => 7,
                 'tag_id' => 3,
                 'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],
         ]);
     }

--- a/database/seeders/CourseTagSeeder.php
+++ b/database/seeders/CourseTagSeeder.php
@@ -2,45 +2,57 @@
 
 namespace Database\Seeders;
 
-use App\Model\Tag;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Carbon;
 
-class TagSeeder extends Seeder
+class CourseTagSeeder extends Seeder
 {
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        Tag::insert([
+        DB::table('course_tag')->insert([
             [
-                'instructor_id' => 1,
-                'content' => 'バックエンド入門編',
+                'course_id' => 1,
+                'tag_id' => 1,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
             [
-                'instructor_id' => 2,
-                'content' => 'バックエンド講座',
+                'course_id' => 2,
+                'tag_id' => 2,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
             [
-                'instructor_id' => 3,
-                'content' => 'フロントエンドマスター講座',
+                'course_id' => 3,
+                'tag_id' => 3,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
             [
-                'instructor_id' => 4,
-                'content' => 'フロントエンド関連講座',
+                'course_id' => 4,
+                'tag_id' => 4,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
             [
-                'instructor_id' => 2,
-                'content' => 'フロントエンド講座',
+                'course_id' => 5,
+                'tag_id' => 1,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'course_id' => 6,
+                'tag_id' => 5,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'course_id' => 7,
+                'tag_id' => 3,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,5 +23,7 @@ class DatabaseSeeder extends Seeder
         $this->call(NotificationSeeder::class);
         $this->call(ViewedOnceNotificationSeeder::class);
         $this->call(ManageInstructorsSeeder::class);
+        $this->call(TagSeeder::class);
+        $this->call(CourseTagSeeder::class);
     }
 }

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class TagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
## issue
JKA-1148：講座分類（タグ）テーブルと講座テーブルとの中間テーブルを作成

## 概要
以下の作業を実施。
 - 講座分類（タグ）テーブルを作成
 - タグと講座テーブルの中間テーブルを作成
 - タグのモデルファイルを作成  
タグと講座のリレーションを設定するため。
 - シーダーファイルを作成

## 動作確認
以下のコマンドを実施。
 - マイグレーションの実行
```
php artisan migrate
```
 - シーディングの実行
```
php artisan db:seed —class=TagSeeder
```
```
php artisan db:seed —class=CourseTagSeeder
```

 - 状況に応じて以下のコマンドを実行する必要あり。
```
php artisan migrate:fresh --seed
```