### PR TITLE
JKA-1185：講師側 お知らせ一覧APIで講座分類名を一覧の中に追加し、かつ講座分類名でソートを掛けられるようにする（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -33,12 +33,25 @@ class NotificationController extends Controller
      */
     public function index(IndexRequest $request): NotificationIndexResource
     {
+        $instructorId = Auth::guard('instructor')->user()->id;
         $perPage = $request->input('per_page', 20);
         $page = $request->input('page', 1);
+        $sortBy = $request->input('sort_by', 'id');
+        $order = $request->input('order', 'desc');
 
-        $notifications = Notification::with(['course'])
-            ->where('instructor_id', Auth::guard('instructor')->user()->id)
-            ->paginate($perPage, ['*'], 'page', $page);
+        $query = Notification::with(['course.tags'])
+            ->where('instructor_id', $instructorId);
+
+        if ($sortBy === 'tag_name') {
+            $query->leftJoin('course_tag', 'notifications.course_id', '=', 'course_tag.course_id')
+                ->leftJoin('tags', 'course_tag.tag_id', '=', 'tags.id')
+                ->select('notifications.*')
+                ->orderBy('tags.content', $order);
+        } else {
+            $query->orderBy($sortBy, $order);
+        }
+
+        $notifications = $query->paginate($perPage, ['*'], 'page', $page);
 
         return new NotificationIndexResource($notifications);
     }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -36,22 +36,10 @@ class NotificationController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
         $perPage = $request->input('per_page', 20);
         $page = $request->input('page', 1);
-        $sortBy = $request->input('sort_by', 'id');
-        $order = $request->input('order', 'desc');
 
-        $query = Notification::with(['course.tags'])
-            ->where('instructor_id', $instructorId);
-
-        if ($sortBy === 'tag_name') {
-            $query->leftJoin('course_tag', 'notifications.course_id', '=', 'course_tag.course_id')
-                ->leftJoin('tags', 'course_tag.tag_id', '=', 'tags.id')
-                ->select('notifications.*')
-                ->orderBy('tags.content', $order);
-        } else {
-            $query->orderBy($sortBy, $order);
-        }
-
-        $notifications = $query->paginate($perPage, ['*'], 'page', $page);
+        $notifications = Notification::with(['course.tags'])
+            ->where('instructor_id', $instructorId)
+            ->paginate($perPage, ['*'], 'page', $page);
 
         return new NotificationIndexResource($notifications);
     }

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -5,7 +5,6 @@ namespace App\Http\Resources\Instructor;
 use App\Http\Resources\Notification\NotificationResource;
 use App\Http\Resources\Tag\TagResource;
 use App\Model\Notification;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
 

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Resources\Instructor;
 
-use App\Http\Resources\Tag\TagResource;
 use App\Http\Resources\Notification\NotificationResource;
+use App\Http\Resources\Tag\TagResource;
 use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -25,26 +25,16 @@ class NotificationIndexResource extends JsonResource
         $notifications = $this->resource;
 
         return [
-            'notifications' => $this->mapNotifications($notifications->getCollection()),
+            'notifications' => $notifications->map(function (Notification $notification) use ($request) {
+                return [
+                    ...(new NotificationResource($notification))->toArray($request),
+                    'tags' => TagResource::collection($notification->course->tags),
+                ];
+            }),
             'pagination' => [
                 'page' => $notifications->currentPage(),
                 'total' => $notifications->total(),
             ],
         ];
-    }
-
-    /**
-     * @param  Collection<int, Notification>  $notifications
-     * @return array
-     */
-    private function mapNotifications($notifications)
-    {
-        return $notifications->map(function (Notification $notification) {
-            return [
-                'notification' => new NotificationResource($notification),
-                'tags' => TagResource::collection($notification->course->tags),
-            ];
-        })
-            ->toArray();
     }
 }

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Resources\Instructor;
 
-use App\Model\Notification;
 use App\Http\Resources\Tag\TagResource;
+use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources\Instructor;
 
 use App\Model\Notification;
+use App\Http\Resources\Tag\TagResource;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -42,6 +43,7 @@ class NotificationIndexResource extends JsonResource
                 'notification_id' => $notification->id,
                 'course_id' => $notification->course_id,
                 'course_title' => $notification->course->title,
+                'tags' => TagResource::collection($notification->course->tags),
                 'title' => $notification->title,
                 'content' => $notification->content,
                 'type' => $notification->type,

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources\Instructor;
 
 use App\Http\Resources\Tag\TagResource;
