### PR TITLE
JKA-1182：空の配列を返すルーターとコントローラーの作成 (Shinya)

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace App\Http\Controllers\Api\Manager;
+
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
+
 /**
  * @tags Manager-Tag
  */

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Http\Controllers\Api\Manager;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+/**
+ * @tags Manager-Tag
+ */
+class TagController extends Controller
+{
+    /**
+     * 講座分類詳細API
+     */
+    public function show(): JsonResponse
+    {
+        return response()->json([]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -247,6 +247,11 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'delete']);
                     });
                 });
+
+                // マネージャー-講座分類
+                Route::prefix('tag/{tag_id}')->group(function () {
+                    Route::get('/', [App\Http\Controllers\Api\Manager\TagController::class, 'show']);
+                });
             });
         });
     });


### PR DESCRIPTION
## Issue
- JKA-1182：空の配列を返すルーターとコントローラーの作成

## 概要
- JKA-1158 Manager側 講座分類 詳細API新規作成の2つ目のタスクとして、空の配列を返すルーターとコントローラの作成を実装。

## 動作確認
Postmanにて動作確認を実施。

instructor_id=1でログイン
URL：http://localhost:8080/api/v1/manager/tag/1
HTTPメソッド：GET
結果：200 OK