### PR TITLE
講師側 受講生詳細画面の学習状況(受講状況API)に講座分類名を追加（川原）

### DIFF
--- a/app/Http/Resources/Instructor/AttendanceStatusResource.php
+++ b/app/Http/Resources/Instructor/AttendanceStatusResource.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Resources\Instructor;
 
+use App\Http\Resources\Tag\TagResource;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use Illuminate\Database\Eloquent\Collection;
-use App\Http\Resources\Tag\TagResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttendanceStatusResource extends JsonResource

--- a/app/Http/Resources/Instructor/AttendanceStatusResource.php
+++ b/app/Http/Resources/Instructor/AttendanceStatusResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources\Instructor;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use Illuminate\Database\Eloquent\Collection;
+use App\Http\Resources\Tag\TagResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttendanceStatusResource extends JsonResource
@@ -28,6 +29,7 @@ class AttendanceStatusResource extends JsonResource
                 'image' => $this->resource->course->image,
                 'chapters' => $this->mapChapters($this->resource->course->chapters),
                 'title' => $this->resource->course->title,
+                'tags' => TagResource::collection($this->resource->course->tags),
             ],
         ];
     }


### PR DESCRIPTION
## issue
JKA-1186 講師側 受講生詳細画面の学習状況(受講状況API)に講座分類名を追加

## 概要
下記の講師側 受講生詳細画面の学習状況(受講状況API)に講座分類名を追加する。

<img width="734" alt="スクリーンショット 2025-03-02 13 03 08" src="https://github.com/user-attachments/assets/d07e5eb4-f2ef-4b59-830b-a18a96d9be3e" />

対象URL:
```
api/v1/instructor/attendance/{attendance_id}/status
```

## 動作確認手順
Postmanにて動作確認を実施。

instructor_id=1でログイン
URL：http://localhost:8080/api/v1/instructor/attendance/1/status
結果：200 OK
```
{
    "data": {
        "attendance_id": 1,
        "course": {
            "course_id": 1,
            "status": "public",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "chapters": [
                {
                    "chapter_id": 1,
                    "title": "PHPとは？",
                    "status": "public",
                    "progress": 0
                },
                {
                    "chapter_id": 2,
                    "title": "PHPの基礎を学ぼう",
                    "status": "public",
                    "progress": 25
                },
                {
                    "chapter_id": 3,
                    "title": "PHPの応用にチャレンジしよう",
                    "status": "public",
                    "progress": 0
                }
            ],
            "title": "PHP入門講座",
            "tags": [
                {
                    "tag_id": 1,
                    "content": "バックエンド入門編"
                }
            ]
        }
    }
}
```