### PR TITLE
JKA-1159 マネージャー側 講師更新API修正後、Scrambleで正しく表示されるように対応(いずみ)

### DIFF
--- a/app/Http/Requests/Manager/Instructor/UpdateRequest.php
+++ b/app/Http/Requests/Manager/Instructor/UpdateRequest.php
@@ -35,7 +35,7 @@ class UpdateRequest extends FormRequest
             'nick_name' => ['required', 'string', 'max:50'],
             'last_name' => ['required', 'string', 'max:50'],
             'first_name' => ['required', 'string', 'max:50'],
-            'email' => ['required', 'email', new InstructorUniqueEmailRule($this->email), 'max:255'],
+            'email' => ['required', 'email', new InstructorUniqueEmailRule($this?->email), 'max:255'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
             'profile_image' => ['mimes:jpg,png', 'max:2048'],
         ];

--- a/app/Http/Requests/Manager/Instructor/UpdateRequest.php
+++ b/app/Http/Requests/Manager/Instructor/UpdateRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Manager\Instructor;
 
+use App\Model\Instructor;
 use App\Rules\InstructorUniqueEmailRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -31,11 +32,13 @@ class UpdateRequest extends FormRequest
      */
     public function rules()
     {
+        $instructor = Instructor::find($this->instructor_id);
+
         return [
             'nick_name' => ['required', 'string', 'max:50'],
             'last_name' => ['required', 'string', 'max:50'],
             'first_name' => ['required', 'string', 'max:50'],
-            'email' => ['required', 'email', new InstructorUniqueEmailRule($this?->email), 'max:255'],
+            'email' => ['required', 'email', new InstructorUniqueEmailRule($instructor?->email), 'max:255'],
             'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
             'profile_image' => ['mimes:jpg,png', 'max:2048'],
         ];

--- a/app/Rules/InstructorUniqueEmailRule.php
+++ b/app/Rules/InstructorUniqueEmailRule.php
@@ -8,8 +8,6 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class InstructorUniqueEmailRule implements ValidationRule
 {
-    // private string $email;
-
     /**
      * Create a new rule instance.
      *

--- a/app/Rules/InstructorUniqueEmailRule.php
+++ b/app/Rules/InstructorUniqueEmailRule.php
@@ -8,17 +8,16 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class InstructorUniqueEmailRule implements ValidationRule
 {
-    private string $email;
+    // private string $email;
 
     /**
      * Create a new rule instance.
      *
      * @return void
      */
-    public function __construct($email)
-    {
-        $this->email = $email;
-    }
+    public function __construct(
+        private ?string $email
+    ){}
 
     /**
      * バリデーションの実行。

--- a/app/Rules/InstructorUniqueEmailRule.php
+++ b/app/Rules/InstructorUniqueEmailRule.php
@@ -17,7 +17,7 @@ class InstructorUniqueEmailRule implements ValidationRule
      */
     public function __construct(
         private ?string $email
-    ){}
+    ) {}
 
     /**
      * バリデーションの実行。

--- a/tests/Feature/Api/Manager/Instructor/UpdateTest.php
+++ b/tests/Feature/Api/Manager/Instructor/UpdateTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Instructor;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/manager/instructor/1', [
+            'nick_name' => 'test',
+            'last_name' => 'test',
+            'first_name' => 'test',
+            'email' => 'test_update@exmaple.com',
+            'profile_image' => $file,
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('instructors', [
+            'id' => 1,
+            'nick_name' => 'test',
+            'last_name' => 'test',
+            'first_name' => 'test',
+            'email' => 'test_update@exmaple.com',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->post('/api/v1/manager/instructor/1', [
+            'nick_name' => '',
+            'last_name' => '',
+            'first_name' => '',
+            'email' => '',
+            'profile_image' => '',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'nick_name',
+            'last_name',
+            'first_name',
+            'email',
+            'profile_image',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1159 マネージャー側 講師更新API修正後、Scrambleで正しく表示されるように対応

## 概要
Swaggerの代わりに導入されたScrambleが正しく表示されるようにするため
マネージャー側 講師更新APIを修正

## 動作確認手順
**①Scrambleのmanager-instructorの講師更新APIが正しく表示されているか確認**
**②ポストマンにてテスト**
URL：http://localhost:8080/api/v1/manager/instructor/:instructor_id
HTTP：POST

Params：instructor_id＝1
（Bodyは通常rawに記載しますが今回profile_imageでファイルをアップロードしたためform-dataに記載しました）
Body：{
  "nick_name": "string",
  "last_name": "string",
  "first_name": "string",
  "email": "user@example.com",
  "instructor_id": 0,
  "profile_image": 'course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png',
}