### PR TITLE
JKA-1181　空の配列を返すルーターとコントローラーの実装

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -24,7 +24,12 @@ class TagController extends Controller
     /**
      * タグ一覧取得API
      */
-    public function index(IndexRequest $request)
+    public function index()
+    {
+        return response()->json([]);
+    }
+
+    public function courseIndex (IndexRequest $request)
     {
         $tagId = $request->query('tag_id');
 

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -29,7 +29,7 @@ class TagController extends Controller
         return response()->json([]);
     }
 
-    public function courseIndex (IndexRequest $request)
+    public function courseIndex(IndexRequest $request)
     {
         $tagId = $request->query('tag_id');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,12 +65,15 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('/', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'show']);
             Route::post('update', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'update']);
 
+            //講師-講座タグ一覧
+            Route::get('tag/index', [App\Http\Controllers\Api\Instructor\TagController::class, 'index']);
+
             // 講師-講座
             Route::prefix('course')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index']);
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
-                Route::get('tag/index', [App\Http\Controllers\Api\Instructor\TagController::class, 'index']);
+                Route::get('tag/index', [App\Http\Controllers\Api\Instructor\TagController::class, 'courseIndex']);
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'update']);


### PR DESCRIPTION
## 概要
JKA-1181　空の配列返すルーターとコントローラーの実装

## 確認
postmanにて空の配列が返ってくることを確認

ログイン
instructor_id1
<img width="783" alt="スクリーンショット 2025-04-05 2 03 21" src="https://github.com/user-attachments/assets/b054fc38-e1e9-4dbb-8dbc-2fad9c566422" />
