### PR TITLE
JKA-1127講師側受講生一覧に受講生のプロフィール画像のレスポンスを追加(yurika)

### DIFF
--- a/app/Http/Resources/Instructor/StudentIndexResource.php
+++ b/app/Http/Resources/Instructor/StudentIndexResource.php
@@ -34,6 +34,7 @@ class StudentIndexResource extends JsonResource
                 'student_id' => $result->student_id,
                 'nick_name' => $result->nick_name,
                 'email' => $result->email,
+                'profile_image' => $result->profile_image,
                 'last_login_at' => $result->last_login_at,
                 'attendance' => [
                     'attendance_id' => $result->attendance_id,


### PR DESCRIPTION
## issus
JKA-1127 講師側　受講生一覧に受講生のプロフィール画像のレスポンスを追加

## 概要
講師側　受講生一覧に受講生のプロフィール画像のレスポンスを追加

## 動作確認
postman使用し動作確認
１講師側でのログイン
２GET：(http://localhost:8080/api/v1/instructor/student/index)
３ヘッダー：キー Referer (http://localhost:3000) キー Origin  (http://localhost:3000)

上記入力　　送信を押して　200 OK{
    "data": {
        "pagination": {
            "page": 1,
            "total": 2
        },
        "students": [
            {
                "student_id": 1,
                "nick_name": "生徒ニックネーム1",
                "email": "test_student_1@example.com",
                "profile_image": "/student/image1.jpg",
                "last_login_at": "2025-03-14 20:28:01",
                "attendance": {
                    "attendance_id": 1,
                    "attendanced_at": "2025-03-14 20:28:01"
                }
            },
            {
                "student_id": 2,
                "nick_name": "生徒ニックネーム2",
                "email": "test_student_2@example.com",
                "profile_image": "/student/image2.jpg",
                "last_login_at": "2025-03-14 20:28:01",
                "attendance": {
                    "attendance_id": 2,
                    "attendanced_at": "2025-03-14 20:28:01"
                }
            }
        ]
    }
}
受講生一覧にて受講生プロフィール画像のレスポンス確認する[](url)