### PR TITLE
(えんどう)JKA-1176(JKA-1204)_レスポンス整形のリソースファイル作成

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -51,7 +51,7 @@ class TagController extends Controller
             ->when($tagId, function (Builder $query, string $tagId) {
                 $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
             })
-            ->with('courses')
+            ->with(['courses.instructor'])
             ->get();
 
         // 各タグの中の各講座に受講中の学生がいるかを設定

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Api\Manager;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\IndexRequest;
 use App\Http\Requests\Manager\Tag\PutRequest;
+use App\Http\Resources\Manager\TagIndexResource;
+use App\Http\Resources\Tag\TagResource;
 use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -51,7 +53,7 @@ class TagController extends Controller
             ->with('courses')
             ->get();
 
-        return response()->json([]);
+        return TagIndexResource::collection($query);
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -9,6 +9,7 @@ use App\Http\Resources\Manager\TagIndexResource;
 use App\Http\Resources\Tag\TagResource;
 use App\Model\Instructor;
 use App\Model\Tag;
+use App\Model\Course;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -53,6 +54,13 @@ class TagController extends Controller
             ->with('courses')
             ->get();
 
+        // 各タグの中の各講座に受講中の学生がいるかを設定
+        $query->each(function (Tag $tag) {
+            $tag->courses->each(function (Course $course) {
+                $course->has_active_students = $course->attendances()->exists();
+            });
+        });
+        
         return TagIndexResource::collection($query);
     }
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -6,10 +6,9 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\IndexRequest;
 use App\Http\Requests\Manager\Tag\PutRequest;
 use App\Http\Resources\Manager\TagIndexResource;
-use App\Http\Resources\Tag\TagResource;
+use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Tag;
-use App\Model\Course;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -60,7 +59,7 @@ class TagController extends Controller
                 $course->has_active_students = $course->attendances()->exists();
             });
         });
-        
+
         return TagIndexResource::collection($query);
     }
 

--- a/app/Http/Resources/Manager/CourseIndexResource.php
+++ b/app/Http/Resources/Manager/CourseIndexResource.php
@@ -27,7 +27,7 @@ class CourseIndexResource extends JsonResource
                 'email' => $this->instructor->email,
                 'profile_image' => $this->instructor->profile_image,
             ],
-            'has_active_students' => $this->attendances()->exists(),
+            'has_active_students' => $this->has_active_students,
         ];
     }
 }

--- a/app/Http/Resources/Manager/CourseIndexResource.php
+++ b/app/Http/Resources/Manager/CourseIndexResource.php
@@ -14,22 +14,20 @@ class CourseIndexResource extends JsonResource
      */
     public function toArray($request)
     {
-        return $this->resource->map(function ($course) {
-            return [
-                'course_id' => $course->id,
-                'title' => $course->title,
-                'image' => $course->image,
-                'status' => $course->status,
-                'instructor' => [
-                    'instructor_id' => $course->instructor_id,
-                    'nick_name' => $course->instructor->nick_name,
-                    'last_name' => $course->instructor->last_name,
-                    'first_name' => $course->instructor->first_name,
-                    'email' => $course->instructor->email,
-                    'profile_image' => $course->instructor->profile_image,
-                ],
-                'has_active_students' => $course->has_active_students,
-            ];
-        });
+        return [
+            'course_id' => $this->id,
+            'title' => $this->title,
+            'image' => $this->image,
+            'status' => $this->status,
+            'instructor' => [
+                'instructor_id' => $this->instructor_id,
+                'nick_name' => $this->instructor->nick_name,
+                'last_name' => $this->instructor->last_name,
+                'first_name' => $this->instructor->first_name,
+                'email' => $this->instructor->email,
+                'profile_image' => $this->instructor->profile_image,
+            ],
+            'has_active_students' => $this->attendances()->exists(),
+        ];
     }
 }

--- a/app/Http/Resources/Manager/CourseIndexResource.php
+++ b/app/Http/Resources/Manager/CourseIndexResource.php
@@ -2,10 +2,14 @@
 
 namespace App\Http\Resources\Manager;
 
+use App\Model\Course;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class CourseIndexResource extends JsonResource
 {
+    /** @var Course */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *
@@ -15,19 +19,19 @@ class CourseIndexResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'course_id' => $this->id,
-            'title' => $this->title,
-            'image' => $this->image,
-            'status' => $this->status,
+            'course_id' => $this->resource->id,
+            'title' => $this->resource->title,
+            'image' => $this->resource->image,
+            'status' => $this->resource->status,
             'instructor' => [
-                'instructor_id' => $this->instructor_id,
-                'nick_name' => $this->instructor->nick_name,
-                'last_name' => $this->instructor->last_name,
-                'first_name' => $this->instructor->first_name,
-                'email' => $this->instructor->email,
-                'profile_image' => $this->instructor->profile_image,
+                'instructor_id' => $this->resource->instructor_id,
+                'nick_name' => $this->resource->instructor->nick_name,
+                'last_name' => $this->resource->instructor->last_name,
+                'first_name' => $this->resource->instructor->first_name,
+                'email' => $this->resource->instructor->email,
+                'profile_image' => $this->resource->instructor->profile_image,
             ],
-            'has_active_students' => $this->has_active_students,
+            'has_active_students' => $this->resource->has_active_students,
         ];
     }
 }

--- a/app/Http/Resources/Manager/TagIndexResource.php
+++ b/app/Http/Resources/Manager/TagIndexResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources\Manager;
 
-use App\Http\Resources\Manager\CourseIndexResource;
 use App\Http\Resources\Tag\TagResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/app/Http/Resources/Manager/TagIndexResource.php
+++ b/app/Http/Resources/Manager/TagIndexResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use App\Http\Resources\Manager\CourseIndexResource;
+use App\Http\Resources\Tag\TagResource;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TagIndexResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            ...(new TagResource($this->resource))->toArray($request),
+            'courses' => CourseIndexResource::collection($this->resource->courses),
+        ];
+    }
+}


### PR DESCRIPTION
他のリソースファイルを参考にTagIndexResource.phpを作成・既存のCourseIndexResource.phpを変更で、
計画時に決めたレスポンスが返るように変更

・１回目の修正で他コントローラーのhas_active_studentsを実装部分を参考に、
　リソースファイルへの直書きからコントローラーへの定義に変更
　テスト時に尚も期待通りのレスポンスが返ることを確認

**・２回目の修正でinstructor部分N+1問題解消の為、eagerLoadingするように変更**


テスト
postmanにて
http://localhost:8085/api/v1/manager/course/tag/index?tag_id=1
をsendして、以下のレスポンスが返ることを確認
`{
    "data": [
        {
            "tag_id": 1,
            "content": "バックエンド入門編",
            "courses": [
                {
                    "course_id": 1,
                    "title": "PHP入門講座",
                    "image": "course/4459908b-3cdf-4521-94fa-c2a9746d92e1.png",
                    "status": "public",
                    "instructor": {
                        "instructor_id": 1,
                        "nick_name": "Yamada",
                        "last_name": "山田",
                        "first_name": "太郎",
                        "email": "test_instructor@example.com",
                        "profile_image": "instructor/default.png"
                    },
                    "has_active_students": true
                }
            ]
        }
    ]
}`
他、http://localhost:8085/api/v1/manager/course/tag/index?tag_id=2以降でも同様のテスト実行