### PR TITLE
JKA-1191：講座のタイトルカラムでの検索を可能にする（こみやま）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -36,11 +36,16 @@ class CourseController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
         // 講座情報を取得
         $perPage = $request->query('per_page', '6');
+        $searchWord = $request->query('search_word');
+
+        $query = Course::where('instructor_id', $instructorId)
+            ->withCount('attendances')
+            ->when($searchWord, function ($query) use ($searchWord) {
+                $query->where('title', 'LIKE', "%{$searchWord}%");
+            });
 
         // ページネーションで講座を取得
-        $courses = Course::where('instructor_id', $instructorId)
-            ->withCount('attendances')
-            ->paginate((int) $perPage);
+        $courses = $query->paginate((int) $perPage);
 
         $courses->getCollection()->map(function (Course $course) {
             $course->has_active_students = $course->attendances_count > 0;

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -17,6 +17,7 @@ use App\Model\Instructor;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -40,7 +41,7 @@ class CourseController extends Controller
 
         $query = Course::where('instructor_id', $instructorId)
             ->withCount('attendances')
-            ->when($searchWord, function ($query) use ($searchWord) {
+            ->when($searchWord, function (Builder $query) use ($searchWord) {
                 $query->where('title', 'LIKE', "%{$searchWord}%");
             });
 

--- a/app/Http/Requests/Instructor/Course/IndexRequest.php
+++ b/app/Http/Requests/Instructor/Course/IndexRequest.php
@@ -24,6 +24,7 @@ class IndexRequest extends FormRequest
         return [
             'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
             'page' => ['integer', 'min:1'],
+            'search_word' => ['sometimes', 'string'],
         ];
     }
 }

--- a/tests/Feature/Api/Instructor/Course/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Course/IndexTest.php
@@ -29,6 +29,7 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
     }
 
     public function test_パラメータ指定_成功(): void
@@ -43,5 +44,20 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
+    }
+
+    public function test_タイトル検索_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+        Course::find(5)->delete();
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/index?search_word=PHP');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
     }
 }


### PR DESCRIPTION
## issue
JKA-1191：講師側 講座一覧APIで、講座名(titleカラム)での検索を可能にする

## 動作確認
1. 正常：検索なしでの一覧取得
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/index
 - HTTPメソッド：GET
 - 結果：200 OK
```
"data": [
        {
            "course_id": 1,
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "title": "PHP入門講座",
            "status": "public",
            "has_active_students": true
        },
        {
            "course_id": 5,
            "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
            "title": "Python入門講座",
            "status": "public",
            "has_active_students": false
        }
    ]
```

2. 正常：「search_word=PHP」で検索
 - instructor_id=1でログイン
 - URL：http://localhost:8080/api/v1/instructor/course/index?search_word=PHP
 - HTTPメソッド：GET
 - 結果：200 OK
```
"data": [
        {
            "course_id": 1,
            "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
            "title": "PHP入門講座",
            "status": "public",
            "has_active_students": true
        }
    ]
```