### PR TITLE
JKA-1183 ロジックの作成 (Shinya)

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
-use App\Model\Tag;
-use App\Model\Instructor;
-use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
+use App\Model\Instructor;
+use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @tags Manager-Tag

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Model\Tag;
+use App\Model\Instructor;
+use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Request;
-use Illuminate\Container\Attributes\Auth;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 
 /**
@@ -21,9 +22,16 @@ class TagController extends Controller
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 
+        // 配下の講師情報を取得
+        $manager = Instructor::with('managings')->find($instructorId);
+
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructorId;
+
         $tag = Tag::findOrFail($request->tag_id);
 
-        if ($tag->instructor_id !== $instructorId) {
+        if (! in_array($tag->instructor_id, $instructorIds, true)) {
+            // 自身もしくは配下の講師が作成した講座分類でない場合、権限エラーを返す
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -2,8 +2,12 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
-use App\Http\Controllers\Controller;
+use App\Model\Tag;
 use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Container\Attributes\Auth;
+use Illuminate\Auth\Access\AuthorizationException;
 
 /**
  * @tags Manager-Tag
@@ -13,8 +17,21 @@ class TagController extends Controller
     /**
      * 講座分類詳細API
      */
-    public function show(): JsonResponse
+    public function show(Request $request): JsonResponse
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        $tag = Tag::findOrFail($request->tag_id);
+
+        if ($tag->instructor_id !== $instructorId) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
+
+        return response()->json([
+            'data' => [
+                'tag_id' => $tag->id,
+                'content' => $tag->content,
+            ],
+        ]);
     }
 }

--- a/tests/Feature/Api/Manager/Tag/ShowTest.php
+++ b/tests/Feature/Api/Manager/Tag/ShowTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Tag;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_タグ詳細取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/tag/1');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_権限のないマネージャー_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/tag/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Issue
- JKA-1183 ロジックの作成

## 概要
- JKA-1158：マネージャー側 講座分類 詳細API新規作成の3つ目のタスクにて、ロジックの作成を実装。

## 動作確認
postmanにて動作確認

- 正常
instructor_id=1でログイン
URL：http://localhost:8080/api/v1/manager/tag/1
HTTPメソッド：GET
結果：200 OK
```
{
   "data": {
       "tag_id": 1,
       "content": "バックエンド入門"
   }
}
```

- 異常：指定したtag_idが存在しない場合、エラーとなる
instructor_id=1でログイン
URL：http://localhost:8080/api/v1/manager/tag/6
HTTPメソッド：GET
結果：404 Not Found

- 異常：ログイン中の講師または配下の講師が作成したタグではない場合、エラー応答
instructor_id=1でログイン
URL：http://localhost:8080/api/v1/manager/tag/4
HTTPメソッド：GET
結果：403 Forbidden
"message": "Forbidden, invalid instructor_id.”