### PR TITLE
JKA-1184 講師側 講座登録APIを改修して、登録時に講座分類名を指定して登録できるようにする（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -92,12 +92,7 @@ class CourseController extends Controller
             // ログイン中の講師が作成したタグかどうか確認
             $tag = Tag::where('id', $request->tag_id)
                 ->where('instructor_id', $instructorId)
-                ->first();
-
-            if (! $tag) {
-                DB::rollback();
-                throw new AuthorizationException('Forbidden, invalid tag.');
-            }
+                ->firstOrFail();
 
             // タグを中間テーブルに紐づける
             $course->tags()->attach($tag->id);
@@ -108,6 +103,7 @@ class CourseController extends Controller
                 'result' => true,
             ]);
         } catch (Exception $e) {
+            DB::rollback();
             Log::error($e);
             throw $e;
         }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -94,10 +94,10 @@ class CourseController extends Controller
 
             // ログイン中の講師が作成したタグかどうか確認
             $tag = Tag::where('id', $request->tag_id)
-                    ->where('instructor_id', $instructorId)
-                    ->first();
-        
-            if (!$tag) {
+                ->where('instructor_id', $instructorId)
+                ->first();
+
+            if (! $tag) {
                 DB::rollback();
                 throw new AuthorizationException('Forbidden, invalid tag.');
             }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -15,7 +15,6 @@ use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Tag;
-use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -88,8 +87,6 @@ class CourseController extends Controller
                 'title' => $request->title,
                 'image' => $filePath,
                 'status' => Course::STATUS_PRIVATE,
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ]);
 
             // ログイン中の講師が作成したタグかどうか確認

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -14,11 +14,13 @@ use App\Http\Resources\Instructor\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Tag;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -71,24 +73,47 @@ class CourseController extends Controller
     public function store(StoreRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $file = $request->file('image');
-        $extension = $file->getClientOriginalExtension();
-        $filename = Str::uuid()->toString().'.'.$extension;
-        $filePath = Storage::putFileAs('public/course', $file, $filename);
-        $filePath = Course::convertImagePath($filePath);
 
-        Course::create([
-            'instructor_id' => $instructorId,
-            'title' => $request->title,
-            'image' => $filePath,
-            'status' => Course::STATUS_PRIVATE,
-            'created_at' => Carbon::now(),
-            'updated_at' => Carbon::now(),
-        ]);
+        DB::beginTransaction();
 
-        return response()->json([
-            'result' => true,
-        ]);
+        try {
+            $file = $request->file('image');
+            $extension = $file->getClientOriginalExtension();
+            $filename = Str::uuid()->toString().'.'.$extension;
+            $filePath = Storage::putFileAs('public/course', $file, $filename);
+            $filePath = Course::convertImagePath($filePath);
+
+            $course = Course::create([
+                'instructor_id' => $instructorId,
+                'title' => $request->title,
+                'image' => $filePath,
+                'status' => Course::STATUS_PRIVATE,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ]);
+
+            // ログイン中の講師が作成したタグかどうか確認
+            $tag = Tag::where('id', $request->tag_id)
+                    ->where('instructor_id', $instructorId)
+                    ->first();
+        
+            if (!$tag) {
+                DB::rollback();
+                throw new AuthorizationException('Forbidden, invalid tag.');
+            }
+
+            // タグを中間テーブルに紐づける
+            $course->tags()->attach($tag->id);
+
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            Log::error($e);
+            throw $e;
+        }
     }
 
     /**

--- a/app/Http/Requests/Instructor/Course/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Course/StoreRequest.php
@@ -26,7 +26,7 @@ class StoreRequest extends FormRequest
         return [
             'title' => ['required'],
             'image' => ['required', 'file', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
-            'tag_id' => ['required', 'exists:tags,id'], 
+            'tag_id' => ['required', 'exists:tags,id'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/Course/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Course/StoreRequest.php
@@ -26,6 +26,7 @@ class StoreRequest extends FormRequest
         return [
             'title' => ['required'],
             'image' => ['required', 'file', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
+            'tag_id' => ['required', 'exists:tags,id'], 
         ];
     }
 }

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -2,6 +2,7 @@
 
 namespace App\Model;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -38,8 +39,6 @@ class Course extends Model
         'title',
         'image',
         'status',
-        'created_at',
-        'updated_at',
     ];
 
     /**
@@ -47,6 +46,8 @@ class Course extends Model
      */
     protected $casts = [
         'instructor_id' => 'int',
+        'created_at' => 'immutable_datetime',
+        'updated_at' => 'immutable_datetime',
     ];
 
     /**
@@ -57,6 +58,15 @@ class Course extends Model
     protected static function boot()
     {
         parent::boot();
+
+        static::creating(function (Course $course) {
+            $course->created_at = CarbonImmutable::now();
+            $course->updated_at = CarbonImmutable::now();
+        });
+
+        static::updating(function (Course $course) {
+            $course->updated_at = CarbonImmutable::now();
+        });
 
         // 削除時に関連するチャプターを削除
         static::deleting(function ($course) {

--- a/tests/Feature/Api/Instructor/Course/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Course/StoreTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/instructor/course', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'tag_id' => 1,
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('courses', [
+            'title' => 'テスト講座',
+        ]);
+
+        $this->assertDatabaseHas('course_tag', [
+            'course_id' => 8,
+            'tag_id' => 1,
+        ]);
+    }
+
+    public function test_無効なタグの指定_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/instructor/course', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'tag_id' => 2,
+        ]);
+
+        // assert
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => 'No query results for model [App\\Model\\Tag].',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue

JKA-1184：講師側 講座登録APIを改修して、登録時に講座分類名を指定して登録できるようにする

## 概要

- 講師が講座を登録する際に、自身が作成したタグの中からプルダウンで必ず１つのタグを選択することにする。
- プルダウンの実装自体はフロント側が行う

## 動作確認テスト

Postmanにて修正箇所に対する動作確認を実施。

**1. 正常：ログイン中の講師が自身の作成したタグを１つ選んで講座を新規登録**
- instructor_id=2でログイン
- URL：http://localhost:8080/api/v1/instructor/course
- HTTPメソッド：POST
- 結果：200 OK　
- 講座テーブルと、講座タグ中間テーブルにデーターが入った

**2. 異常：
Bodyに、ログイン中の講師が作成していないタグ数値を入力**
- instructor_id=2でログイン
- URL：http://localhost:8080/api/v1/instructor/course
- HTTPメソッド：POST
- 結果：~~403 エラー~~ 404 **NotFound**
- message:　~~'Forbidden, invalid tag.'~~ **"No query results for model [App\\Model\\Tag]."**

**3. 異常：tryの中に例外を発生させ、catchのエラーテスト**
- instructor_id=2でログイン
- try の下に、一時的に　throw new Exception('test');　を追加
- URL：http://localhost:8080/api/v1/instructor/course
- HTTPメソッド：POST
- 結果：500 サーバーエラー
- message:　'test'

## ご確認いただきたいこと
firstOrFail の記述に変更し、Postmanのテスト結果が一部変更となりました。
~~今回のstoreメソッド内のcreated_at と updated_at にも Carbon::now() が記載されています。
前回の私のタスクである「タグの新規登録API」のときと同じように、モデルイベントを利用してCarbonImmutabeの記述に変更すべきでしょうか？
もし変更すべき場合は、追加で前回のファイルを参考にしながらぜひ挑戦したいと思います。~~
