### PR TITLE
JKA-1180 講師側受講状況取得APIに講座分類名を追加(大畑)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -88,7 +88,7 @@ class AttendanceController extends Controller
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $courseId = $request->course_id;
-        $course = Course::findOrFail($courseId);
+        $course = Course::with('tags')->findOrFail($courseId);
 
         if ($course->instructor_id !== $instructorId) {
             // ログインしている講師の講座でない場合はエラーを返す
@@ -104,6 +104,7 @@ class AttendanceController extends Controller
         return new AttendanceShowResource([
             'chapters' => $chapters,
             'studentsCount' => $studentsCount,
+            'course_tags' => $course->tags->pluck('content'),
         ]);
     }
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -104,7 +104,7 @@ class AttendanceController extends Controller
         return new AttendanceShowResource([
             'chapters' => $chapters,
             'studentsCount' => $studentsCount,
-            'course_tags' => $course->tags->pluck('content'),
+            'tags' => $course->tags,
         ]);
     }
 

--- a/app/Http/Resources/Instructor/AttendanceShowResource.php
+++ b/app/Http/Resources/Instructor/AttendanceShowResource.php
@@ -28,7 +28,7 @@ class AttendanceShowResource extends JsonResource
                 ];
             }),
             'students_count' => $this->resource['studentsCount'],
-            'course_tags' => $this->resource['course_tags'],
-        ];
+            'tag' => TagResource::collection($this->resource->course->tags),
+        ];    
     }
 }

--- a/app/Http/Resources/Instructor/AttendanceShowResource.php
+++ b/app/Http/Resources/Instructor/AttendanceShowResource.php
@@ -29,6 +29,6 @@ class AttendanceShowResource extends JsonResource
             }),
             'students_count' => $this->resource['studentsCount'],
             'tag' => TagResource::collection($this->resource->course->tags),
-        ];    
+        ];
     }
 }

--- a/app/Http/Resources/Instructor/AttendanceShowResource.php
+++ b/app/Http/Resources/Instructor/AttendanceShowResource.php
@@ -28,6 +28,7 @@ class AttendanceShowResource extends JsonResource
                 ];
             }),
             'students_count' => $this->resource['studentsCount'],
+            'course_tags' => $this->resource['course_tags'],
         ];
     }
 }


### PR DESCRIPTION
## issue
- JKA-1180 講師側受講状況取得APIに講座分類名を追加

## 概要
- 講座分類名を講座分類名を（URL: api/v1/instructor/course/{course_id}/attendance/status）で取得できるようにAPIを改修する.。

## 動作確認手順
- ファイル変更後Scrambleにて確認。
結果：200

- Postmanにて動作確認
URL:api/v1/instructor/course/{course_id}/attendance/status
http: GET
以下値を確認
{
    "data": {
        "chapters": [
            {
                "chapter_id": 1,
                "title": "PHPとは？",
                "completed_count": 1
            },
            {
                "chapter_id": 2,
                "title": "PHPの基礎を学ぼう",
                "completed_count": 2
            },
            {
                "chapter_id": 3,
                "title": "PHPの応用にチャレンジしよう",
                "completed_count": 0
            }
        ],
        "students_count": 2,
        "course_tags": [
            "バックエンド入門編"
        ]
    }
}