### PR TITLE
　JKA-1194 マネージャー側 講座一覧APIで、検索時に講座名以外に講座分類名での検索を可能にする（伊藤）

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -40,6 +40,7 @@ class CourseController extends Controller
         $perPage = $request->input('per_page', 6);
         $page = $request->input('page', 1);
         $tagId = $request->input('tag_id', null);
+        $searchWord = $request->input('search_word');
 
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -53,6 +54,11 @@ class CourseController extends Controller
         $courses = Course::with('instructor', 'tags')
             ->whereIn('instructor_id', $instructorIds)
             ->when($tagId, fn (Builder $q) => $q->whereHas('tags', fn (Builder $q) => $q->where('tags.id', $tagId)))
+            ->when($searchWord, function (Builder $query) use ($searchWord) {
+                $query->WhereHas('tags', function (Builder $tagQuery) use ($searchWord) {
+                    $tagQuery->where('content', 'like', "%{$searchWord}%");
+                });
+            })
             ->withCount('attendances')
             ->orderBy('id')
             ->paginate($perPage, ['*'], 'page', $page);

--- a/app/Http/Requests/Manager/Course/IndexRequest.php
+++ b/app/Http/Requests/Manager/Course/IndexRequest.php
@@ -25,6 +25,7 @@ class IndexRequest extends FormRequest
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
             'tag_id' => ['nullable', 'integer', 'exists:tags,id'],
+            'search_word' => ['sometimes', 'string']
         ];
     }
 }

--- a/app/Http/Requests/Manager/Course/IndexRequest.php
+++ b/app/Http/Requests/Manager/Course/IndexRequest.php
@@ -25,7 +25,7 @@ class IndexRequest extends FormRequest
             'per_page' => ['integer', 'min:1'],
             'page' => ['integer', 'min:1'],
             'tag_id' => ['nullable', 'integer', 'exists:tags,id'],
-            'search_word' => ['sometimes', 'string']
+            'search_word' => ['sometimes', 'string'],
         ];
     }
 }


### PR DESCRIPTION
## 概要
JKA-1194 マネージャー側 講座一覧APIで、検索時に講座名以外に講座分類名での検索を可能にする

## 確認
postmanでクエリパラメータに講座分類名を入れたときに検索条件にあったレスポンスが返ってくることを確認。

今回のタスクではtitleでの検索機能が入っている前提でしたが、僕がpullした時点ではまだtitleでの検索機能は入っていないように見えましたのでひとまずtagのみで検索できるようにしましたが大丈夫でしょうか？

ログインID
instructor_1

<img width="877" alt="スクリーンショット 2025-04-11 11 42 09" src="https://github.com/user-attachments/assets/63ac7b9c-9717-4aa5-9bef-9e743b72e05f" />
<img width="877" alt="スクリーンショット 2025-04-11 11 42 15" src="https://github.com/user-attachments/assets/0af29929-e87e-4951-a2ed-e407e659429c" />

<img width="877" alt="スクリーンショット 2025-04-11 11 42 30" src="https://github.com/user-attachments/assets/980cfa4c-3e2a-4fbb-af46-dd0803a29d9e" />
