### PR TITLE
JKA-1221　チャプター更新サービスクラスの実装（伊藤）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -93,26 +93,42 @@ class ChapterController extends Controller
         }
     }
 
-    /**
+/**
      * チャプター更新API
      */
-    public function update(PatchRequest $request, UpdateChapterService $service): JsonResponse
-    {
-        $instructorId = Auth::guard('instructor')->id();
+    private UpdateChapterService $updateChapterService;
 
-        $service->__invoke(
-            chapterId: $request->chapter_id,
-            courseId: (int) $request->course_id,
-            requestingInstructorId: $instructorId,
-            allowedInstructorIds: [$instructorId],
-            newTitle: $request->title
+    public function __construct(UpdateChapterService $updateChapterService)
+    {
+        $this->updateChapterService = $updateChapterService;
+    }
+    public function update(PatchRequest $request): JsonResponse
+    {
+        /** @var Instructor $user */
+        $user = Instructor::find(Auth::guard('instructor')->user()->id);
+
+        /** @var Chapter $chapter */
+        $chapter = Chapter::findOrFail($request->chapter_id);
+
+        if ($chapter->course->instructor_id !== $user->id) {
+            // ログインしている講師が作成していないチャプターの更新を許可しない
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
+            throw new AuthorizationException('Invalid course_id.');
+        }
+
+        ($this->updateChapterService)(
+            $request->chapter_id,
+            $request->title
         );
 
         return response()->json([
             'result' => true,
         ]);
     }
-
     /**
      * チャプターの公開/非公開API
      */

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -18,6 +18,7 @@ use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Chapter\QueryService;
+use App\Services\Chapter\UpdateChapterService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -95,27 +96,17 @@ class ChapterController extends Controller
     /**
      * チャプター更新API
      */
-    public function update(PatchRequest $request): JsonResponse
+    public function update(PatchRequest $request, UpdateChapterService $service): JsonResponse
     {
-        /** @var Instructor $user */
-        $user = Instructor::find(Auth::guard('instructor')->user()->id);
+        $instructorId = Auth::guard('instructor')->id();
 
-        /** @var Chapter $chapter */
-        $chapter = Chapter::findOrFail($request->chapter_id);
-
-        if ($chapter->course->instructor_id !== $user->id) {
-            // ログインしている講師が作成していないチャプターの更新を許可しない
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
-
-        if ((int) $request->course_id !== $chapter->course->id) {
-            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
-            throw new AuthorizationException('Invalid course_id.');
-        }
-
-        $chapter->update([
-            'title' => $request->title,
-        ]);
+        $service->__invoke(
+            chapterId: $request->chapter_id,
+            courseId: (int) $request->course_id,
+            requestingInstructorId: $instructorId,
+            allowedInstructorIds: [$instructorId],
+            newTitle: $request->title
+        );
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -93,7 +93,7 @@ class ChapterController extends Controller
         }
     }
 
-/**
+    /**
      * チャプター更新API
      */
     private UpdateChapterService $updateChapterService;
@@ -102,6 +102,7 @@ class ChapterController extends Controller
     {
         $this->updateChapterService = $updateChapterService;
     }
+
     public function update(PatchRequest $request): JsonResponse
     {
         /** @var Instructor $user */
@@ -129,6 +130,7 @@ class ChapterController extends Controller
             'result' => true,
         ]);
     }
+
     /**
      * チャプターの公開/非公開API
      */

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -96,7 +96,7 @@ class ChapterController extends Controller
     /**
      * チャプター更新API
      */
