### PR TITLE
講師側のTagControllerの講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修(yuki)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -40,9 +40,12 @@ class TagController extends Controller
             }
         }
 
-        $query = Tag::where('instructor_id', $instructorId)->when($tagId, function (Builder $query, string $tagId) {
-            $query->whereHas('courses', fn ($query) => $query->where('tags.id', $tagId));
-        })->with('courses')->get();
+        $query = Tag::where('instructor_id', $instructorId)
+            ->when($tagId, function (Builder $query, string $tagId) {
+                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
+            })
+            ->with('courses')
+            ->get();
 
         return TagIndexResource::collection($query);
     }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\Tag\IndexRequest;
 use App\Http\Requests\Instructor\Tag\PutRequest;
 use App\Http\Requests\Instructor\Tag\ShowRequest;
 use App\Http\Requests\Instructor\Tag\StoreRequest;
@@ -13,6 +14,7 @@ use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 /**
  * @tags Instructor-Tag
@@ -22,14 +24,27 @@ class TagController extends Controller
     /**
      * タグ一覧取得API
      */
-    public function index()
+    public function index(IndexRequest $request)
     {
+        $tagId = $request->query('tag_id');
+
         // ログインしている講師
         $instructorId = Auth::guard('instructor')->user()->id;
 
-        $tags = Tag::where('instructor_id', $instructorId)->with('courses')->get();
+        if ($tagId) {
+            $tag = Tag::findOrFail($tagId);
 
-        return TagIndexResource::collection($tags);
+            // ログインしている講師とtag_idの講師が一致しない
+            if ($instructorId !== $tag->instructor_id) {
+                throw new AuthorizationException('Forbidden, invalid instructor_id.');
+            }
+        }
+        
+        $query = Tag::where('instructor_id', $instructorId)->when($tagId, function (Builder $query, string $tagId) {
+            $query->whereHas('courses', fn ($query) => $query->where('tags.id', $tagId));
+        })->with('courses')->get();
+
+        return TagIndexResource::collection($query);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -12,9 +12,9 @@ use App\Http\Resources\Tag\TagResource;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Contracts\Database\Eloquent\Builder;
 
 /**
  * @tags Instructor-Tag
@@ -39,7 +39,7 @@ class TagController extends Controller
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
         }
-        
+
         $query = Tag::where('instructor_id', $instructorId)->when($tagId, function (Builder $query, string $tagId) {
             $query->whereHas('courses', fn ($query) => $query->where('tags.id', $tagId));
         })->with('courses')->get();

--- a/app/Http/Requests/Instructor/Tag/IndexRequest.php
+++ b/app/Http/Requests/Instructor/Tag/IndexRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'tag_id' => ['sometimes', 'integer', 'exists:tags,id'],
+        ];
+    }
+}

--- a/database/seeders/CourseTagSeeder.php
+++ b/database/seeders/CourseTagSeeder.php
@@ -36,7 +36,7 @@ class CourseTagSeeder extends Seeder
             ],
             [
                 'course_id' => 5,
-                'tag_id' => 1,
+                'tag_id' => 6,
                 'created_at' => Carbon::now(),
             ],
             [

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -44,6 +44,12 @@ class TagSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'instructor_id' => 1,
+                'content' => 'バックエンド応用編',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }

--- a/tests/Feature/Api/Instructor/Tag/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Tag/IndexTest.php
@@ -28,5 +28,20 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
+    }
+
+    public function test_パラメータ指定_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/tag/index?tag_id=1');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
     }
 }


### PR DESCRIPTION
## issue
- Closes
#JKA-1195 講師側のTagControllerの講座一覧APIにクエリパラメータとしてタグIDで検索できるように改修する

## 概要
- クエリパラメータとしてタグIDで検索できるように修正

## 動作確認手順
### Instructor/TagController
- indexメソッド
テストケース1（正常系：http://localhost:8080/api/v1/instructor/course/tag/index?tag_id=1）
URL：
ログイン：
instructor_id = 1
クエリパラメータ：
tag_id = 1
結果：
```
{
    "data": [
        {
            "tag_id": 1,
            "content": "バックエンド入門編",
            "courses": [
                {
                    "course_id": 1,
                    "title": "PHP入門講座",
                    "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
                    "status": "public"
                },
                {
                    "course_id": 5,
                    "title": "Python入門講座",
                    "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
                    "status": "public"
                }
            ]
        }
    ]
}
```

テストケース2（正常系：http://localhost:8080/api/v1/instructor/course/tag/index）
URL：
ログイン：
instructor_id = 1
結果：
```
{
    "data": [
        {
            "tag_id": 1,
            "content": "バックエンド入門編",
            "courses": [
                {
                    "course_id": 1,
                    "title": "PHP入門講座",
                    "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
                    "status": "public"
                },
                {
                    "course_id": 5,
                    "title": "Python入門講座",
                    "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
                    "status": "public"
                }
            ]
        },
        {
            "tag_id": 7,
            "content": "バックエンド講座",
            "courses": [
                {
                    "course_id": 12,
                    "title": "Python入門講座",
                    "image": "course/c0fb049e-7419-4325-a992-3393dadaf21d.png",
                    "status": "public"
                }
            ]
        }
    ]
}
```

テストケース3（異常系：http://localhost:8080/api/v1/instructor/course/tag/index?tag_id=2）
URL：
ログイン：
instructor_id = 1
クエリパラメータ：
tag_id = 2
結果：
```
"message": "Forbidden, invalid instructor_id."
```