### PR TITLE
JKA-1163：ロジックの作成（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,10 +3,10 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -22,7 +22,7 @@ class TagController extends Controller
         $user = Instructor::find(Auth::guard('instructor')->user()->id);
         $tag = Tag::FindOrFail($request->tag_id);
 
-        if ($user->id !== $tag->instructor_id){
+        if ($user->id !== $tag->instructor_id) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
 

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,6 +3,11 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Model\Instructor;
+use App\Model\Tag;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @tags Instructor-Tag
@@ -12,8 +17,21 @@ class TagController extends Controller
     /**
      * 講座分類更新API
      */
-    public function update()
+    public function put(Request $request)
     {
-        return response()->json([]);
+        $user = Instructor::find(Auth::guard('instructor')->user()->id);
+        $tag = Tag::FindOrFail($request->tag_id);
+
+        if ($user->id !== $tag->instructor_id){
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
+        $tag->update([
+            'content' => $request->content,
+        ]);
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -21,7 +21,7 @@ class TagController extends Controller
     public function put(Request $request): JsonResponse
     {
         $user = Instructor::find(Auth::guard('instructor')->user()->id);
-        $tag = Tag::FindOrFail($request->tag_id);
+        $tag = Tag::findOrFail($request->tag_id);
 
         if ($user->id !== $tag->instructor_id) {
             throw new AuthorizationException('Forbidden, invalid instructor.');

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -17,13 +18,13 @@ class TagController extends Controller
     /**
      * 講座分類更新API
      */
-    public function put(Request $request)
+    public function put(Request $request): JsonResponse
     {
         $user = Instructor::find(Auth::guard('instructor')->user()->id);
         $tag = Tag::FindOrFail($request->tag_id);
 
         if ($user->id !== $tag->instructor_id) {
-            throw new AuthorizationException('Invalid instructor_id.');
+            throw new AuthorizationException('Forbidden, invalid instructor.');
         }
 
         $tag->update([

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,7 +66,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::post('update', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'update']);
 
             // 講師-講座分類
-            Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Instructor\TagController::class, 'update']);
+            Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
 
             // 講師-講座
             Route::prefix('course')->group(function () {

--- a/tests/Feature/Api/Instructor/Tag/PutTest.php
+++ b/tests/Feature/Api/Instructor/Tag/PutTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Tag;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_タグ_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/tag/1', [
+            'content' => 'test',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('tags', [
+            'id' => 1,
+            'content' => 'test',
+        ]);
+    }
+
+    public function test_許可がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/tag/1', [
+            'content' => 'test',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor.',
+        ]);
+    }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+
+    //     // act
+    //     $response = $this->putJson('/api/v1/instructor/tag/aaa', []);
+
+    //     // assert
+    //     $response->assertStatus(422);
+    // }
+}


### PR DESCRIPTION
## issue
JKA-1163：ロジックの作成

## 概要
JKA-1155 講師側 講座分類 更新API新規作成の3つ目のタスク。  
講座分類更新APIのロジックを作成。

## 動作確認
Postmanにて以下の動作確認を実施。

1. 正常：講座分類を更新
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1
 - HTTPメソッド：PUT
 - 結果：200 OK  
"result": true

2. 異常：存在しない講座分類IDの場合、エラーとなる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/10
 - HTTPメソッド：PUT
 - 結果：404 Not Found  
"message": "No query results for model [App\\Model\\Tag] 10"

3. 異常：ログイン中の講師が作成した講座分類でない場合は、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/2
 - HTTPメソッド：PUT
 - 結果：403 Forbidden  
"message": "Invalid instructor_id."