### PR TITLE
JKA-1179 マネージャー側 受講状況取得APIに講座分類名を追加（川原）

### DIFF
--- a/app/Http/Resources/Manager/AttendanceShowResource.php
+++ b/app/Http/Resources/Manager/AttendanceShowResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources\Manager;
 
 use App\Model\Chapter;
 use Illuminate\Database\Eloquent\Collection;
+use App\Http\Resources\Tag\TagResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttendanceShowResource extends JsonResource
@@ -25,7 +26,7 @@ class AttendanceShowResource extends JsonResource
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
                     'completed_count' => $chapter->completed_count,
-                    'tags' => $chapter->course->tags,
+                    'tags' => TagResource::collection($chapter->course->tags),
                 ];
             }),
             'students_count' => $this->resource['studentsCount'],

--- a/app/Http/Resources/Manager/AttendanceShowResource.php
+++ b/app/Http/Resources/Manager/AttendanceShowResource.php
@@ -25,13 +25,7 @@ class AttendanceShowResource extends JsonResource
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
                     'completed_count' => $chapter->completed_count,
-                    'tags' => $chapter->course->tags->map(function ($tag) {
-                        return [
-                            'id' => $tag->id,
-                            'instructor_id' => $tag->instructor_id,
-                            'content' => $tag->content,
-                        ];
-                    }) ?? [],
+                    'tags' => $chapter->course->tags,
                 ];
             }),
             'students_count' => $this->resource['studentsCount'],

--- a/app/Http/Resources/Manager/AttendanceShowResource.php
+++ b/app/Http/Resources/Manager/AttendanceShowResource.php
@@ -25,6 +25,13 @@ class AttendanceShowResource extends JsonResource
                     'chapter_id' => $chapter->id,
                     'title' => $chapter->title,
                     'completed_count' => $chapter->completed_count,
+                    'tags' => $chapter->course->tags->map(function ($tag) {
+                        return [
+                            'id' => $tag->id,
+                            'instructor_id' => $tag->instructor_id,
+                            'content' => $tag->content,
+                        ];
+                    }) ?? [],
                 ];
             }),
             'students_count' => $this->resource['studentsCount'],

--- a/app/Http/Resources/Manager/AttendanceShowResource.php
+++ b/app/Http/Resources/Manager/AttendanceShowResource.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Resources\Manager;
 
+use App\Http\Resources\Tag\TagResource;
 use App\Model\Chapter;
 use Illuminate\Database\Eloquent\Collection;
-use App\Http\Resources\Tag\TagResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttendanceShowResource extends JsonResource

--- a/tests/Feature/Api/Manager/Attendance/ShowTest.php
+++ b/tests/Feature/Api/Manager/Attendance/ShowTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Attendance;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_受講状況を取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/1/attendance/status');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_配下ではない講師の講座_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/4/attendance/status');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/aaa/attendance/status');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+        ]);
+    }
+
+    public function test_マネージャーではない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/4/attendance/status');
+
+        // assert
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1179 マネージャー側 受講状況取得APIに講座分類名を追加

## 概要
下記画面の下記APIで、講座分類名（バックエンドマスター講座の部分）を取得できるようにAPIを改修する。

<img width="528" alt="スクリーンショット 2025-02-27 17 01 11" src="https://github.com/user-attachments/assets/04bfca1c-ebdd-4bb7-be74-0e3069e81c44" />

マネージャー側 受講状況取得API
URL: **api/v1/manager/course/{course_id}/attendance/status**

## 動作確認手順
Postmanにて動作確認を実施。

instructor_id=1でログイン
URL：api/v1/manager/course/1/attendance/status
結果：200 OK
```
{
    "data": {
        "chapters": [
            {
                "chapter_id": 1,
                "title": "PHPとは？",
                "completed_count": 1,
                "tags": [
                    {
                        "id": 1,
                        "instructor_id": 1,
                        "content": "バックエンド入門編"
                    }
                ]
            },
            {
                "chapter_id": 2,
                "title": "PHPの基礎を学ぼう",
                "completed_count": 2,
                "tags": [
                    {
                        "id": 1,
                        "instructor_id": 1,
                        "content": "バックエンド入門編"
                    }
                ]
            },
            {
                "chapter_id": 3,
                "title": "PHPの応用にチャレンジしよう",
                "completed_count": 0,
                "tags": [
                    {
                        "id": 1,
                        "instructor_id": 1,
                        "content": "バックエンド入門編"
                    }
                ]
            }
        ],
        "students_count": 2
    }
}
```