### PR TITLE
ロジックの作成(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Model\Course;
+use App\Model\Tag;
+use Illuminate\Support\Facades\Auth;
 
 class TagController extends Controller
 {
@@ -11,6 +14,15 @@ class TagController extends Controller
      */
     public function index()
     {
-        return response()->json([]);
+        // ログインしている講師
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        $tags = Tag::where('instructor_id', $instructorId)->select('id', 'content')->get();
+        $courses = Course::where('instructor_id', $instructorId)->select('id', 'title', 'image', 'status')->get();
+
+        return response()->json([
+            'tags' => $tags,
+            'courses' => $courses
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -22,7 +22,7 @@ class TagController extends Controller
 
         return response()->json([
             'tags' => $tags,
-            'courses' => $courses
+            'courses' => $courses,
         ]);
     }
 }

--- a/app/Http/Resources/LessonAttendance/LessonAttendanceResource.php
+++ b/app/Http/Resources/LessonAttendance/LessonAttendanceResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources\LessonAttendance;
+
+use App\Model\LessonAttendance;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class LessonAttendanceResource extends JsonResource
+{
+    /** @var LessonAttendance */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'lesson_attendance_id' => $this->resource->id,
+            'status' => $this->resource->status,
+        ];
+    }
+}

--- a/app/Http/Resources/Student/AttendanceShowResource.php
+++ b/app/Http/Resources/Student/AttendanceShowResource.php
@@ -2,14 +2,14 @@
 
 namespace App\Http\Resources\Student;
 
+use App\Http\Resources\Chapter\ChapterResource;
+use App\Http\Resources\Course\CourseResource;
+use App\Http\Resources\Lesson\LessonResource;
+use App\Http\Resources\LessonAttendance\LessonAttendanceResource;
+use App\Http\Resources\Tag\TagResource;
 use App\Model\Attendance;
-use App\Model\Chapter;
-use App\Model\Course;
-use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
-use App\Model\Tag;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttendanceShowResource extends JsonResource
@@ -27,79 +27,26 @@ class AttendanceShowResource extends JsonResource
     {
         return [
             'attendance_id' => $this->resource->id,
-            'course' => $this->course($this->resource->course),
+            'course' => [
+                ...(new CourseResource($this->resource->course))->toArray($request),
+                'tags' => TagResource::collection($this->resource->course->tags),
+                'chapters' => ChapterResource::collection($this->resource->course->publicChapters)->collection->map(function (ChapterResource $chapterResource) use ($request) {
+                    return [
+                        ...$chapterResource->toArray($request),
+                        'lessons' => $chapterResource->resource->lessons->map(function (Lesson $lesson) use ($request) {
+                            $lessonAttendance = $this->resource->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($lesson) {
+                                return $lesson->id === $lessonAttendance->lesson_id;
+                            })->first();
+                            assert($lessonAttendance instanceof LessonAttendance);
+
+                            return [
+                                ...(new LessonResource($lesson))->toArray($request),
+                                'lessonAttendance' => new LessonAttendanceResource($lessonAttendance),
+                            ];
+                        }),
+                    ];
+                }),
+            ],
         ];
-    }
-
-    private function course(Course $course)
-    {
-        return [
-            'course_id' => $course->id,
-            'title' => $course->title,
-            'image' => $course->image,
-            'tags' => $this->tags($course->tags),
-            'instructor' => $this->instructor($course->instructor),
-            'chapters' => $this->chapters($course->publicChapters),
-        ];
-    }
-
-    private function instructor(Instructor $instructor)
-    {
-        return [
-            'instructor_id' => $instructor->id,
-            'nick_name' => $instructor->nick_name,
-            'last_name' => $instructor->last_name,
-            'first_name' => $instructor->first_name,
-            'email' => $instructor->email,
-            'profile_image' => $instructor->profile_image,
-        ];
-    }
-
-    /**
-     * @param  Collection<int, Chapter>  $chapters
-     */
-    private function chapters(Collection $chapters)
-    {
-        return $chapters->map(function (Chapter $chapter) {
-            return [
-                'chapter_id' => $chapter->id,
-                'title' => $chapter->title,
-                'lessons' => $this->lessons($chapter->lessons),
-            ];
-        });
-    }
-
-    /**
-     * @param  Collection<int, Lesson>  $lessons
-     */
-    private function lessons(Collection $lessons)
-    {
-        return $lessons->map(function (Lesson $lesson) {
-            /** @var LessonAttendance $lessonAttendance */
-            $lessonAttendance = $this->resource->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($lesson) {
-                return $lesson->id === $lessonAttendance->lesson_id;
-            })->first();
-
-            return [
-                'lesson_id' => $lesson->id,
-                'title' => $lesson->title,
-                'url' => $lesson->url,
-                'remarks' => $lesson->remarks,
-                'lessonAttendance' => [
-                    'lesson_attendance_id' => $lessonAttendance->id,
-                    'status' => $lessonAttendance->status,
-                ],
-            ];
-        });
-    }
-
-    private function tags(Collection $tags)
-    {
-        return $tags->map(function (Tag $tag) {
-            return [
-                'tag_id' => $tag->id,
-                'content' => $tag->content,
-            ];
-        });
     }
 }

