### PR TITLE
JKA-1181 ロジックの実装(伊藤)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/Course/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/Course/TagController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor\Course;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\Tag\IndexRequest;
+use App\Http\Resources\Instructor\TagIndexResource;
+use App\Model\Tag;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * @tags Instructor-Course-Tag
+ */
+class TagController extends Controller
+{
+    /**
+     * 講座のタグ一覧を取得する
+     */
+    public function index(IndexRequest $request): AnonymousResourceCollection
+    {
+        $tagId = $request->query('tag_id');
+
+        // ログインしている講師
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        if ($tagId) {
+            $tag = Tag::findOrFail($tagId);
+
+            // ログインしている講師とtag_idの講師が一致しない
+            if ($instructorId !== $tag->instructor_id) {
+                throw new AuthorizationException('Forbidden, invalid instructor_id.');
+            }
+        }
+
+        $query = Tag::where('instructor_id', $instructorId)
+            ->when($tagId, function (Builder $query, string $tagId) {
+                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
+            })
+            ->with('courses')
+            ->get();
+
+        return TagIndexResource::collection($query);
+    }
+}

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -28,6 +28,7 @@ class TagController extends Controller
     {
         $instructor = Auth::guard('instructor')->user();
         $tags = $instructor->tags()->select('id', 'content')->get();
+
         return TagResource::collection($tags);
     }
 

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -26,7 +26,9 @@ class TagController extends Controller
      */
     public function index()
     {
-        return response()->json([]);
+        $instructor = Auth::guard('instructor')->user();
+        $tags = $instructor->tags()->select('id', 'content')->get();
+        return TagResource::collection($tags);
     }
 
     public function courseIndex(IndexRequest $request)

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -91,13 +91,14 @@ class Instructor extends Authenticatable
      * 配下の講師を取得
      *
      * @return BelongsToMany<Instructor, $this>
+     * @return HasMany<Tag>
      */
     public function managings(): BelongsToMany
     {
         return $this->belongsToMany(Instructor::class, 'manage_instructors', 'manager_id', 'instructor_id');
     }
 
-    public function tags()
+    public function tags(): HasMany
     {
         return $this->hasMany(Tag::class);
     }

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -98,7 +98,7 @@ class Instructor extends Authenticatable
     }
 
     /**
-     * 所有している講座分類を取得
+     * タグを取得
      *
      * @return HasMany<Tag, $this>
      */

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -91,13 +91,19 @@ class Instructor extends Authenticatable
      * 配下の講師を取得
      *
      * @return BelongsToMany<Instructor, $this>
-     * @return HasMany<Tag>
+     *
      */
     public function managings(): BelongsToMany
     {
         return $this->belongsToMany(Instructor::class, 'manage_instructors', 'manager_id', 'instructor_id');
     }
 
+        /**
+     * 配下の講師を取得
+     *
+     *  @return HasMany<Tag, $this>
+     *
+     */
     public function tags(): HasMany
     {
         return $this->hasMany(Tag::class);

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -96,4 +96,9 @@ class Instructor extends Authenticatable
     {
         return $this->belongsToMany(Instructor::class, 'manage_instructors', 'manager_id', 'instructor_id');
     }
+
+    public function tags()
+    {
+        return $this->hasMany(Tag::class);
+    }
 }

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -98,7 +98,7 @@ class Instructor extends Authenticatable
     }
 
     /**
-     * 配下の講師を取得
+     * 所有している講座分類を取得
      *
      * @return HasMany<Tag, $this>
      */

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -91,18 +91,16 @@ class Instructor extends Authenticatable
      * 配下の講師を取得
      *
      * @return BelongsToMany<Instructor, $this>
-     *
      */
     public function managings(): BelongsToMany
     {
         return $this->belongsToMany(Instructor::class, 'manage_instructors', 'manager_id', 'instructor_id');
     }
 
-        /**
+    /**
      * 配下の講師を取得
      *
-     *  @return HasMany<Tag, $this>
-     *
+     * @return HasMany<Tag, $this>
      */
     public function tags(): HasMany
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -73,7 +73,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index']);
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
-                Route::get('tag/index', [App\Http\Controllers\Api\Instructor\TagController::class, 'courseIndex']);
+                Route::get('tag/index', [App\Http\Controllers\Api\Instructor\Course\TagController::class, 'index']);
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'update']);

--- a/tests/Feature/Api/Instructor/Course/Tag/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Course/Tag/IndexTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api\Instructor\Tag;
+namespace Tests\Feature\Api\Instructor\Course\Tag;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -24,10 +24,24 @@ class IndexTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->getJson('/api/v1/instructor/tag/index');
+        $response = $this->getJson('/api/v1/instructor/course/tag/index');
 
         // assert
         $response->assertStatus(200);
         $response->assertJsonCount(2, 'data');
+    }
+
+    public function test_パラメータ指定_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/course/tag/index?tag_id=1');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
     }
 }


### PR DESCRIPTION
## 概要
JKA-1181　ロジックの作成

## 確認
postmanにてログイン中のinstructorが所有するtag_idと分類名(content)が返ってくることを確認

ログイン
id_1
<img width="604" alt="スクリーンショット 2025-04-06 2 06 46" src="https://github.com/user-attachments/assets/f47daf7a-caaf-4cf2-9f8b-79e0a0022621" />


id_2
<img width="604" alt="スクリーンショット 2025-04-06 2 07 15" src="https://github.com/user-attachments/assets/73c3ac4e-5bc5-4874-aa36-fa99d3bcebfb" />


