### PR TITLE
空の配列を返すルーターとコントローラの作成(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 
 class TagController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    /**
+     * 分類表示ボタン活性の時の講座一覧API
+     */
+    public function index()
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,6 +70,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index']);
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
+                Route::get('tag/index', [App\Http\Controllers\Api\Instructor\TagController::class, 'index']);
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'update']);


### PR DESCRIPTION
## issue
- Closes
#JKA-1150 分類表示ボタン活性の時の、講師側 講座一覧APIを新規作成

## 概要
- api.phpにルーティングを記載。tagコントローラー作成して、indexメソッドを記載しました。

## 動作確認手順
### Instructor/TagController
- indexメソッド
テストケース1
URL：http://localhost:8080/api/v1/instructor/course/tag/index
結果：
```
[]
```

## 考慮して欲しいこと
## 確認して欲しいこと