### PR TITLE
ロジックの作成(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Model\Course;
+use App\Model\Tag;
+use Illuminate\Support\Facades\Auth;
 
 class TagController extends Controller
 {
@@ -11,6 +14,15 @@ class TagController extends Controller
      */
     public function index()
     {
-        return response()->json([]);
+        // ログインしている講師
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        $tags = Tag::where('instructor_id', $instructorId)->select('id', 'content')->get();
+        $courses = Course::where('instructor_id', $instructorId)->select('id', 'title', 'image', 'status')->get();
+
+        return response()->json([
+            'tags' => $tags,
+            'courses' => $courses
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -10,19 +10,17 @@ use Illuminate\Support\Facades\Auth;
 class TagController extends Controller
 {
     /**
-     * 分類表示ボタン活性の時の講座一覧API
+     * 講座一覧取得API
      */
     public function index()
     {
         // ログインしている講師
         $instructorId = Auth::guard('instructor')->user()->id;
 
-        $tags = Tag::where('instructor_id', $instructorId)->select('id', 'content')->get();
-        $courses = Course::where('instructor_id', $instructorId)->select('id', 'title', 'image', 'status')->get();
+        $tags = Tag::where('instructor_id', $instructorId)->with('courses')->get();
 
         return response()->json([
-            'tags' => $tags,
-            'courses' => $courses
+            'tags' => $tags
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 
 class TagController extends Controller
 {

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    /**
+     * 分類表示ボタン活性の時の講座一覧API
+     */
+    public function index()
+    {
+        return response()->json([]);
+    }
+}

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use App\Model\Course;
 use App\Model\Tag;
 use Illuminate\Support\Facades\Auth;
 
@@ -20,7 +19,7 @@ class TagController extends Controller
         $tags = Tag::where('instructor_id', $instructorId)->with('courses')->get();
 
         return response()->json([
-            'tags' => $tags
+            'tags' => $tags,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -22,7 +22,7 @@ class TagController extends Controller
 
         return response()->json([
             'tags' => $tags,
-            'courses' => $courses
+            'courses' => $courses,
         ]);
     }
 }

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -3,7 +3,6 @@
 namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Tag extends Model

--- a/app/Model/Tag.php
+++ b/app/Model/Tag.php
@@ -4,6 +4,7 @@ namespace App\Model;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Tag extends Model
 {
@@ -34,10 +35,10 @@ class Tag extends Model
     /**
      * 講座を取得
      *
-     * @return BelongsTo<Course, $this>
+     * @return BelongsToMany<Course, $this>
      */
-    public function courses(): BelongsTo
+    public function courses(): BelongsToMany
     {
-        return $this->belongsTo(Course::class, 'course_tag', 'tag_id', 'course_id');
+        return $this->belongsToMany(Course::class, 'course_tag', 'tag_id', 'course_id');
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,6 +70,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index']);
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
+                Route::get('tag/index', [App\Http\Controllers\Api\Instructor\TagController::class, 'index']);
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'update']);


### PR DESCRIPTION
## issue
- Closes
#JKA-1150 分類表示ボタン活性の時の、講師側 講座一覧APIを新規作成（ロジックの作成）

## 概要
- indexメソッドのロジックを作成しました。

## 動作確認手順
### Instructor/TagController
- indexメソッド
テストケース1
URL：http://localhost:8080/api/v1/instructor/course/tag/index
ログイン：
instructor_id = 1
結果：
```
{
    "tags": [
        {
            "id": 1,
            "content": "バックエンド入門編"
        }
    ],
    "courses": [
        {
            "id": 1,
            "title": "PHP入門講座",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "status": "public"
        },
        {
            "id": 5,
            "title": "Python入門講座",
            "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
            "status": "public"
        }
    ]
}
```