### PR TITLE
JKA-1164(親1154)：空の配列を返すルーターとコントローラの作成（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+
+/**
+ * @tags Instructor-Tag
+ */
+class TagController extends Controller
+{
+    /**
+     * 講座分類（タグ）登録API
+     */
+    public function store()
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -120,6 +120,9 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 });
             });
 
+            // 講師-タグ
+            Route::post('tag', [App\Http\Controllers\Api\Instructor\TagController::class, 'store']);
+
             // 講師-受講
             Route::prefix('attendance')->group(function () {
                 Route::post('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'store']);


### PR DESCRIPTION
## issue
JKA-1164：空の配列を返すルーターとコントローラ実装

## 概要
講師側 講座分類 新規登録API新規作成に伴い、空の配列を返すようルーターとコントローラーを実装。

## 動作確認
postmanにて動作確認を実施。
 - instructor_id=1、instructor_id=2  でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag
 - HTTPメソッド：POST
 - 結果：200 OK  
正常に空の配列が返された。