### PR TITLE
マネージャー側 講師講座情報一覧APIに講座分類名を追加（櫻井）

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -8,7 +8,6 @@ use App\Http\Resources\Manager\InstructorCourseIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
 /**

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -19,7 +19,7 @@ class CourseController extends Controller
     /**
      * 講師-講座情報一覧取得API
      */
-    public function index(IndexRequest $request): InstructorCourseIndexResource|JsonResponse
+    public function index(IndexRequest $request): InstructorCourseIndexResource
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -35,7 +35,7 @@ class CourseController extends Controller
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
-        $courses = Course::where('instructor_id', $request->instructor_id)->paginate(5);
+        $courses = Course::with('tags')->where('instructor_id', $request->instructor_id)->paginate(5);
 
         return new InstructorCourseIndexResource($courses);
     }

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -6,6 +6,7 @@ use App\Model\Course;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
+use App\Http\Resources\Tag\TagResource;
 
 class InstructorCourseIndexResource extends JsonResource
 {
@@ -43,6 +44,7 @@ class InstructorCourseIndexResource extends JsonResource
                 'title' => $course->title,
                 'status' => $course->status,
                 'updated_at' => $course->updated_at->format('Y/m/d H:i:s'),
+                'tags' => TagResource::collection($course->tags),
             ];
         })
             ->toArray();

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Resources\Manager;
 
+use App\Http\Resources\Tag\TagResource;
 use App\Model\Course;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
-use App\Http\Resources\Tag\TagResource;
 
 class InstructorCourseIndexResource extends JsonResource
 {

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Resources\Manager;
 
-use App\Http\Resources\Tag\TagResource;
+use App\Http\Resources\Base\Instructor\TagResource;
 use App\Model\Course;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;


### PR DESCRIPTION
## issue
#JKA-1177 マネージャー側 講師講座情報一覧APIに講座分類名を追加
## テスト
### Postmanにて確認

#### 講師講座情報一覧取得API
- 取得できた状態
URL：http://localhost:8080/api/v1/manager/instructor/2/course/index
 Origin → http://localhost:3000/
 Referer → http://localhost:3000/