### PR TITLE
講師側 講座分類 削除API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -74,6 +74,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
                 Route::get('tag/index', [App\Http\Controllers\Api\Instructor\Course\TagController::class, 'index']);
+                Route::delete('tag/{tag_id}', [App\Http\Controllers\Api\Instructor\TagController::class, 'delete']);
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'update']);


### PR DESCRIPTION
## 概要
- 「コースに紐づいているタグを削除する」というAPI新規作成※講師側
空の配列を返すようなルーティングを実装しました。