### PR TITLE
JKA-1156 フォームリクエストの作成（川原）

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\Tag\PutRequest;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -16,9 +16,9 @@ use Illuminate\Support\Facades\Auth;
 class TagController extends Controller
 {
     /**
-     * タグ更新API
+     * 講座分類更新API
      */
-    public function put(Request $request): JsonResponse
+    public function put(PutRequest $request): JsonResponse
     {
         // マネージャーが管理する講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -32,7 +32,7 @@ class TagController extends Controller
         $tag = Tag::findOrFail($request->tag_id);
 
         // 配下のインストラクターまたは本人が作成したタグのみ更新可能
-        if (! in_array($tag->instructor_id, $instructorIds, true)) {
+        if (!in_array($tag->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -32,7 +32,7 @@ class TagController extends Controller
         $tag = Tag::findOrFail($request->tag_id);
 
         // 配下のインストラクターまたは本人が作成したタグのみ更新可能
-        if (!in_array($tag->instructor_id, $instructorIds, true)) {
+        if (! in_array($tag->instructor_id, $instructorIds, true)) {
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Auth;
 class TagController extends Controller
 {
     /**
-     * 講座分類更新API
+     * タグ更新API
      */
     public function put(PutRequest $request): JsonResponse
     {

--- a/app/Http/Requests/Manager/Tag/PutRequest.php
+++ b/app/Http/Requests/Manager/Tag/PutRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Manager\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PutRequest extends FormRequest
+{
+  /**
+   * Determine if the user is authorized to make this request.
+   */
+  public function authorize(): bool
+  {
+    return true;
+  }
+
+  protected function prepareForValidation()
+  {
+    $this->merge([
+      'tag_id' => $this->route('tag_id'),
+    ]);
+  }
+
+  /**
+   * Get the validation rules that apply to the request.
+   *
+   * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+   */
+  public function rules(): array
+  {
+    return [
+      'tag_id' => ['required', 'integer', 'exists:tags,id'],
+      'content' => ['required', 'string'],
+    ];
+  }
+}

--- a/app/Http/Requests/Manager/Tag/PutRequest.php
+++ b/app/Http/Requests/Manager/Tag/PutRequest.php
@@ -6,31 +6,31 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class PutRequest extends FormRequest
 {
-  /**
-   * Determine if the user is authorized to make this request.
-   */
-  public function authorize(): bool
-  {
-    return true;
-  }
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
 
-  protected function prepareForValidation()
-  {
-    $this->merge([
-      'tag_id' => $this->route('tag_id'),
-    ]);
-  }
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'tag_id' => $this->route('tag_id'),
+        ]);
+    }
 
-  /**
-   * Get the validation rules that apply to the request.
-   *
-   * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
-   */
-  public function rules(): array
-  {
-    return [
-      'tag_id' => ['required', 'integer', 'exists:tags,id'],
-      'content' => ['required', 'string'],
-    ];
-  }
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'tag_id' => ['required', 'integer', 'exists:tags,id'],
+            'content' => ['required', 'string'],
+        ];
+    }
 }

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -116,7 +116,7 @@ class Course extends Model
     }
 
     /**
-     * 講座分類（タグ）を取得
+     * タグを取得
      *
      * @return BelongsToMany<Tag, $this>
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -154,7 +154,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
 
-                // マネージャー-講座分類
+                // マネージャー-タグ
                 Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'put']);
 
                 // マネージャー-講師

--- a/tests/Feature/Api/Manager/Tag/PutTest.php
+++ b/tests/Feature/Api/Manager/Tag/PutTest.php
@@ -56,21 +56,22 @@ class PutTest extends TestCase
         $response->assertStatus(403);
     }
 
-    // public function test_バリデーションエラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(1);
-    //     $this->actingAs($instructor, 'instructor');
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
 
-    //     // act
-    //     $response = $this->putJson('/api/v1/manager/tag/1', [
-    //         'content' => '',
-    //     ]);
+        // act
+        $response = $this->putJson('/api/v1/manager/tag/aaa', [
+            'content' => '',
+        ]);
 
-    //     // assert
-    //     $response->assertStatus(422);
-    //     $response->assertJsonValidationErrors([
-    //         'content' => 'The content field is required.',
-    //     ]);
-    // }
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'tag_id',
+            'content',
+        ]);
+    }
 }


### PR DESCRIPTION
## issue
JKA-1156：フォームリクエストの作成

## 概要
JKA-1156：マネージャー側 講座分類 更新API新規作成の4つ目のタスク。
講座分類更新APIのフォームリクエストを作成。

## 動作確認
Postmanにて動作確認を実施。

1. tag_idが整数値でない場合

- instructor_id=1でログイン
- URL：http://localhost:8080/api/v1/instructor/tag/1.5
- 結果：422 Unprocessable Content
   "message": "The tag id must be an integer.”

2. contentがnullの場合

- instructor_id=1でログイン
- URL：http://localhost:8080/api/v1/instructor/tag/1
- 結果：422 Unprocessable Content
   "message": "The content field is required.”