+use App\Http\Resources\Notification\NotificationResource;
 use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -40,15 +41,8 @@ class NotificationIndexResource extends JsonResource
     {
         return $notifications->map(function (Notification $notification) {
             return [
-                'notification_id' => $notification->id,
-                'course_id' => $notification->course_id,
-                'course_title' => $notification->course->title,
+                'notification' => new NotificationResource($notification),
                 'tags' => TagResource::collection($notification->course->tags),
-                'title' => $notification->title,
-                'content' => $notification->content,
-                'type' => $notification->type,
-                'start_date' => $notification->start_date,
-                'end_date' => $notification->end_date,
             ];
         })
             ->toArray();

--- a/tests/Feature/Api/Instructor/Notification/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Notification/IndexTest.php
@@ -25,8 +25,6 @@ class IndexTest extends TestCase
         // act
         $response = $this->getJson('/api/v1/instructor/notification/index');
 
-        $response->dump();
-
         // assert
         $response->assertStatus(200);
     }

--- a/tests/Feature/Api/Instructor/Notification/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Notification/IndexTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/notification/index');
+
+        $response->dump();
+
+        // assert
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Api/Manager/Notification/IndexTest.php
+++ b/tests/Feature/Api/Manager/Notification/IndexTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api\Manager\Notification;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -16,7 +16,7 @@ class IndexTest extends TestCase
         $this->seed();
     }
 
-    public function test_お知らせ登録_成功(): void
+    public function test_お知らせ一覧取得_成功(): void
     {
         // arrange
         $instructor = Instructor::find(1);
@@ -29,7 +29,7 @@ class IndexTest extends TestCase
         $response->assertStatus(200);
     }
 
-    public function test_お知らせ登録_権限エラー(): void
+    public function test_権限エラー_失敗(): void
     {
         // arrange
         $unauthorizedInstructor = Instructor::find(2);


### PR DESCRIPTION
## issue
JKA-1185：講師側 お知らせ一覧APIで講座分類名を一覧の中に追加し、かつ講座分類名でソートを掛けられるようにする

## 動作確認
1. ソートを掛けていない状態での一覧取得
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/notification/index
 - HTTPメソッド：GET
 - 結果：200 OK
```
{
    "data": {
        "notifications": [
            {
                "notification_id": 5,
                "course_id": 5,
                "course_title": "Python入門講座",
                "tags": [
                    {
                        "tag_id": 1,
                        "content": "バックエンド入門編"
                    }
                ],
                "title": "テストお知らせ",
                "content": "これはテストのお知らせです。",
                "type": "always",
                "start_date": "2024-08-01 00:00:00",
                "end_date": "2025-05-04 14:59:42"
            },
            {
                "notification_id": 1,
                "course_id": 1,
                "course_title": "PHP入門講座",
                "tags": [
                    {
                        "tag_id": 6,
                        "content": "PHP講座"
                    }
                ],
                "title": "レッスン「変数とは？」閲覧について",
                "content": "10月1日〜10日の間、レッスン「変数とは？」がメンテナンスにつき閲覧できなくなります。",
                "type": "always",
                "start_date": "2023-08-01 00:00:00",
                "end_date": "2025-04-04 14:59:42"
            }
        ],
        "pagination": {
            "page": 1,
            "total": 2
        }
    }
}
```

2. タグ名でソートを掛けた場合
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/notification/index?sort_id=tag_name&order=asc
 - HTTPメソッド：GET
 - 結果：200 OK
```
{
    "data": {
        "notifications": [
            {
                "notification_id": 1,
                "course_id": 1,
                "course_title": "PHP入門講座",
                "tags": [
                    {
                        "tag_id": 6,
                        "content": "PHP講座"
                    }
                ],
                "title": "レッスン「変数とは？」閲覧について",
                "content": "10月1日〜10日の間、レッスン「変数とは？」がメンテナンスにつき閲覧できなくなります。",
                "type": "always",
                "start_date": "2023-08-01 00:00:00",
                "end_date": "2025-04-04 14:59:42"
            },
            {
                "notification_id": 5,
                "course_id": 5,
                "course_title": "Python入門講座",
                "tags": [
                    {
                        "tag_id": 1,
                        "content": "バックエンド入門編"
                    }
                ],
                "title": "テストお知らせ",
                "content": "これはテストのお知らせです。",
                "type": "always",
                "start_date": "2024-08-01 00:00:00",
                "end_date": "2025-05-04 14:59:42"
            }
        ],
        "pagination": {
            "page": 1,
            "total": 2
        }
    }
}
```

## 確認したいこと
 - 1つの講座に対してタグが複数ある場合、レスポンスには
 ```
"tags": [
                    {
                        "tag_id": 1,
                        "content": "バックエンド入門編"
                    },
                    {
                        "tag_id": 2,
                        "content": "PHP講座"
                    }                
],
```
のように、複数の形で表示されるのですが、UIを見ると1つのお知らせに対して1つのタグ名となるようにも思えました。この場合、バックエンド側で1つのお知らせに対してタグ名が1つ表示されるようにする必要がありますか？もしくはフロント側で制御できるのでしょうか…？  
どのようにしたら良いのかわからず、一旦ここまででプルリクを作成しました。ご確認をよろしくお願いいたします。