### PR TITLE
講師側の講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -39,11 +39,6 @@ class CourseController extends Controller
         $perPage = $request->query('per_page', '6');
         $tagId = $request->query('tag_id');
 
-        $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
-            ->when($tagId, function ($query, $tagId) {
-                $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
-            });
-
         if ($tagId) {
             $tag = Tag::findOrFail($tagId);
 
@@ -51,9 +46,12 @@ class CourseController extends Controller
             if ($instructorId !== $tag->instructor_id) {
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
-
-            $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
         }
+
+        $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
+        ->when($tagId, function ($query, $tagId) {
+            $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
+        });
 
         // ページネーションで講座を取得
         $courses = $query->paginate((int) $perPage);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -49,9 +49,9 @@ class CourseController extends Controller
         }
 
         $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
-        ->when($tagId, function ($query, $tagId) {
-            $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
-        });
+            ->when($tagId, function ($query, $tagId) {
+                $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
+            });
 
         // ページネーションで講座を取得
         $courses = $query->paginate((int) $perPage);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -52,11 +52,11 @@ class CourseController extends Controller
 
             $query->whereHas('tags', function ($query) use ($tagId) {
             $query->where('tags.id', $tagId);
-        });
-    }
+            });
+        }
 
-    // ページネーションで講座を取得
-    $courses = $query->paginate((int) $perPage);
+        // ページネーションで講座を取得
+        $courses = $query->paginate((int) $perPage);
 
         $courses->getCollection()->map(function (Course $course) {
             $course->has_active_students = $course->attendances_count > 0;

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -51,9 +51,9 @@ class CourseController extends Controller
             if ($instructorId !== $tag->instructor_id) {
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
-            
-            $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
-        };
+
+            $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
+        }
 
         // ページネーションで講座を取得
         $courses = $query->paginate((int) $perPage);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -18,6 +18,7 @@ use App\Model\Tag;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -49,7 +50,7 @@ class CourseController extends Controller
         }
 
         $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
