### PR TITLE
JKA1166(親1154)：ロジックの作成(西山しょうこ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Auth;
 class TagController extends Controller
 {
     /**
-     * 講座分類（タグ）登録API
+     * タグ登録API
      */
     public function store(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Model\Tag;
-use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -24,8 +24,6 @@ class TagController extends Controller
         Tag::create([
             'instructor_id' => $instructorId,
             'content' => $request->content,
-            'created_at' => Carbon::now(),
-            'updated_at' => Carbon::now(),
         ]);
         
         return response()->json([

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -6,8 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Model\Tag;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @tags Instructor-Tag
@@ -27,7 +27,7 @@ class TagController extends Controller
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ]);
-        
+
         return response()->json([
             'result' => true,
         ]);

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,6 +3,11 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Model\Tag;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 /**
  * @tags Instructor-Tag
@@ -12,8 +17,19 @@ class TagController extends Controller
     /**
      * 講座分類（タグ）登録API
      */
-    public function store()
+    public function store(Request $request): JsonResponse
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        Tag::create([
+            'instructor_id' => $instructorId,
+            'content' => $request->content,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+        
+        return response()->json([
+            'result' => true,
+        ]);
     }
 }

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -14,14 +14,15 @@ class Tag extends Model
      */
     protected $table = 'tags';
 
+    // Laravelの自動タイムスタンプ機能（created_at, updated_at が自動管理(now)される）
+    public $timestamps = true;
+
     /**
      * @var array<int, string>
      */
     protected $fillable = [
         'instructor_id',
         'content',
-        'created_at',
-        'updated_at',
     ];
 
     /**

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -2,6 +2,7 @@
 
 namespace App\Model;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -13,9 +14,6 @@ class Tag extends Model
      * @var string
      */
     protected $table = 'tags';
-
-    // Laravelの自動タイムスタンプ機能（created_at, updated_at が自動管理(now)される）
-    public $timestamps = true;
 
     /**
      * @var array<int, string>
@@ -30,6 +28,8 @@ class Tag extends Model
      */
     protected $casts = [
         'instructor_id' => 'int',
+        'created_at' => 'immutable_datetime',
+        'updated_at' => 'immutable_datetime',
     ];
 
     /**
@@ -40,5 +40,19 @@ class Tag extends Model
     public function courses(): BelongsTo
     {
         return $this->belongsTo(Course::class, 'course_tag', 'tag_id', 'course_id');
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function (Tag $tag) {
+            $tag->created_at = CarbonImmutable::now();
+            $tag->updated_at = CarbonImmutable::now();
+        });
+
+        static::updating(function (Tag $tag) {
+            $tag->updated_at = CarbonImmutable::now();
+        });
     }
 }

--- a/database/migrations/2025_02_16_144219_create_tags_table.php
+++ b/database/migrations/2025_02_16_144219_create_tags_table.php
@@ -16,7 +16,9 @@ return new class extends Migration
             $table->bigIncrements('id');
             $table->foreignIdFor(Instructor::class)->constrained();
             $table->string('content', 255);
-            $table->datetimes();
+
+            $table->dateTime('created_at');
+            $table->dateTime('updated_at');
         });
     }
 

--- a/tests/Feature/Api/Instructor/Tag/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Tag/StoreTest.php
@@ -53,47 +53,4 @@ class StoreTest extends TestCase
     //     // assert
     //     $response->assertStatus(422);
     // }
-
-    // public function test_認証コード重複エラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(1);
-    //     $this->actingAs($instructor, 'instructor');
-    //     $this->mock(\App\Services\Auth\CredentialGeneratorService::class, function ($mock) {
-    //         $mock->shouldReceive('createCode')->andThrow(new \App\Exceptions\DuplicateAuthorizationCodeException('Failed to generate unique authorization code.'));
-    //     });
-
-    //     // act
-    //     $response = $this->postJson('/api/v1/instructor', [
-    //         'nick_name' => 'test',
-    //         'last_name' => 'test',
-    //         'first_name' => 'test',
-    //         'email' => 'testtest@exmaple.com',
-    //     ]);
-
-    //     // assert
-    //     $response->assertStatus(400);
-    // }
-
-    // public function test_トークン重複エラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(1);
-    //     $this->actingAs($instructor, 'instructor');
-    //     $this->mock(\App\Services\Auth\CredentialGeneratorService::class, function ($mock) {
-    //         $mock->shouldReceive('createCode')->andReturn('1234');
-    //         $mock->shouldReceive('createToken')->andThrow(new \App\Exceptions\DuplicateAuthorizationTokenException('Failed to generate unique authorization token.'));
-    //     });
-
-    //     // act
-    //     $response = $this->postJson('/api/v1/instructor', [
-    //         'nick_name' => 'test',
-    //         'last_name' => 'test',
-    //         'first_name' => 'test',
-    //         'email' => 'testtest@exmaple.com',
-    //     ]);
-
-    //     // assert
-    //     $response->assertStatus(400);
-    // }
 }

--- a/tests/Feature/Api/Instructor/Tag/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Tag/StoreTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Tag;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_タグ登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/tag', [
+            'content' => 'test',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('tags', [
+            'instructor_id' => $instructor->id,
+            'content' => 'test',
+        ]);
+    }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+
+    //     // act
+    //     $response = $this->postJson('/api/v1/instructor', [
+    //         'nick_name' => '',
+    //         'last_name' => '',
+    //         'first_name' => '',
+    //         'email' => '',
+    //     ]);
+
+    //     // assert
+    //     $response->assertStatus(422);
+    // }
+
+    // public function test_認証コード重複エラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+    //     $this->mock(\App\Services\Auth\CredentialGeneratorService::class, function ($mock) {
+    //         $mock->shouldReceive('createCode')->andThrow(new \App\Exceptions\DuplicateAuthorizationCodeException('Failed to generate unique authorization code.'));
+    //     });
+
+    //     // act
+    //     $response = $this->postJson('/api/v1/instructor', [
+    //         'nick_name' => 'test',
+    //         'last_name' => 'test',
+    //         'first_name' => 'test',
+    //         'email' => 'testtest@exmaple.com',
+    //     ]);
+
+    //     // assert
+    //     $response->assertStatus(400);
+    // }
+
+    // public function test_トークン重複エラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+    //     $this->mock(\App\Services\Auth\CredentialGeneratorService::class, function ($mock) {
+    //         $mock->shouldReceive('createCode')->andReturn('1234');
+    //         $mock->shouldReceive('createToken')->andThrow(new \App\Exceptions\DuplicateAuthorizationTokenException('Failed to generate unique authorization token.'));
+    //     });
+
+    //     // act
+    //     $response = $this->postJson('/api/v1/instructor', [
+    //         'nick_name' => 'test',
+    //         'last_name' => 'test',
+    //         'first_name' => 'test',
+    //         'email' => 'testtest@exmaple.com',
+    //     ]);
+
+    //     // assert
+    //     $response->assertStatus(400);
+    // }
+}


### PR DESCRIPTION
## issue
JKA-1166：ロジックの作成

## 概要
JKA-1154 講師側 講座分類 新規登録API新規作成  　に伴い、ロジックの作成

## 動作確認
・php artisan migrate の実行

・Postmanにて以下の動作確認を実施。
 - instructor_id=1、instructor_id=2  でそれぞれログイン
 - URL：http://localhost:8080/api/v1/instructor/tag
 - HTTPメソッド：POST
 - 結果：200 OK  
"result": true
