### PR TITLE
マネージャー側 全チャプター削除APIでチャプターだけでなく配下のレッスンも削除するようにする (Shinya)

### DIFF
--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -7,7 +7,6 @@ use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Chapter;
 use App\Model\Instructor;
-use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -2,30 +2,31 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
-use App\Exceptions\ValidationErrorException;
-use App\Http\Controllers\Controller;
-use App\Http\Requests\Manager\Chapter\BulkDeleteRequest;
-use App\Http\Requests\Manager\Chapter\DeleteAllRequest;
-use App\Http\Requests\Manager\Chapter\DeleteRequest;
-use App\Http\Requests\Manager\Chapter\PatchStatusRequest;
-use App\Http\Requests\Manager\Chapter\PutRequest;
-use App\Http\Requests\Manager\Chapter\PutStatusRequest;
-use App\Http\Requests\Manager\Chapter\ShowRequest;
-use App\Http\Requests\Manager\Chapter\SortRequest;
-use App\Http\Requests\Manager\Chapter\StoreRequest;
-use App\Http\Requests\Manager\Chapter\UpdateStatusRequest;
-use App\Http\Resources\Manager\ChapterShowResource;
-use App\Model\Chapter;
+use Exception;
 use App\Model\Course;
+use App\Model\Lesson;
+use App\Model\Chapter;
 use App\Model\Instructor;
 use App\Model\LessonAttendance;
-use Exception;
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use App\Exceptions\ValidationErrorException;
+use App\Http\Requests\Manager\Chapter\PutRequest;
+use App\Http\Requests\Manager\Chapter\ShowRequest;
+use App\Http\Requests\Manager\Chapter\SortRequest;
+use Illuminate\Auth\Access\AuthorizationException;
+use App\Http\Requests\Manager\Chapter\StoreRequest;
+use App\Http\Resources\Manager\ChapterShowResource;
+use App\Http\Requests\Manager\Chapter\DeleteRequest;
+use App\Http\Requests\Manager\Chapter\DeleteAllRequest;
+use App\Http\Requests\Manager\Chapter\PutStatusRequest;
+use App\Http\Requests\Manager\Chapter\BulkDeleteRequest;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Http\Requests\Manager\Chapter\PatchStatusRequest;
+use App\Http\Requests\Manager\Chapter\UpdateStatusRequest;
 
 /**
  * @tags Manager-Chapter
@@ -275,6 +276,9 @@ class ChapterController extends Controller
                 // 受講中のレッスンがあれば、エラー応答
                 throw new AuthorizationException('Forbidden, this lesson has attendance.');
             }
+
+            // 削除するチャプターに紐づくレッスンを削除する
+            Lesson::whereIn('id', $lessonIds)->delete();
             // チャプターを削除
             Chapter::where('course_id', $courseId)->delete();
 

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -2,31 +2,31 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
-use Exception;
-use App\Model\Course;
-use App\Model\Lesson;
-use App\Model\Chapter;
-use App\Model\Instructor;
-use App\Model\LessonAttendance;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
-use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
 use App\Exceptions\ValidationErrorException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\Chapter\BulkDeleteRequest;
+use App\Http\Requests\Manager\Chapter\DeleteAllRequest;
+use App\Http\Requests\Manager\Chapter\DeleteRequest;
+use App\Http\Requests\Manager\Chapter\PatchStatusRequest;
 use App\Http\Requests\Manager\Chapter\PutRequest;
+use App\Http\Requests\Manager\Chapter\PutStatusRequest;
 use App\Http\Requests\Manager\Chapter\ShowRequest;
 use App\Http\Requests\Manager\Chapter\SortRequest;
-use Illuminate\Auth\Access\AuthorizationException;
 use App\Http\Requests\Manager\Chapter\StoreRequest;
-use App\Http\Resources\Manager\ChapterShowResource;
-use App\Http\Requests\Manager\Chapter\DeleteRequest;
-use App\Http\Requests\Manager\Chapter\DeleteAllRequest;
-use App\Http\Requests\Manager\Chapter\PutStatusRequest;
-use App\Http\Requests\Manager\Chapter\BulkDeleteRequest;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use App\Http\Requests\Manager\Chapter\PatchStatusRequest;
 use App\Http\Requests\Manager\Chapter\UpdateStatusRequest;
+use App\Http\Resources\Manager\ChapterShowResource;
+use App\Model\Chapter;
+use App\Model\Course;
+use App\Model\Instructor;
+use App\Model\Lesson;
+use App\Model\LessonAttendance;
+use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 /**
  * @tags Manager-Chapter

--- a/tests/Feature/Api/Manager/Chapter/DeleteAllTest.php
+++ b/tests/Feature/Api/Manager/Chapter/DeleteAllTest.php
@@ -36,6 +36,9 @@ class DeleteAllTest extends TestCase
         $this->assertSoftDeleted('chapters', [
             'course_id' => 5,
         ]);
+        $this->assertSoftDeleted('lessons', [
+            'chapter_id' => 6,
+        ]);
     }
 
     public function test_配下の講師チャプター全削除_成功(): void
@@ -54,6 +57,9 @@ class DeleteAllTest extends TestCase
         ]);
         $this->assertSoftDeleted('chapters', [
             'course_id' => 2,
+        ]);
+        $this->assertSoftDeleted('lessons', [
+            'chapter_id' => 4,
         ]);
     }
 


### PR DESCRIPTION
## Issue
- JKA-1145 マネージャー側 全チャプター削除APIでチャプターだけでなく配下のレッスンも削除するようにする (Shinya)

## 動作確認
- DELETE http://localhost:8080/api/v1/manager/course/2/chapter/all
で削除したChapterに紐づくLessonが削除されることを確認。