### PR TITLE
JKA-1162：空の配列を返すルーターとコントローラの作成（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+/**
+ * @tags Instructor-Tag
+ */
+class TagController extends Controller
+{
+    /**
+     * 講座分類更新API
+     */
+    public function update()
+    {
+        return response()->json([]);
+    }
+}

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 
 /**
  * @tags Instructor-Tag

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,6 +65,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('/', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'show']);
             Route::post('update', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'update']);
 
+            // 講師-講座分類
+            Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Instructor\TagController::class, 'update']);
+
             // 講師-講座
             Route::prefix('course')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index']);


### PR DESCRIPTION
## issue
JKA-1162：空の配列を返すルーターとコントローラの作成

## 概要
JKA-1155の子課題として、空の配列を返すルーティングの設定とコントローラーを作成。  
講座分類機能に関するコントローラーとして、新たにTagControllerを作成。

## 動作確認
Postmanにて動作確認を実施。

 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1
 - HTTPメソッド：PUT
 - 結果：200 OK  
期待通り空の配列が返された。

## 備考
 - 必要に応じて以下のコマンドを実施。
```
php artisan migrate:fresh --seed
```