### PR TITLE
JKA-1156 ロジック作成（川原）

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -38,7 +38,7 @@ class TagController extends Controller
         $tag = Tag::findOrFail($validated['tag_id']);
 
         // 配下のインストラクターまたは本人が作成したタグのみ更新可能
-        if (!in_array($tag->instructor_id, $instructorIds, true)) {
+        if (! in_array($tag->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Unauthorized');
         }
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -3,6 +3,12 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Model\Instructor;
+use App\Model\Tag;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @tags Manager-Tag
@@ -12,8 +18,24 @@ class TagController extends Controller
     /**
      * 講座分類更新API
      */
-    public function update()
+    public function put(Request $request): JsonResponse
     {
-        return response()->json([]);
+
+        $user = Instructor::find(Auth::guard('manager')->user()->id);
+        $tag = Tag::findOrFail($request->tag_id);
+
+        // マネージャー本人または配下の講師が作成したタグのみ更新可能
+        $subordinateIds = $user->getSubordinateIds();
+        if ($user->id !== $tag->manager_id && !in_array($tag->manager_id, $subordinateIds)) {
+            throw new AuthorizationException('Invalid manager.');
+        }
+
+        $tag->update([
+            'content' => $request->content,
+        ]);
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -32,7 +32,7 @@ class TagController extends Controller
         $tag = Tag::findOrFail($request->tag_id);
 
         // 配下のインストラクターまたは本人が作成したタグのみ更新可能
-        if (!in_array($tag->instructor_id, $instructorIds, true)) {
+        if (! in_array($tag->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -20,18 +20,31 @@ class TagController extends Controller
      */
     public function put(Request $request): JsonResponse
     {
+        // バリデーション
+        $validated = $request->validate([
+            'tag_id' => 'required|integer|exists:tags,id',
+            'content' => 'required|string',
+        ]);
 
-        $user = Instructor::find(Auth::guard('manager')->user()->id);
-        $tag = Tag::findOrFail($request->tag_id);
+        // マネージャーが管理する講師IDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
 
-        // マネージャー本人または配下の講師が作成したタグのみ更新可能
-        $subordinateIds = $user->getSubordinateIds();
-        if ($user->id !== $tag->manager_id && !in_array($tag->manager_id, $subordinateIds)) {
-            throw new AuthorizationException('Invalid manager.');
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id; // 自身のIDも追加
+
+        // タグの取得
+        $tag = Tag::findOrFail($validated['tag_id']);
+
+        // 配下のインストラクターまたは本人が作成したタグのみ更新可能
+        if (!in_array($tag->instructor_id, $instructorIds, true)) {
+            throw new AuthorizationException('Unauthorized');
         }
 
+        // タグの更新
         $tag->update([
-            'content' => $request->content,
+            'content' => $validated['content'],
         ]);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -20,12 +20,6 @@ class TagController extends Controller
      */
     public function put(Request $request): JsonResponse
     {
-        // バリデーション
-        $validated = $request->validate([
-            'tag_id' => 'required|integer|exists:tags,id',
-            'content' => 'required|string',
-        ]);
-
         // マネージャーが管理する講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -35,16 +29,16 @@ class TagController extends Controller
         $instructorIds[] = $manager->id; // 自身のIDも追加
 
         // タグの取得
-        $tag = Tag::findOrFail($validated['tag_id']);
+        $tag = Tag::findOrFail($request->tag_id);
 
         // 配下のインストラクターまたは本人が作成したタグのみ更新可能
         if (!in_array($tag->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Unauthorized');
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         // タグの更新
         $tag->update([
-            'content' => $validated['content'],
+            'content' => $request->content,
         ]);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Auth;
 class TagController extends Controller
 {
     /**
-     * 講座分類更新API
+     * タグ更新API
      */
     public function put(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -26,7 +26,7 @@ class TagController extends Controller
 
         // マネージャー本人または配下の講師が作成したタグのみ更新可能
         $subordinateIds = $user->getSubordinateIds();
-        if ($user->id !== $tag->manager_id && !in_array($tag->manager_id, $subordinateIds)) {
+        if ($user->id !== $tag->manager_id && ! in_array($tag->manager_id, $subordinateIds)) {
             throw new AuthorizationException('Invalid manager.');
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -155,7 +155,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('manager')->group(function () {
 
                 // マネージャー-講座分類
-                Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'update']);
+                Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'put']);
 
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {

--- a/tests/Feature/Api/Manager/Tag/PutTest.php
+++ b/tests/Feature/Api/Manager/Tag/PutTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Tag;
+
+use App\Model\Course;
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_タグ更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $course = Course::find(1);
+
+        // act
+        $response = $this->putJson('/api/v1/manager/tag/1', [
+            'content' => 'test',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'result' => true,
+        ]);
+        $this->assertDatabaseHas('tags', [
+            'id' => 1,
+            'content' => 'test',
+        ]);
+    }
+
+    public function test_権限エラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/manager/tag/1', [
+            'content' => 'test',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+
+    //     // act
+    //     $response = $this->putJson('/api/v1/manager/tag/1', [
+    //         'content' => '',
+    //     ]);
+
+    //     // assert
+    //     $response->assertStatus(422);
+    //     $response->assertJsonValidationErrors([
+    //         'content' => 'The content field is required.',
+    //     ]);
+    // }
+}


### PR DESCRIPTION
## issue
ロジックの作成

概要
JKA-1156 マネージャー側 講座分類 更新API新規作成の3つ目のタスク。
講座分類更新APIのロジックを作成。

## 動作確認
Postmanにて以下の動作確認を実施。

正常：講座分類を更新
instructor_id=1でログイン
URL：http://localhost:8080/api/v1/instructor/tag/1
HTTPメソッド：PUT
ボディ：
{
    "content": "新しいタグの内容"
}
結果：200 OK
"result": true

異常：存在しない講座分類IDの場合、エラーとなる
instructor_id=1でログイン
URL：http://localhost:8080/api/v1/instructor/tag/10
HTTPメソッド：PUT
ボディ：
{
    "content": "新しいタグの内容"
}
結果：404 Not Found
"message": "No query results for model [App\\Model\\Tag] 10",

異常：ログイン中のマネージャー講師、その配下の講師が作成した講座分類でない場合は、エラー応答
instructor_id=1でログイン
URL：http://localhost:8080/api/v1/instructor/tag/1
HTTPメソッド：PUT
ボディ：
{
"content": "新しいタグの内容"
}
結果：403 Forbidden
"message": "Forbidden, invalid instructor_id.",