### PR TITLE
JKA-1156 空の配列を返すルーターとコントローラの作成（川原）

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -9,11 +9,11 @@ use App\Http\Controllers\Controller;
  */
 class TagController extends Controller
 {
-  /**
-   * 講座分類更新API
-   */
-  public function update()
-  {
-    return response()->json([]);
-  }
+    /**
+     * 講座分類更新API
+     */
+    public function update()
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api\Manager;
+
+use App\Http\Controllers\Controller;
+
+/**
+ * @tags Manager-Tag
+ */
+class TagController extends Controller
+{
+  /**
+   * 講座分類更新API
+   */
+  public function update()
+  {
+    return response()->json([]);
+  }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,6 +153,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
+                // 新規に講座分類更新APIを追加
+                Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'update']);
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {
                     Route::post('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,8 +153,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
-                // 新規に講座分類更新APIを追加
+
+                // マネージャー-講座分類
                 Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'update']);
+
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {
                     Route::post('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'store']);


### PR DESCRIPTION
## issue
JKA-1156：空の配列を返すルーターとコントローラの作成

## 概要
空の配列を返すルーティングの設定とコントローラーを作成。
講座分類機能に関するコントローラーとして、新たに
「app/Http/Controllers/Api/Manager/TagController.php」を作成。


## 動作確認
Postmanにて動作確認を実施。

- instructor_id=1でログイン
- URL：http://localhost:8080/api/v1/manager/tag/1
- HTTPメソッド：PUT
- 結果：200 OK
   期待通り空の配列が返された。

## 備考
- 必要に応じて以下のコマンドを実施。

```shell
php artisan migrate:fresh --seed
``` 