-    public function update(PatchRequest $request, UpdateChapterService $updateChapterService): JsonResponse
+    public function put(PatchRequest $request, UpdateChapterService $updateChapterService): JsonResponse
     {
         /** @var Instructor $user */
         $user = Instructor::find(Auth::guard('instructor')->user()->id);
@@ -106,7 +106,7 @@ class ChapterController extends Controller
 
         if ($chapter->course->instructor_id !== $user->id) {
             // ログインしている講師が作成していないチャプターの更新を許可しない
-            throw new AuthorizationException('Invalid instructor_id.');
+            throw new AuthorizationException('Forbidden, not allowed to this chapter.');
         }
 
         if ((int) $request->course_id !== $chapter->course->id) {

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -102,7 +102,7 @@ class ChapterController extends Controller
     {
         $this->updateChapterService = $updateChapterService;
     }
-    public function update(PatchRequest $request): JsonResponse
+    public function update(PatchRequest $request, UpdateChapterService $updateChapterService): JsonResponse
     {
         /** @var Instructor $user */
         $user = Instructor::find(Auth::guard('instructor')->user()->id);
@@ -120,9 +120,9 @@ class ChapterController extends Controller
             throw new AuthorizationException('Invalid course_id.');
         }
 
-        ($this->updateChapterService)(
-            $request->chapter_id,
-            $request->title
+        $updateChapterService(
+            chapterId: $request->chapter_id,
+            newTitle: $request->title
         );
 
         return response()->json([

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -108,32 +108,51 @@ class ChapterController extends Controller
         }
     }
 
-    /**
+/**
      * チャプター更新API
      *
      * @return JsonResponse
      */
-    public function put(PutRequest $request, UpdateChapterService $service)
+    private UpdateChapterService $updateChapterService;
+
+    public function __construct(UpdateChapterService $updateChapterService)
     {
-        $managerId = Auth::guard('instructor')->id();
+        $this->updateChapterService = $updateChapterService;
+    }
 
+    public function put(PutRequest $request)
+    {
+        // ログイン中の講師IDを取得
+        $managerId = Auth::guard('instructor')->user()->id;
+
+        // マネージャーが管理する講師を取得
         $manager = Instructor::with('managings')->find($managerId);
-        $allowedInstructorIds = $manager->managings->pluck('id')->toArray();
-        $allowedInstructorIds[] = $managerId;
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
 
-        $service->__invoke(
-            chapterId: $request->chapter_id,
-            courseId: (int) $request->course_id,
-            requestingInstructorId: $managerId,
-            allowedInstructorIds: $allowedInstructorIds,
-            newTitle: $request->title
+        // チャプターを取得
+        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
+
+        if (! in_array($chapter->course->instructor_id, $instructorIds, true)) {
+            // 自分、または配下の講師の講座のチャプターでなければエラー応答
+            throw new AuthorizationException('Forbidden, not allowed to this chapter.');
+        }
+
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
+            throw new AuthorizationException('Forbidden, invalid course_id.');
+        }
+
+        // チャプターを更新する
+        ($this->updateChapterService)(
+            $request->chapter_id,
+            $request->title
         );
 
         return response()->json([
             'result' => true,
         ]);
     }
-
     /**
      * チャプター削除API
      *

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -120,7 +120,7 @@ class ChapterController extends Controller
         $this->updateChapterService = $updateChapterService;
     }
 
-    public function put(PutRequest $request)
+    public function put(PutRequest $request,UpdateChapterService $updateChapterService)
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
@@ -143,10 +143,9 @@ class ChapterController extends Controller
             throw new AuthorizationException('Forbidden, invalid course_id.');
         }
 
-        // チャプターを更新する
-        ($this->updateChapterService)(
-            $request->chapter_id,
-            $request->title
+        $updateChapterService(
+            chapterId: $request->chapter_id,
+            newTitle: $request->title
         );
 
         return response()->json([

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -108,7 +108,7 @@ class ChapterController extends Controller
         }
     }
 
-/**
+    /**
      * チャプター更新API
      *
      * @return JsonResponse
@@ -153,6 +153,7 @@ class ChapterController extends Controller
             'result' => true,
         ]);
     }
+
     /**
      * チャプター削除API
      *

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -20,6 +20,7 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
+use App\Services\Chapter\UpdateChapterService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -112,33 +113,21 @@ class ChapterController extends Controller
      *
      * @return JsonResponse
      */
-    public function put(PutRequest $request)
+    public function put(PutRequest $request, UpdateChapterService $service)
     {
-        // ログイン中の講師IDを取得
-        $managerId = Auth::guard('instructor')->user()->id;
+        $managerId = Auth::guard('instructor')->id();
 
-        // マネージャーが管理する講師を取得
         $manager = Instructor::with('managings')->find($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
+        $allowedInstructorIds = $manager->managings->pluck('id')->toArray();
+        $allowedInstructorIds[] = $managerId;
 
-        // チャプターを取得
-        $chapter = Chapter::with('course')->findOrFail($request->chapter_id);
-
-        if (! in_array($chapter->course->instructor_id, $instructorIds, true)) {
-            // 自分、または配下の講師の講座のチャプターでなければエラー応答
-            throw new AuthorizationException('Forbidden, not allowed to this chapter.');
-        }
-
-        if ((int) $request->course_id !== $chapter->course->id) {
-            // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない
-            throw new AuthorizationException('Forbidden, invalid course_id.');
-        }
-
-        // チャプターを更新する
-        $chapter->update([
-            'title' => $request->title,
-        ]);
+        $service->__invoke(
+            chapterId: $request->chapter_id,
+            courseId: (int) $request->course_id,
+            requestingInstructorId: $managerId,
+            allowedInstructorIds: $allowedInstructorIds,
+            newTitle: $request->title
+        );
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -113,7 +113,7 @@ class ChapterController extends Controller
      *
      * @return JsonResponse
      */
-    public function put(PutRequest $request,UpdateChapterService $updateChapterService)
+    public function put(PutRequest $request, UpdateChapterService $updateChapterService)
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -110,10 +110,8 @@ class ChapterController extends Controller
 
     /**
      * チャプター更新API
-     *
-     * @return JsonResponse
      */
-    public function put(PutRequest $request, UpdateChapterService $updateChapterService)
+    public function put(PutRequest $request, UpdateChapterService $updateChapterService): JsonResponse
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;

--- a/app/Services/Chapter/UpdateChapterService.php
+++ b/app/Services/Chapter/UpdateChapterService.php
@@ -8,10 +8,6 @@ class UpdateChapterService
 {
     /**
      * チャプターのタイトルを更新する
-     *
-     * @param int $chapterId
-     * @param string $newTitle
-     * @return void
      */
     public function __invoke(int $chapterId, string $newTitle): void
     {

--- a/app/Services/Chapter/UpdateChapterService.php
+++ b/app/Services/Chapter/UpdateChapterService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services\Chapter;
+
+use App\Model\Chapter;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class UpdateChapterService
+{
+    /**
+     * @param int $chapterId 更新対象のチャプターID
+     * @param int $courseID　チャプターが属する講座のID
+     * @param int $requestingInstructorID 更新を試みる講師またはマネージャーのID
+     * @param int array<int> $allowedInstructorIds 許可された自身や配下の講師ID
+     * @param string $newTitle 新しいチャプタータイトル
+     * @return void
+     * 
+     * @throws AuthorizationException 権限がない場合にスロー
+     */
+    public function __invoke(
+        int $chapterId,
+        int $courseId,
+        int $requestingInstructorId,
+        array $allowedInstructorIds,
+        string $newTitle
+    ): void {
+        $chapter = Chapter::with('course')->findOrFail($chapterId);
+
+        if (!in_array($chapter->course->instructor_id, $allowedInstructorIds, true)){
+            throw new AuthorizationException('Forbidden, not allowed to this chapter.');
+        }
+
+        if ($courseId !== $chapter->course->id) {
+            throw new AuthorizationException('Invalid course_id.');
+        }
+
+        $chapter->update([
+            'title' => $newTitle,
+        ]);
+    }
+}

--- a/app/Services/Chapter/UpdateChapterService.php
+++ b/app/Services/Chapter/UpdateChapterService.php
@@ -3,36 +3,19 @@
 namespace App\Services\Chapter;
 
 use App\Model\Chapter;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class UpdateChapterService
 {
     /**
-     * @param int $chapterId 更新対象のチャプターID
-     * @param int $courseID　チャプターが属する講座のID
-     * @param int $requestingInstructorID 更新を試みる講師またはマネージャーのID
-     * @param int array<int> $allowedInstructorIds 許可された自身や配下の講師ID
-     * @param string $newTitle 新しいチャプタータイトル
+     * チャプターのタイトルを更新する
+     *
+     * @param int $chapterId
+     * @param string $newTitle
      * @return void
-     * 
-     * @throws AuthorizationException 権限がない場合にスロー
      */
-    public function __invoke(
-        int $chapterId,
-        int $courseId,
-        int $requestingInstructorId,
-        array $allowedInstructorIds,
-        string $newTitle
-    ): void {
-        $chapter = Chapter::with('course')->findOrFail($chapterId);
-
-        if (!in_array($chapter->course->instructor_id, $allowedInstructorIds, true)){
-            throw new AuthorizationException('Forbidden, not allowed to this chapter.');
-        }
-
-        if ($courseId !== $chapter->course->id) {
-            throw new AuthorizationException('Invalid course_id.');
-        }
+    public function __invoke(int $chapterId, string $newTitle): void
+    {
+        $chapter = Chapter::findOrFail($chapterId);
 
         $chapter->update([
             'title' => $newTitle,

--- a/routes/api.php
+++ b/routes/api.php
@@ -88,7 +88,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::delete('all', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'deleteAll']);
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'show']);
-                            Route::patch('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'update']);
+                            Route::put('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'put']);
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', [App\Http\Controllers\Api\Instructor\LessonController::class, 'store']);

--- a/tests/Feature/Api/Instructor/Chapter/PutTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/PutTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Chapter;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_チャプター更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/1/chapter/1', [
+            'title' => '更新テスト',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        $this->assertDatabaseHas('chapters', [
+            'id' => 1,
+            'title' => '更新テスト',
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/1/chapter/1', [
+            'title' => '更新テスト',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to this chapter.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/aaa/chapter/bbb', [
+            'title' => '',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'chapter_id',
+            'title',
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要
チャプター更新処理を共通化するための専用サービスクラスを作成し、既存のコントローラからこのサービスを利用するように変更する。

## 確認
postmanにて以下のレスポンスを確認

manager側
Instructor_1
<img width="917" alt="スクリーンショット 2025-04-21 16 20 36" src="https://github.com/user-attachments/assets/7c42efd3-06bd-4caf-8460-79ecef329228" />

instructor側
instructor_2
<img width="917" alt="スクリーンショット 2025-04-21 16 20 56" src="https://github.com/user-attachments/assets/477efeac-6a73-46be-9ec9-b7ac46935296" />

