### PR TITLE
受講生側の講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修する(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -41,7 +41,6 @@ class AttendanceController extends Controller
         $perPage = $request->input('per_page', 6);
         $page = $request->input('page', 1);
         $tagId = $request->input('tag_id');
-        // dd($tagId);
         $studentId = Auth::id();
         $indexDto = new IndexDto($studentId, $request->search_word);
 

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -40,13 +40,16 @@ class AttendanceController extends Controller
     ): AttendanceIndexResource {
         $perPage = $request->input('per_page', 6);
         $page = $request->input('page', 1);
+        $tagId = $request->input('tag_id');
+        // dd($tagId);
         $studentId = Auth::id();
         $indexDto = new IndexDto($studentId, $request->search_word);
 
         return new AttendanceIndexResource($service(
             indexDto: $indexDto,
             perPage: $perPage,
-            page: $page
+            page: $page,
+            tagId: $tagId
         ));
     }
 

--- a/app/Http/Requests/Student/Attendance/IndexRequest.php
+++ b/app/Http/Requests/Student/Attendance/IndexRequest.php
@@ -25,6 +25,7 @@ class IndexRequest extends FormRequest
     {
         return [
             'search_word' => 'string',
+            'tag_id' => ['sometimes', 'integer', 'exists:tags,id'],
         ];
     }
 }

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -17,13 +17,14 @@ class IndexService
      * @return LengthAwarePaginator<Attendance>
      */
     public function __invoke(
-        IndexDto $indexDto, int $perPage, int $page
+        IndexDto $indexDto, int $perPage, int $page, int $tagId
     ): LengthAwarePaginator {
         // 受講情報を関連情報と一緒に取得
         $attendances = Attendance::with([
             'course.instructor',
             'course.chapters.lessons',
             'lessonAttendances',
+            'course.tags',
         ])
             ->where('student_id', $indexDto->getStudentId())
             ->whereHas('course', function (Builder $query) use ($indexDto) {
@@ -32,6 +33,11 @@ class IndexService
                 })->when($indexDto->getSearchWord(), function ($query) use ($indexDto) {
                     $query->where('title', 'like', "%{$indexDto->getSearchWord()}%")
                         ->where('status', Course::STATUS_PUBLIC);
+                });
+            })
+            ->when($tagId, function ($query) use ($tagId) {
+                $query->whereHas('course.tags', function ($query) use ($tagId) {
+                    $query->where('tags.id', $tagId);
                 });
             })
             ->paginate($perPage, ['*'], 'page', $page);

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -28,15 +28,15 @@ class IndexService
         ])
             ->where('student_id', $indexDto->getStudentId())
             ->whereHas('course', function (Builder $query) use ($indexDto) {
-                $query->when(! $indexDto->getSearchWord(), function ($query) {
+                $query->when(! $indexDto->getSearchWord(), function (Builder $query) {
                     $query->where('status', Course::STATUS_PUBLIC);
-                })->when($indexDto->getSearchWord(), function ($query) use ($indexDto) {
+                })->when($indexDto->getSearchWord(), function (Builder $query) use ($indexDto) {
                     $query->where('title', 'like', "%{$indexDto->getSearchWord()}%")
                         ->where('status', Course::STATUS_PUBLIC);
                 });
             })
             ->when($tagId, function (Builder $query) use ($tagId) {
-                $query->whereHas('course.tags', function ($query) use ($tagId) {
+                $query->whereHas('course.tags', function (Builder $query) use ($tagId) {
                     $query->where('tags.id', $tagId);
                 });
             })

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -17,7 +17,7 @@ class IndexService
      * @return LengthAwarePaginator<Attendance>
      */
     public function __invoke(
-        IndexDto $indexDto, int $perPage, int $page, int $tagId
+        IndexDto $indexDto, int $perPage, int $page, ?int $tagId
     ): LengthAwarePaginator {
         // 受講情報を関連情報と一緒に取得
         $attendances = Attendance::with([
@@ -35,7 +35,7 @@ class IndexService
                         ->where('status', Course::STATUS_PUBLIC);
                 });
             })
-            ->when($tagId, function ($query) use ($tagId) {
+            ->when($tagId, function (Builder $query) use ($tagId) {
                 $query->whereHas('course.tags', function ($query) use ($tagId) {
                     $query->where('tags.id', $tagId);
                 });

--- a/tests/Feature/Api/Student/Attendance/IndexTest.php
+++ b/tests/Feature/Api/Student/Attendance/IndexTest.php
@@ -29,4 +29,17 @@ class IndexTest extends TestCase
         // assert
         $response->assertStatus(200);
     }
+
+    public function test_受講一覧を取得_タグ指定_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/index?tag_id=1');
+
+        // assert
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
## issue
- Closes
#JKA-1168 受講生側の講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修する

## 概要
- クエリパラメータとしてタグIDで検索できるように修正

## 動作確認手順
### Student/AttendanceController
- indexメソッド
テストケース1（正常系：http://localhost:8080/api/v1/attendance/index?tag_id=1）
URL：
ログイン：
student_id = 1
クエリパラメータ：
tag_id = 1
結果：
```
{
    "data": [
        {
            "attendance_id": 4,
            "course": {
                "course_id": 1,
                "title": "PHP入門講座",
                "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
                "status": "public",
                "progress_percentage": 67
            }
        }
    ]
}
```

テストケース2（正常系：http://localhost:8080/api/v1/attendance/index?tag_id=2）
URL：
ログイン：
student_id = 1
クエリパラメータ：
tag_id = 2
結果：
```
{
    "data": [
        {
            "attendance_id": 8,
            "course": {
                "course_id": 2,
                "title": "Laravel入門講座",
                "image": "course/dbe1f6ef-66b4-4ce0-bfef-7555b6213bd4.png",
                "status": "public",
                "progress_percentage": 17
            }
        }
    ]
}
```