### PR TITLE
(えんどう)JKA-1176(JKA-1202)_ロジック作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\PutRequest;
+use Illuminate\Http\Request;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -18,8 +19,37 @@ class TagController extends Controller
     /**
      * タグ一覧取得API
      */
-    public function index()
-    {
+    public function index(Request $request)
+    {   
+        $tagId = $request->query('tag_id');
+
+        // マネージャーが管理する講師IDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($instructorId);
+
+        // マネージャー(講師)＋マネージャー配下インストラクターのID一覧
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id; // 自身のIDも追加
+
+        if ($tagId) {
+            // タグの取得
+            $tag = Tag::findOrFail($tagId);
+
+            // ログインしているマネージャー(講師)もしくはその配下の講師とtag_idの講師が一致しない
+            if (!in_array($tag->instructor_id, $instructorIds, true)) {
+                throw new AuthorizationException('Forbidden, invalid instructor_id.');
+            }
+        }
+
+        $query = Tag::where('instructor_id', $instructorId)
+            ->when($tagId, function (Builder $query, string $tagId) {
+                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
+            })
+            ->with('courses')
+            ->get();
+
         return response()->json([]);
     }
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -43,7 +43,7 @@ class TagController extends Controller
             }
         }
 
-        $query = Tag::where('instructor_id', $instructorIds)
+        $query = Tag::whereIn('instructor_id', $instructorIds)
             ->when($tagId, function (Builder $query, string $tagId) {
                 $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
             })

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -4,12 +4,12 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\PutRequest;
-use Illuminate\Http\Request;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -21,7 +21,7 @@ class TagController extends Controller
      * タグ一覧取得API
      */
     public function index(Request $request)
-    {   
+    {
         $tagId = $request->query('tag_id');
 
         // マネージャーが管理する講師IDを取得
@@ -39,7 +39,7 @@ class TagController extends Controller
             $tag = Tag::findOrFail($tagId);
 
             // ログインしているマネージャー(講師)もしくはその配下の講師とtag_idの講師が一致しない
-            if (!in_array($tag->instructor_id, $instructorIds, true)) {
+            if (! in_array($tag->instructor_id, $instructorIds, true)) {
                 throw new AuthorizationException('Forbidden, invalid instructor_id.');
             }
         }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -43,7 +43,7 @@ class TagController extends Controller
             }
         }
 
-        $query = Tag::where('instructor_id', $instructorId)
+        $query = Tag::where('instructor_id', $instructorIds)
             ->when($tagId, function (Builder $query, string $tagId) {
                 $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
             })

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -43,7 +43,7 @@ class TagController extends Controller
             }
         }
 
-        $query = Tag::whereIn('instructor_id', $instructorIds)
+        $query = Tag::where('instructor_id', $instructorIds)
             ->when($tagId, function (Builder $query, string $tagId) {
                 $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
             })

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
@@ -43,7 +44,7 @@ class TagController extends Controller
             }
         }
 
-        $query = Tag::where('instructor_id', $instructorIds)
+        $query = Tag::whereIn('instructor_id', $instructorIds)
             ->when($tagId, function (Builder $query, string $tagId) {
                 $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
             })

--- a/tests/Feature/Api/Manager/Tag/IndexTest.php
+++ b/tests/Feature/Api/Manager/Tag/IndexTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Tag;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_タグ一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/tag/index');
+
+        // assert
+        $response->assertStatus(200);
+        // $response->assertJsonCount(3, 'data');
+    }
+
+    public function test_パラメータ指定_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/course/tag/index?tag_id=1');
+
+        // assert
+        $response->assertStatus(200);
+        // $response->assertJsonCount(2, 'data');
+    }
+
+    // public function test_権限エラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(2);
+    //     $this->actingAs($instructor, 'instructor');
+
+    //     // act
+    //     $response = $this->getJson('/api/v1/manager/tag/1', [
+    //         'content' => 'test',
+    //     ]);
+
+    //     // assert
+    //     $response->assertStatus(403);
+    // }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+
+    //     // act
+    //     $response = $this->getJson('/api/v1/manager/tag/aaa', [
+    //         'content' => '',
+    //     ]);
+
+    //     // assert
+    //     $response->assertStatus(422);
+    //     $response->assertJsonValidationErrors([
+    //         'tag_id',
+    //         'content',
+    //     ]);
+    // }
+}


### PR DESCRIPTION
# ロジックの作成

・app/Http/Controllers/Api/Manager/TagController.phpのindexメソッドにロジックを作成
　(現状postmanテストで$rewuestを反映させる為、use Illuminate\Http\Request;を記載しています。）

・postmanでURL：http://localhost:8085/api/v1/manager/course/tag/index
　でsendして、エラーが無いことを確認、

・レスポンス結果　[]

**・４回目の修正時URL：http://localhost:8085/api/v1/manager/course/tag/index?tag_id=1
でレスポンスが[]であることを確認（エラー表示なし)**

・１回目の修正で$queryに挿入するwhereの第二引数を$instructorIdsに変更
・２回目の修正でwhereをwehreInに変更
　**・３回目の修正　間違ってwhere修正前の状態でpushしてしまいました。**
　**・４回目の修正でクエリビルダ宣言を追加しました。**