### PR TITLE
JKA-1174：フォームリクエストの作成（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -4,15 +4,14 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Tag\PutRequest;
-use App\Http\Requests\Instructor\Tag\StoreRequest;
 use App\Http\Requests\Instructor\Tag\ShowRequest;
+use App\Http\Requests\Instructor\Tag\StoreRequest;
 use App\Http\Resources\Instructor\TagIndexResource;
 use App\Http\Resources\Tag\TagResource;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Tag\PutRequest;
 use App\Http\Requests\Instructor\Tag\StoreRequest;
+use App\Http\Requests\Instructor\Tag\ShowRequest;
 use App\Http\Resources\Instructor\TagIndexResource;
+use App\Http\Resources\Tag\TagResource;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -51,7 +53,7 @@ class TagController extends Controller
     /**
      * タグ詳細API
      */
-    public function show(Request $request): JsonResponse
+    public function show(ShowRequest $request)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -61,12 +63,7 @@ class TagController extends Controller
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
-        return response()->json([
-            'data' => [
-                'tag_id' => $tag->id,
-                'content' => $tag->content,
-            ],
-        ]);
+        return new TagResource($tag);
     }
 
     /**

--- a/app/Http/Requests/Instructor/Tag/ShowRequest.php
+++ b/app/Http/Requests/Instructor/Tag/ShowRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'tag_id' => $this->route('tag_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'tag_id' => ['required', 'integer', 'exists:tags,id'],
+        ];
+    }
+}


### PR DESCRIPTION
## issue
JKA-1174：フォームリクエストの作成

## 概要
JKA-1157：講師側 講座分類 詳細API新規作成の4つ目のタスクとして、フォームリクエストの作成を実装。  
※今回、既存のTagResourceを使用するため、return部分についても本タスク内で実装しました。

## 動作確認
Postmanにて以下の動作確認を実施。

1. 正常
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1
 - HTTPメソッド：GET
 - 結果：200 OK
```
{
    "data": {
        "tag_id": 1,
        "content": "バックエンド入門"
    }
}
```

2. 異常：リクエストしたtag_idがテーブルに存在しない場合
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/10
 - HTTPメソッド：GET
 - 結果：422 Unprocessable Content  
"message": "The selected tag id is invalid.”

3. 異常：リクエストしたtag_idが整数値でない場合
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/tag/1.5
 - HTTPメソッド：GET
 - 結果：422 Unprocessable Content  
"message": "The tag id must be an integer.”