### PR TITLE
jka-1158フォームリクエスト作成(yurika)

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -49,14 +49,14 @@ class TagController extends Controller
     }
 
     //タグ詳細API
-    public function show(ShowRequest $request, $id)
+    public function show(ShowRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $instructorId;
 
-        $tag = Tag::findOrFail($id);
+        $tag = Tag::findOrFail($request->tag_id);
 
         if (! in_array($tag->instructor_id, $instructorIds, true)) {
             // 自分、または配下の講師の講座でなければエラー応答

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -4,12 +4,11 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\PutRequest;
+use App\Http\Requests\Manager\Tag\ShowRequest;
 use App\Model\Instructor;
 use App\Model\Tag;
-use App\Http\Requests\Manager\Tag\ShowRequest;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 /**

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\PutRequest;
 use App\Model\Instructor;
 use App\Model\Tag;
-use App\Http\Requests\ShowTagRequest;
+use App\Http\Requests\Manager\Tag\ShowRequest;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -49,7 +49,7 @@ class TagController extends Controller
     }
 
     //タグ詳細API
-    public function show(ShowTagRequest $request, $id)
+    public function show(ShowRequest $request, $id)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $manager = Instructor::with('managings')->find($instructorId);

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\PutRequest;
 use App\Model\Instructor;
 use App\Model\Tag;
+use App\Http\Requests\ShowTagRequest;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -48,7 +49,7 @@ class TagController extends Controller
     }
 
     //タグ詳細API
-    public function show(Request $request, $id)
+    public function show(ShowTagRequest $request, $id)
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $manager = Instructor::with('managings')->find($instructorId);

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -47,7 +47,9 @@ class TagController extends Controller
         ]);
     }
 
-    //タグ詳細API
+    /**
+     * タグ詳細取得API
+     */
     public function show(ShowRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Requests/Manager/Tag/ShowRequest.php
+++ b/app/Http/Requests/Manager/Tag/ShowRequest.php
@@ -14,7 +14,7 @@ class ShowRequest extends FormRequest
         return true;
     }
 
-    protected function prepareForValidation()
+    protected function prepareForValidation(): void
     {
         $this->merge([
             'tag_id' => $this->route('tag_id'),

--- a/app/Http/Requests/Manager/Tag/ShowRequest.php
+++ b/app/Http/Requests/Manager/Tag/ShowRequest.php
@@ -1,13 +1,10 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Manager\Tag;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Auth\Access\AuthorizationException;
-use App\Model\Tag;
 
-class ShowTagRequest extends FormRequest
+class ShowRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -17,12 +14,13 @@ class ShowTagRequest extends FormRequest
         return true;
     }
 
-     protected function prepareForValidation()
+    protected function prepareForValidation()
     {
         $this->merge([
             'tag_id' => $this->route('tag_id'),
         ]);
     }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -31,7 +29,7 @@ class ShowTagRequest extends FormRequest
     public function rules(): array
     {
         return [
-        'tag_id' => ['required', 'integer', 'exists:tags,id'],
+            'tag_id' => ['required', 'integer', 'exists:tags,id'],
         ];
     }
 }

--- a/app/Http/Requests/ShowTagRequest.php
+++ b/app/Http/Requests/ShowTagRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Access\AuthorizationException;
+use App\Model\Tag;
+
+class ShowTagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+     protected function prepareForValidation()
+    {
+        $this->merge([
+            'tag_id' => $this->route('tag_id'),
+        ]);
+    }
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+        'tag_id' => ['required', 'integer', 'exists:tags,id'],
+        ];
+    }
+}

--- a/tests/Feature/Api/Manager/Tag/ShowTest.php
+++ b/tests/Feature/Api/Manager/Tag/ShowTest.php
@@ -60,7 +60,7 @@ class ShowTest extends TestCase
         $response = $this->getJson('/api/v1/manager/tag/9999');
 
         // assert
-        $response->assertStatus(404);
+        $response->assertStatus(422);
     }
 
     public function test_不正なタグ_id形式(): void
@@ -73,6 +73,6 @@ class ShowTest extends TestCase
         $response = $this->getJson('/api/v1/manager/tag/abc');
 
         // assert
-        $response->assertStatus(404);
+        $response->assertStatus(422);
     }
 }


### PR DESCRIPTION
## issue

## jka-1158 マネージャー側講座分類　詳細API フォームリクエスト作成(yurika)

## ポストマンにて動作確認
１：インストラクターでのログイン　２００　OK
{
    "result": true,
    "message": "Authenticated."
}

２：GET[ ](http://localhost:8080/api/v1/manager/tag/:tag_id)
　　パス関数を使用　　キー：tag_id　値：１
　　ヘッダー　　
　　キー：origin　値：(http://localhost:3000)
　　キー：Refere　値：(http://localhost:3000)
　　キー：tag_id　値：１
３：送信　Json
{
    "id": 1,
    "instructor_id": 1,
    "content": "バックエンド入門編",
    "created_at": "2025-03-14T11:28:01.000000Z",
    "updated_at": "2025-03-14T11:28:01.000000Z"
}