### PR TITLE
マネージャー側の講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修する（川原）

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -54,7 +55,7 @@ class CourseController extends Controller
 
             // タグの所有者が自分、または配下の講師でない場合はエラー
             if (!in_array($tag->instructor_id, $instructorIds, true)) {
-                throw new AuthorizationException('Forbidden, invalid instructor_id.');
+                throw new AuthorizationException('Forbidden, invalid tag_id.');
             }
         }
 
@@ -62,8 +63,8 @@ class CourseController extends Controller
         $query = Course::with('instructor')
             ->whereIn('instructor_id', $instructorIds)
             ->withCount('attendances')
-            ->when($tagId, function ($query, $tagId) {
-                $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
+            ->when($tagId, function (Builder $query, $tagId) {
+                $query->whereHas('tags', fn(Builder $query) => $query->where('tags.id', $tagId));
             });
 
         // ページネーションで講座を取得

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -14,8 +14,8 @@ use App\Http\Resources\Manager\CourseShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
-use App\Services\Course\QueryService;
 use App\Model\Tag;
+use App\Services\Course\QueryService;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -53,7 +53,7 @@ class CourseController extends Controller
             $tag = Tag::findOrFail($tagId);
 
             // タグの所有者が自分、または配下の講師でない場合はエラー
-            if (!in_array($tag->instructor_id, $instructorIds, true)) {
+            if (! in_array($tag->instructor_id, $instructorIds, true)) {
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
         }
@@ -63,7 +63,7 @@ class CourseController extends Controller
             ->whereIn('instructor_id', $instructorIds)
             ->withCount('attendances')
             ->when($tagId, function ($query, $tagId) {
-                $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
+                $query->whereHas('tags', fn ($query) => $query->where('tags.id', $tagId));
             });
 
         // ページネーションで講座を取得
@@ -113,7 +113,7 @@ class CourseController extends Controller
 
         $file = $request->file('image');
         $extension = $file->getClientOriginalExtension();
-        $filename = Str::uuid()->toString() . '.' . $extension;
+        $filename = Str::uuid()->toString().'.'.$extension;
         $filePath = Storage::disk('public')->putFileAs('course', $file, $filename);
 
         $course = Course::create([
@@ -161,7 +161,7 @@ class CourseController extends Controller
 
                 // 画像ファイル保存処理
                 $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString() . '.' . $extension;
+                $filename = Str::uuid()->toString().'.'.$extension;
                 $imagePath = Storage::putFileAs('public/course', $file, $filename);
                 $imagePath = Course::convertImagePath($imagePath);
             }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -19,11 +19,11 @@ use App\Services\Course\QueryService;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -54,7 +54,7 @@ class CourseController extends Controller
             $tag = Tag::findOrFail($tagId);
 
             // タグの所有者が自分、または配下の講師でない場合はエラー
-            if (!in_array($tag->instructor_id, $instructorIds, true)) {
+            if (! in_array($tag->instructor_id, $instructorIds, true)) {
                 throw new AuthorizationException('Forbidden, invalid tag_id.');
             }
         }
@@ -64,7 +64,7 @@ class CourseController extends Controller
             ->whereIn('instructor_id', $instructorIds)
             ->withCount('attendances')
             ->when($tagId, function (Builder $query, $tagId) {
-                $query->whereHas('tags', fn(Builder $query) => $query->where('tags.id', $tagId));
+                $query->whereHas('tags', fn (Builder $query) => $query->where('tags.id', $tagId));
             });
 
         // ページネーションで講座を取得

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -15,6 +15,7 @@ use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Services\Course\QueryService;
+use App\Model\Tag;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -36,22 +37,40 @@ class CourseController extends Controller
      */
     public function index(IndexRequest $request): AnonymousResourceCollection
     {
-        $perPage = $request->input('per_page', 6);
-        $page = $request->input('page', 1);
-
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得
         $manager = Instructor::with('managings')->find($instructorId);
-
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
-        // 自分、または配下の講師の講座情報を取得
-        $courses = Course::with('instructor')->whereIn('instructor_id', $instructorIds)->withCount('attendances')->orderBy('id')->paginate($perPage, ['*'], 'page', $page);
+        // クエリパラメータ取得
+        $perPage = $request->query('per_page', '6');
+        $tagId = $request->query('tag_id');
+
+        // タグIDが指定されている場合の検証
+        if ($tagId) {
+            $tag = Tag::findOrFail($tagId);
+
+            // タグの所有者が自分、または配下の講師でない場合はエラー
+            if (!in_array($tag->instructor_id, $instructorIds, true)) {
+                throw new AuthorizationException('Forbidden, invalid instructor_id.');
+            }
+        }
+
+        // 講座のクエリ構築
+        $query = Course::with('instructor')
+            ->whereIn('instructor_id', $instructorIds)
+            ->withCount('attendances')
+            ->when($tagId, function ($query, $tagId) {
+                $query->whereHas('tags', fn($query) => $query->where('tags.id', $tagId));
+            });
+
+        // ページネーションで講座を取得
+        $courses = $query->paginate((int) $perPage);
 
         // 各講座に受講中の学生がいるかを設定
-        $courses->each(function (Course $course) {
+        $courses->getCollection()->map(function (Course $course) {
             $course->has_active_students = $course->attendances_count > 0;
         });
 
@@ -94,7 +113,7 @@ class CourseController extends Controller
 
         $file = $request->file('image');
         $extension = $file->getClientOriginalExtension();
-        $filename = Str::uuid()->toString().'.'.$extension;
+        $filename = Str::uuid()->toString() . '.' . $extension;
         $filePath = Storage::disk('public')->putFileAs('course', $file, $filename);
 
         $course = Course::create([
@@ -142,7 +161,7 @@ class CourseController extends Controller
 
                 // 画像ファイル保存処理
                 $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString().'.'.$extension;
+                $filename = Str::uuid()->toString() . '.' . $extension;
                 $imagePath = Storage::putFileAs('public/course', $file, $filename);
                 $imagePath = Course::convertImagePath($imagePath);
             }
@@ -156,7 +175,6 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-
         } catch (ModelNotFoundException $e) {
             throw $e;
         } catch (Exception $e) {

--- a/app/Http/Requests/Manager/Course/IndexRequest.php
+++ b/app/Http/Requests/Manager/Course/IndexRequest.php
@@ -24,6 +24,7 @@ class IndexRequest extends FormRequest
         return [
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
+            'tag_id' => ['sometimes', 'integer', 'exists:tags,id'],
         ];
     }
 }

--- a/tests/Feature/Api/Manager/Course/IndexTest.php
+++ b/tests/Feature/Api/Manager/Course/IndexTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api\Manager\Course;
 
-use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -36,10 +35,9 @@ class IndexTest extends TestCase
         // arrange
         $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
-        Course::find(5)->delete();
 
         // act
-        $response = $this->getJson('/api/v1/manager/course/index?per_page=5');
+        $response = $this->getJson('/api/v1/manager/course/index?per_page=5&tag_id=1');
 
         // assert
         $response->assertStatus(200);


### PR DESCRIPTION
## issue
#JKA-1188 マネージャー側の講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修する

## 概要
受講生側の講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修する。

つまり現在のURLを現在の形からクエリパラメータ部分を変更して、
```
api/v1/manager/course/index?page=1
```
下の形でタグIDを指定してアクセスできるようにする
```
api/v1/manager/course/index?page=1&tag_id=1
```

## 動作確認手順
Postmanにて動作確認を実施。

テストケース1（正常系：http://localhost:8080/api/v1/manager/course/index?page=1&tag_id=1)
URL：
ログイン：
instructor_id = 1
クエリパラメータ：
page = 1
tag_id = 1
結果：
```
{
    "data": [
        {
            "course_id": 1,
            "title": "PHP入門講座",
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "status": "public",
            "has_active_students": true
        },
        {
            "course_id": 5,
            "title": "Python入門講座",
            "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
            "status": "public",
            "has_active_students": false
        }
    ],
    "links": {
        "first": "http://localhost:8080/api/v1/manager/course/index?page=1",
        "last": "http://localhost:8080/api/v1/manager/course/index?page=1",
        "prev": null,
        "next": null
    },
    "meta": {
        "current_page": 1,
        "from": 1,
        "last_page": 1,
        "links": [
            {
                "url": null,
                "label": "&laquo; Previous",
                "active": false
            },
            {
                "url": "http://localhost:8080/api/v1/manager/course/index?page=1",
                "label": "1",
                "active": true
            },
            {
                "url": null,
                "label": "Next &raquo;",
                "active": false
            }
        ],
        "path": "http://localhost:8080/api/v1/manager/course/index",
        "per_page": 6,
        "to": 2,
        "total": 2
    }
}
```

テストケース2（異常系：http://localhost:8080/api/v1/manager/course/index?page=1&tag_id=4)
URL：
ログイン：
instructor_id = 1
クエリパラメータ：
page = 1
tag_id = 4
結果：
```
 "message": "Forbidden, invalid instructor_id."
```