### PR TITLE
受講生側 チャプター詳細APIに講座分類名を追加

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -60,7 +60,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage()."\n".$e->getTraceAsString());
+            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
             throw $e;
         }
     }
@@ -75,6 +75,7 @@ class AttendanceController extends Controller
         $attendance = Attendance::with([
             'course.chapters.lessons',
             'lessonAttendances',
+            'course.tags',
         ])
             ->where('id', $request->attendance_id)
             ->firstOrFail();

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -60,7 +60,7 @@ class AttendanceController extends Controller
 
             return new AttendanceShowResource($attendance);
         } catch (AuthorizationException $e) {
-            Log::error($e->getMessage() . "\n" . $e->getTraceAsString());
+            Log::error($e->getMessage()."\n".$e->getTraceAsString());
             throw $e;
         }
     }

--- a/app/Http/Resources/Student/AttendanceShowChapterResource.php
+++ b/app/Http/Resources/Student/AttendanceShowChapterResource.php
@@ -24,7 +24,7 @@ class AttendanceShowChapterResource extends JsonResource
                 'course_id' => $attendance->course->id,
                 'title' => $attendance->course->title,
                 'image' => $attendance->course->image,
-                'tags' => $attendance->course->tags->map(fn($tag) => $tag->content),
+                'tags' => $attendance->course->tags,
                 'chapter' => [
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,

--- a/app/Http/Resources/Student/AttendanceShowChapterResource.php
+++ b/app/Http/Resources/Student/AttendanceShowChapterResource.php
@@ -24,7 +24,7 @@ class AttendanceShowChapterResource extends JsonResource
                 'course_id' => $attendance->course->id,
                 'title' => $attendance->course->title,
                 'image' => $attendance->course->image,
-                'tags' => $attendance->course->tags->map(fn($tag) => $tag->content),
+                'tags' => $attendance->course->tags->map(fn ($tag) => $tag->content),
                 'chapter' => [
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,

--- a/app/Http/Resources/Student/AttendanceShowChapterResource.php
+++ b/app/Http/Resources/Student/AttendanceShowChapterResource.php
@@ -24,6 +24,7 @@ class AttendanceShowChapterResource extends JsonResource
                 'course_id' => $attendance->course->id,
                 'title' => $attendance->course->title,
                 'image' => $attendance->course->image,
+                'tags' => $attendance->course->tags->map(fn($tag) => $tag->content),
                 'chapter' => [
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -33,8 +33,6 @@ class Tag extends Model
 
     /**
      * 講座を取得
-     *
-     * @return BelongsToMany
      */
     public function courses(): BelongsToMany
     {

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -3,7 +3,7 @@
 namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Tag extends Model
 {
@@ -34,10 +34,10 @@ class Tag extends Model
     /**
      * 講座を取得
      *
-     * @return BelongsTo<Course, $this>
+     * @return BelongsToMany
      */
-    public function courses(): BelongsTo
+    public function courses(): BelongsToMany
     {
-        return $this->belongsTo(Course::class, 'course_tag', 'tag_id', 'course_id');
+        return $this->belongsToMany(Course::class, 'course_tag', 'tag_id', 'course_id');
     }
 }


### PR DESCRIPTION
## issue
JKA-1152 受講生側 チャプター詳細APIに講座分類名を追加

## 概要
他タスクで実装済の
講座分類（講座にタグを付けるような存在なのでタグと捉えてもOK）テーブルと、
中間テーブルを利用して
（中間テーブルは、多対多の関係にあるタグテーブルと現状存在する講座テーブルを繋ぐテーブル）
下記APIで、講座分類名を取得できるようにAPIを改修する。

**チャプター詳細API**
URL: api/v1/attendance/{attendance_id}/course/{course_id}/chapter/{chapter_id}

## 動作確認手順
Postmanにて確認実施。

Postmanにてテスト
URL = [http://localhost:8080/api/v1//instructor/course/{course_id}/chapter](http://localhost:8080/api/v1/attendance/1/course/1/chapter/1)
HTTP = GET

以下のように、講座分類名を取得できていればOK。
```
"tags": [
                "バックエンド入門編"
            ],
```

レスポンス：
```
{
    "data": {
        "attendance_id": 1,
        "course": {
            "course_id": 1,
            "title": "PHP入門講座",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "tags": [
                "バックエンド入門編"
            ],
            "chapter": {
                "chapter_id": 1,
                "title": "PHPとは？",
                "lessons": [
                    {
                        "lesson_id": 1,
                        "title": "echo",
                        "completed_lessons_count": 1,
                        "total_lessons_count": 1,
                        "url": "sVbEyFZKgqk",
                        "remarks": "HTMLでは決められたテキストしか表示することができませんでした。\nPHPを使うと、見る人や状況に応じて、表示するテキストを変えることができます。",
                        "lessonAttendance": {
                            "lesson_attendance_id": 1,
                            "status": "in_attendance"
                        }
                    }
                ]
            }
        }
    }
}
```