### PR TITLE
JKA-1173：ロジックの作成（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -32,8 +32,8 @@ class TagController extends Controller
         return response()->json([
             'data' => [
                 'tag_id' => $tag->id,
-                'content' => $tag->content
-            ]
+                'content' => $tag->content,
+            ],
         ]);
     }
 

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -21,7 +21,20 @@ class TagController extends Controller
      */
     public function show(Request $request): JsonResponse
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        $tag = Tag::findOrFail($request->tag_id);
+
+        if ($tag->instructor_id !== $instructorId) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
+
+        return response()->json([
+            'data' => [
+                'tag_id' => $tag->id,
+                'content' => $tag->content
+            ]
+        ]);
     }
 
     /**


### PR DESCRIPTION
## issue
JKA-1173：ロジックの作成

## 概要
JKA-1157：講師側 講座分類 詳細API新規作成の3つ目のタスクにて、ロジックの作成を実装。

## 動作確認
Postmanにて動作確認を実施。

1. 正常
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1
 - HTTPメソッド：GET
 - 結果：200 OK
 ```
{
    "data": {
        "tag_id": 1,
        "content": "バックエンド入門"
    }
}
```

2. 異常：指定したtag_idが存在しない場合、エラーとなる
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/10
 - HTTPメソッド：GET
 - 結果：404 Not Found

3. 異常：ログイン中の講師が作成したタグではない場合、エラー応答
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/2
 - HTTPメソッド：GET
 - 結果：403 Forbidden  
"message": "Forbidden, invalid instructor_id.”

## 備考
レスポンス整形のリソースファイルについては、この後フォームリクエストファイル作成後に実装予定のため、今回はコントローラーに直接書いています。