### PR TITLE
JKA-1165：フォームリクエストの作成（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\Tag\PutRequest;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -18,7 +18,7 @@ class TagController extends Controller
     /**
      * 講座分類更新API
      */
-    public function put(Request $request): JsonResponse
+    public function put(PutRequest $request): JsonResponse
     {
         $user = Instructor::find(Auth::guard('instructor')->user()->id);
         $tag = Tag::findOrFail($request->tag_id);

--- a/app/Http/Requests/Instructor/Tag/PutRequest.php
+++ b/app/Http/Requests/Instructor/Tag/PutRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PutRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'tag_id' => $this->route('tag_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'tag_id' => ['required', 'integer', 'exists:tags,id'],
+            'content' => ['required', 'string'],
+        ];
+    }
+}

--- a/tests/Feature/Api/Instructor/Tag/PutTest.php
+++ b/tests/Feature/Api/Instructor/Tag/PutTest.php
@@ -54,16 +54,16 @@ class PutTest extends TestCase
         ]);
     }
 
-    // public function test_バリデーションエラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(1);
-    //     $this->actingAs($instructor, 'instructor');
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
 
-    //     // act
-    //     $response = $this->putJson('/api/v1/instructor/tag/aaa', []);
+        // act
+        $response = $this->putJson('/api/v1/instructor/tag/aaa', []);
 
-    //     // assert
-    //     $response->assertStatus(422);
-    // }
+        // assert
+        $response->assertStatus(422);
+    }
 }


### PR DESCRIPTION
## issue
JKA-1165：フォームリクエストの作成

## 概要
JKA-1155：講師側 講座分類 更新API新規作成の4つ目のタスク。
講座分類更新APIのフォームリクエストを作成。

## 動作確認
Postmanにて動作確認を実施。

1. tag_idが整数値でない場合
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1.5
 - 結果：422 Unprocessable Content  
"message": "The tag id must be an integer.”

2. contentがnullの場合
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1
 - 結果：422 Unprocessable Content  
"message": "The content field is required.”