### PR TITLE
JKA-1158マネージャー側講座分類、詳細API　ロジック作成(yurika)

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -8,8 +8,8 @@ use App\Model\Instructor;
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @tags Manager-Tag
@@ -46,11 +46,12 @@ class TagController extends Controller
             'result' => true,
         ]);
     }
+
     //タグ詳細API
-    public function show(Request $request,$id)
+    public function show(Request $request, $id)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $manager= Instructor::with('managings')->find($instructorId);
+        $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -9,6 +9,7 @@ use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 /**
  * @tags Manager-Tag
@@ -43,6 +44,27 @@ class TagController extends Controller
 
         return response()->json([
             'result' => true,
+        ]);
+    }
+        /**
+     * タグ詳細API
+     */
+    public function show(Request $request, $id)
+    {
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        $tag = Tag::findOrFail($id);
+
+        if ($tag->instructor_id !== $instructorId) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
+
+        return response()->json([
+            'id' => $tag->id,
+            'instructor_id' => $tag->instructor_id,
+            'content' => $tag->content,
+            'created_at' => $tag->created_at,
+            'updated_at' => $tag->updated_at,
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -163,7 +163,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
-                
+
                 // マネージャー-タグ
                 Route::prefix('tag')->group(function () {
                     Route::prefix('{tag_id}')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -163,10 +163,14 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
-
+                
                 // マネージャー-タグ
-                Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'put']);
-
+                Route::prefix('tag')->group(function () {
+                    Route::prefix('{tag_id}')->group(function () {
+                        Route::put('/', [App\Http\Controllers\Api\Manager\TagController::class, 'put']);
+                        Route::get('/', [App\Http\Controllers\Api\Manager\TagController::class, 'show']);
+                    });
+                });
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {
                     Route::post('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'store']);

--- a/tests/Feature/Api/Manager/Tag/ShowTest.php
+++ b/tests/Feature/Api/Manager/Tag/ShowTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Tag;
+
+use App\Model\Instructor;
+use App\Model\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_タグ詳細取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $tag = Tag::find(1);
+
+        // act
+        $response = $this->getJson('/api/v1/manager/tag/1');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'id' => $tag->id,
+            'instructor_id' => $tag->instructor_id,
+            'content' => $tag->content,
+        ]);
+    }
+
+    public function test_権限エラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/tag/1');
+
+        // assert
+        $response->assertStatus(403);
+    }
+
+    public function test_存在しないタグ_id(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/tag/9999');
+
+        // assert
+        $response->assertStatus(404);
+    }
+
+    public function test_不正なタグ_id形式(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/tag/abc');
+
+        // assert
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## issue

## JKA-1158マネージャー側講座分類、詳細API　ロジック作成(yurika)

## 動作確認方法　ポストマンにて確認

1:インストラクターにてログイン中
post[ ](http://localhost:8080/login/instructor) 送信
Json  200 OK　下記　リスポンス　確認
{
    "result": true,
    "message": "Authenticated."
}

2:get[ ](http://localhost:8080/api/v1/manager/tag/1) 送信
Json 200 OK　下記　リスポンス　確認
{
    "id": 1,
    "instructor_id": 1,
    "content": "バックエンド入門編",
    "created_at": "2025-03-14T11:28:01.000000Z",
    "updated_at": "2025-03-14T11:28:01.000000Z"
}