### PR TITLE
JKA-1190 受講生側 講座一覧APIで検索時に講座名での検索以外に「講座分類名」で検索可能にする(miyagi)

### DIFF
--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -32,6 +32,9 @@ class IndexService
                     $query->where('status', Course::STATUS_PUBLIC);
                 })->when($indexDto->getSearchWord(), function (Builder $query) use ($indexDto) {
                     $query->where('title', 'like', "%{$indexDto->getSearchWord()}%")
+                        ->orWhereHas('tags', function (Builder $query) use ($indexDto) {
+                            $query->where('content', 'like', "%{$indexDto->getSearchWord()}%");
+                        })
                         ->where('status', Course::STATUS_PUBLIC);
                 });
             })

--- a/database/seeders/AttendanceSeeder.php
+++ b/database/seeders/AttendanceSeeder.php
@@ -16,7 +16,6 @@ class AttendanceSeeder extends Seeder
     public function run()
     {
         Attendance::insert([
-            // 受講生1
             [
                 'course_id' => 1,
                 'student_id' => 1,
@@ -26,6 +25,12 @@ class AttendanceSeeder extends Seeder
             [
                 'course_id' => 1,
                 'student_id' => 2,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'course_id' => 6,
+                'student_id' => 1,
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],

--- a/tests/Feature/Api/Instructor/Student/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Student/ShowTest.php
@@ -33,7 +33,7 @@ class ShowTest extends TestCase
     public function test_許可がない講師_失敗(): void
     {
         // arrange
-        $instructor = Instructor::find(2);
+        $instructor = Instructor::find(3);
         $this->actingAs($instructor, 'instructor');
 
         // act

--- a/tests/Feature/Api/Student/Attendance/IndexTest.php
+++ b/tests/Feature/Api/Student/Attendance/IndexTest.php
@@ -28,6 +28,7 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
     }
 
     public function test_受講一覧を取得_タグ指定_成功(): void
@@ -41,5 +42,34 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_タグ名で検索_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/index?search_word=バックエンド');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_講座名で検索_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student);
+
+        // act
+        $response = $this->getJson('/api/v1/attendance/index?search_word=Vue');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
     }
 }


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1190

## 概要
- 受講生側 講座一覧APIで、検索時に講座名での検索以外に「講座分類名」でも検索可能に変更する

## 動作確認
- Postmanにて動作確認
1. 下記の受講生でログイン
    - email：test_student_1@example.com
    - password：password1
    - URL：http://localhost:8080/login
    - HTTPメソッド：POST
    - 結果：200 OK
```
{
    "result": true,
    "message": "Authenticated."
}
```
2. 下記の条件で講座一覧取得
    - URL：http://localhost:8080/api/v1/attendance/index?search_word=バックエンド
    - HTTPメソッド：GET
    - 結果：200 OK
```
{
    "data": [
        {
            "attendance_id": 1,
            "course": {
                "course_id": 1,
                "title": "PHP入門講座",
                "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
                "status": "public",
                "progress_percentage": 0
            }
        }
    ],
    "links": {
        "first": "http://localhost:8080/api/v1/attendance/index?page=1",
        "last": "http://localhost:8080/api/v1/attendance/index?page=1",
        "prev": null,
        "next": null
    },
    "meta": {
        "current_page": 1,
        "from": 1,
        "last_page": 1,
        "links": [
            {
                "url": null,
                "label": "&laquo; Previous",
                "active": false
            },
            {
                "url": "http://localhost:8080/api/v1/attendance/index?page=1",
                "label": "1",
                "active": true
            },
            {
                "url": null,
                "label": "Next &raquo;",
                "active": false
            }
        ],
        "path": "http://localhost:8080/api/v1/attendance/index",
        "per_page": 6,
        "to": 1,
        "total": 1
    }
}
```