-            ->when($tagId, function ($query, $tagId) {
+            ->when($tagId, function (Builder $query, string $tagId) {
                 $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
             });
 

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -43,6 +43,7 @@ class CourseController extends Controller
         ->when($tagId, function ($query, $tagId) use ($instructorId) {
             $tag = Tag::findOrFail($tagId);
 
+            // ログインしている講師とtag_idの講師が一致しない
             if ($instructorId !== $tag->instructor_id) {
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -43,13 +43,13 @@ class CourseController extends Controller
             ->when($tagId, function ($query, $tagId) use ($instructorId) {
                 $tag = Tag::findOrFail($tagId);
 
-            // ログインしている講師とtag_idの講師が一致しない
-            if ($instructorId !== $tag->instructor_id) {
-                throw new AuthorizationException('Forbidden, invalid instructor_id.');
-            }
-            
-            $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
-        });
+                // ログインしている講師とtag_idの講師が一致しない
+                if ($instructorId !== $tag->instructor_id) {
+                    throw new AuthorizationException('Forbidden, invalid instructor_id.');
+                }
+
+                $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
+            });
 
         // ページネーションで講座を取得
         $courses = $query->paginate((int) $perPage);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -40,15 +40,15 @@ class CourseController extends Controller
         $tagId = $request->query('tag_id');
 
         $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
-        ->when($tagId, function ($query, $tagId) use ($instructorId) {
-            $tag = Tag::findOrFail($tagId);
+            ->when($tagId, function ($query, $tagId) use ($instructorId) {
+                $tag = Tag::findOrFail($tagId);
 
-            if ($instructorId !== $tag->instructor_id) {
-                throw new AuthorizationException('Forbidden, invalid instructor_id.');
-            }
-            
-            $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
-        });
+                if ($instructorId !== $tag->instructor_id) {
+                    throw new AuthorizationException('Forbidden, invalid instructor_id.');
+                }
+
+                $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
+            });
 
         // ページネーションで講座を取得
         $courses = $query->paginate((int) $perPage);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -39,21 +39,16 @@ class CourseController extends Controller
         $perPage = $request->query('per_page', '6');
         $tagId = $request->query('tag_id');
 
-        $query = Course::where('instructor_id', $instructorId)
-            ->withCount('attendances');
+        $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
+        ->when($tagId, function ($query, $tagId) use ($instructorId) {
+            $tag = Tag::findOrFail($tagId);
 
-        if ($tagId) {
-            $tag = Tag::FindOrFail($tagId);
-
-            // ログインしている講師と指定したtag_idの講師が一致しない
             if ($instructorId !== $tag->instructor_id) {
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
-
-            $query->whereHas('tags', function ($query) use ($tagId) {
-                $query->where('tags.id', $tagId);
-            });
-        }
+            
+            $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
+        });
 
         // ページネーションで講座を取得
         $courses = $query->paginate((int) $perPage);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -40,23 +40,23 @@ class CourseController extends Controller
         $tagId = $request->query('tag_id');
 
         $query = Course::where('instructor_id', $instructorId)
-        ->withCount('attendances');
+            ->withCount('attendances');
 
         if ($tagId) {
             $tag = Tag::FindOrFail($tagId);
 
             // ログインしている講師と指定したtag_idの講師が一致しない
-            if($instructorId !== $tag->instructor_id){
+            if ($instructorId !== $tag->instructor_id) {
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
 
             $query->whereHas('tags', function ($query) use ($tagId) {
-            $query->where('tags.id', $tagId);
-        });
-    }
+                $query->where('tags.id', $tagId);
+            });
+        }
 
-    // ページネーションで講座を取得
-    $courses = $query->paginate((int) $perPage);
+        // ページネーションで講座を取得
+        $courses = $query->paginate((int) $perPage);
 
         $courses->getCollection()->map(function (Course $course) {
             $course->has_active_students = $course->attendances_count > 0;

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -14,6 +14,7 @@ use App\Http\Resources\Instructor\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Tag;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -36,11 +37,26 @@ class CourseController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
         // 講座情報を取得
         $perPage = $request->query('per_page', '6');
+        $tagId = $request->query('tag_id');
 
-        // ページネーションで講座を取得
-        $courses = Course::where('instructor_id', $instructorId)
-            ->withCount('attendances')
-            ->paginate((int) $perPage);
+        $query = Course::where('instructor_id', $instructorId)
+        ->withCount('attendances');
+
+        if ($tagId) {
+            $tag = Tag::FindOrFail($tagId);
+
+            // ログインしている講師と指定したtag_idの講師が一致しない
+            if($instructorId !== $tag->instructor_id){
+                throw new AuthorizationException('Forbidden, invalid instructor_id.');
+            }
+
+            $query->whereHas('tags', function ($query) use ($tagId) {
+            $query->where('tags.id', $tagId);
+        });
+    }
+
+    // ページネーションで講座を取得
+    $courses = $query->paginate((int) $perPage);
 
         $courses->getCollection()->map(function (Course $course) {
             $course->has_active_students = $course->attendances_count > 0;

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -40,8 +40,12 @@ class CourseController extends Controller
         $tagId = $request->query('tag_id');
 
         $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
-            ->when($tagId, function ($query, $tagId) use ($instructorId) {
-                $tag = Tag::findOrFail($tagId);
+            ->when($tagId, function ($query, $tagId) {
+                $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
+            });
+
+        if ($tagId) {
+            $tag = Tag::findOrFail($tagId);
 
             // ログインしている講師とtag_idの講師が一致しない
             if ($instructorId !== $tag->instructor_id) {
@@ -49,7 +53,7 @@ class CourseController extends Controller
             }
             
             $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
-        });
+        };
 
         // ページネーションで講座を取得
         $courses = $query->paginate((int) $perPage);

--- a/app/Http/Requests/Instructor/Course/IndexRequest.php
+++ b/app/Http/Requests/Instructor/Course/IndexRequest.php
@@ -24,7 +24,7 @@ class IndexRequest extends FormRequest
         return [
             'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
             'page' => ['integer', 'min:1'],
-            'tag_id' => ['sometimes', 'integer', 'min:1'],
+            'tag_id' => ['sometimes', 'integer', 'exists:tags,id'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/Course/IndexRequest.php
+++ b/app/Http/Requests/Instructor/Course/IndexRequest.php
@@ -24,6 +24,7 @@ class IndexRequest extends FormRequest
         return [
             'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
             'page' => ['integer', 'min:1'],
+            'tag_id' => ['sometimes', 'integer', 'min:1'],
         ];
     }
 }

--- a/tests/Feature/Api/Instructor/Course/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Course/IndexTest.php
@@ -29,6 +29,7 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
     }
 
     public function test_パラメータ指定_成功(): void
@@ -39,9 +40,10 @@ class IndexTest extends TestCase
         Course::find(5)->delete();
 
         // act
-        $response = $this->getJson('/api/v1/instructor/course/index?per_page=5');
+        $response = $this->getJson('/api/v1/instructor/course/index?per_page=5&tag_id=1');
 
         // assert
         $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
     }
 }


### PR DESCRIPTION
## issue
- Closes
#JKA-1167 講師側の講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修する。

## 概要
- クエリパラメータでタグIDを検索できるるように追加。ログインしている講師と指定したtag_idの講師が一致しない場合エラーになるように記載。

## 動作確認手順
### Instructor/CourseController
- indexメソッド
テストケース1（正常系：http://localhost:8080/api/v1/instructor/course/index?page=1&tag_id=1）
URL：
ログイン：
instructor_id = 1
クエリパラメータ：
page = 1
tag_id = 1
結果：
```
{
    "data": [
        {
            "course_id": 1,
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "title": "PHP入門講座",
            "status": "public",
            "has_active_students": true
        },
        {
            "course_id": 5,
            "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
            "title": "Python入門講座",
            "status": "public",
            "has_active_students": true
        }
    ]
}
```
course_tagテーブル
![image](https://github.com/user-attachments/assets/cb1308fd-c81e-435e-a688-69285279a509)

pageのクエリパラメータが正常に動作してるか確認
テストケース2（正常系：http://localhost:8080/api/v1/instructor/course/index?page=2）
URL：
ログイン：
instructor_id = 1
クエリパラメータ：
page = 2
結果：
```
{
    "data": [
        {
            "course_id": 12,
            "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
            "title": "Python入門講座",
            "status": "public",
            "has_active_students": false
        }
    ]
}
```
courseテーブル
![image](https://github.com/user-attachments/assets/24b7a6ce-588e-48a9-a718-0d14ab6233fe)

テストケース3（異常系：http://localhost:8080/api/v1/instructor/course/index?page=1&tag_id=2）
URL：
ログイン：
instructor_id = 1
クエリパラメータ：
page = 1
tag_id = 2
結果：
```
"message": "Forbidden, invalid instructor_id."
```
tagテーブル
![image](https://github.com/user-attachments/assets/eb7ff639-676d-46a1-bf00-a0d6b81faa21)