--- a/app/Http/Resources/Student/AttendanceShowResource.php
+++ b/app/Http/Resources/Student/AttendanceShowResource.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Resources\Student;
 
-use App\Model\Tag;
-use App\Model\Course;
-use App\Model\Lesson;
-use App\Model\Chapter;
 use App\Model\Attendance;
+use App\Model\Chapter;
+use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Lesson;
 use App\Model\LessonAttendance;
+use App\Model\Tag;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/app/Http/Resources/Student/AttendanceShowResource.php
+++ b/app/Http/Resources/Student/AttendanceShowResource.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Resources\Student;
 
-use App\Model\Attendance;
-use App\Model\Chapter;
+use App\Model\Tag;
 use App\Model\Course;
-use App\Model\Instructor;
 use App\Model\Lesson;
+use App\Model\Chapter;
+use App\Model\Attendance;
+use App\Model\Instructor;
 use App\Model\LessonAttendance;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -36,6 +37,7 @@ class AttendanceShowResource extends JsonResource
             'course_id' => $course->id,
             'title' => $course->title,
             'image' => $course->image,
+            'tags' => $this->tags($course->tags),
             'instructor' => $this->instructor($course->instructor),
             'chapters' => $this->chapters($course->publicChapters),
         ];
@@ -87,6 +89,16 @@ class AttendanceShowResource extends JsonResource
                     'lesson_attendance_id' => $lessonAttendance->id,
                     'status' => $lessonAttendance->status,
                 ],
+            ];
+        });
+    }
+
+    private function tags(Collection $tags)
+    {
+        return $tags->map(function (Tag $tag) {
+            return [
+                'tag_id' => $tag->id,
+                'content' => $tag->content,
             ];
         });
     }

--- a/app/Http/Resources/Tag/TagResource.php
+++ b/app/Http/Resources/Tag/TagResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources\Tag;
+
+use App\Model\Tag;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TagResource extends JsonResource
+{
+    /** @var Tag */
+    public $resource;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'tag_id' => $this->resource->id,
+            'content' => $this->resource->content,
+        ];
+    }
+}

--- a/database/migrations/2022_10_29_022717_create_lesson_attendances_table.php
+++ b/database/migrations/2022_10_29_022717_create_lesson_attendances_table.php
@@ -21,8 +21,8 @@ class CreateLessonAttendancesTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
-            $table->foreign('lesson_id')->references('id')->on('lessons');
-            $table->foreign('attendance_id')->references('id')->on('attendances');
+            $table->foreign('lesson_id')->references('id')->on('lessons'); //外部キー制約
+            $table->foreign('attendance_id')->references('id')->on('attendances'); //外部キー制約
         });
     }
 

--- a/database/migrations/2022_10_29_022717_create_lesson_attendances_table.php
+++ b/database/migrations/2022_10_29_022717_create_lesson_attendances_table.php
@@ -21,6 +21,8 @@ class CreateLessonAttendancesTable extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
+            $table->foreign('lesson_id')->references('id')->on('lessons');
+            $table->foreign('attendance_id')->references('id')->on('attendances');
         });
     }
 

--- a/database/migrations/2022_10_30_022717_create_lesson_attendances_table.php
+++ b/database/migrations/2022_10_30_022717_create_lesson_attendances_table.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Model\Attendance;
+use App\Model\Lesson;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,14 +17,12 @@ class CreateLessonAttendancesTable extends Migration
     {
         Schema::create('lesson_attendances', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('lesson_id')->unsigned()->comment('レッスンID');
-            $table->bigInteger('attendance_id')->unsigned()->comment('受講ID');
+            $table->foreignIdFor(Lesson::class)->constrained()->comment('レッスンID');
+            $table->foreignIdFor(Attendance::class)->constrained()->comment('受講ID');
             $table->string('status', 30)->comment('レッスン受講状態');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
-            $table->foreign('lesson_id')->references('id')->on('lessons'); //外部キー制約
-            $table->foreign('attendance_id')->references('id')->on('attendances'); //外部キー制約
         });
     }
 

--- a/tests/Feature/Api/Student/Attendance/ShowTest.php
+++ b/tests/Feature/Api/Student/Attendance/ShowTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Api\Student\Attendance;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講取得_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_権限がない受講生_失敗(): void
+    {
+        // arrange
+        $student = Student::find(2);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/1');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'attendance_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes
#JKA-1150 分類表示ボタン活性の時の、講師側 講座一覧APIを新規作成（ロジックの作成）

## 概要
- indexメソッドのロジックを作成しました。

## 動作確認手順
### Instructor/TagController
- indexメソッド
テストケース1
URL：http://localhost:8080/api/v1/instructor/course/tag/index
結果：
```
{
    "tags": [
        {
            "id": 1,
            "content": "バックエンド入門編"
        }
    ],
    "courses": [
        {
            "id": 1,
            "title": "PHP入門講座",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "status": "public"
        },
        {
            "id": 5,
            "title": "Python入門講座",
            "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
            "status": "public"
        }
    ]
}
```