### PR TITLE
JKA1175(親1154)：フォームリクエストの作成(西山しょうこ) 

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\Tag\StoreRequest;
 use App\Model\Tag;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -16,7 +16,7 @@ class TagController extends Controller
     /**
      * タグ登録API
      */
-    public function store(Request $request): JsonResponse
+    public function store(StoreRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 

--- a/app/Http/Requests/Instructor/Tag/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Tag/StoreRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => ['required', 'string', 'max:50'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
JKA-1175：フォームリクエストの作成

## 概要
JKA-1175 講師側 講座分類 新規登録API新規作成  　に伴い、フォームリクエストの作成
　・App\Http\Requests\Instructor\Tag\StoreRequest.php の作成
　・TagControllerの一部変更

## 動作確認
Postmanにて以下の動作確認を実施。
**①正常系**
 - instructor_id=2  でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag
 - HTTPメソッド：POST
 - 結果：200 OK  
"result": true

**②異常系**
- instructor_id=2でログイン
- 50文字以上のcontentをBodyに含める
- URL：http://localhost:8080/api/v1/instructor/tag
- HTTPメソッド：POST
- 結果：422  Unprocessable Content
- message": "The content may not be greater than 50 characters.",.