### PR TITLE
JKA-1172：空の配列を返すルーターとコントローラーの作成（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -8,8 +8,8 @@ use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @tags Instructor-Tag

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -9,12 +9,21 @@ use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 /**
  * @tags Instructor-Tag
  */
 class TagController extends Controller
 {
+    /**
+     * 講座分類詳細API
+     */
+    public function show(Request $request): JsonResponse
+    {
+        return response()->json([]);
+    }
+
     /**
      * 講座分類更新API
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,8 +67,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
             // 講師-講座分類
             Route::prefix('tag/{tag_id}')->group(function () {
-                Route::get('', [App\Http\Controllers\Api\Instructor\TagController::class, 'show']);
-                Route::put('', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
+                Route::get('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'show']);
+                Route::put('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
             });
 
             // 講師-講座

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,7 +66,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::post('update', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'update']);
 
             // 講師-講座分類
-            Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
+            Route::prefix('tag/{tag_id}')->group(function () {
+                Route::get('', [App\Http\Controllers\Api\Instructor\TagController::class, 'show']);
+                Route::put('', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
+            });
 
             // 講師-講座
             Route::prefix('course')->group(function () {


### PR DESCRIPTION
## issue
JKA-1172：空の配列を返すルーターとコントローラーの作成

## 概要
JKA-1157 講師側 講座分類 詳細API新規作成の2つ目のタスクとして、空の配列を返すルーターとコントローラの作成を実装。

## 動作確認
Postmanにて動作確認を実施。

 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1
 - HTTPメソッド：GET
 - 結果：200 OK