### PR TITLE
JKA-1220 チャプター新規作成サービスクラスの実装(miyagi)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -76,8 +76,8 @@ class ChapterController extends Controller
             }
 
             $createChapterService(
-                $course,
-                $request->title
+                course: $course,
+                title: $request->title
             );
 
             return response()->json([

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -75,13 +75,14 @@ class ChapterController extends Controller
                 throw new AuthorizationException('Invalid instructor_id for this course.');
             }
 
-            $createChapterService(
+            $chapter = $createChapterService(
                 course: $course,
                 title: $request->title
             );
 
             return response()->json([
                 'result' => true,
+                'chapter_id' => $chapter->id,
             ]);
         } catch (Exception $e) {
             Log::error($e);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -17,6 +17,7 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
+use App\Services\Chapter\CreateChapterService;
 use App\Services\Chapter\QueryService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -57,7 +58,7 @@ class ChapterController extends Controller
     /**
      * チャプター新規作成API
      */
-    public function store(StoreRequest $request): JsonResponse
+    public function store(StoreRequest $request, CreateChapterService $createChapterService): JsonResponse
     {
         try {
             // 講師の情報を取得
@@ -73,14 +74,10 @@ class ChapterController extends Controller
                 throw new AuthorizationException('Invalid instructor_id for this course.');
             }
 
-            $order = $course->chapters->count();
-            $newOrder = $order + 1;
-            Chapter::create([
-                'course_id' => $course->id,
-                'title' => $request->input('title'),
-                'order' => $newOrder,
-                'status' => Chapter::STATUS_PUBLIC,
-            ]);
+            $createChapterService(
+                $course,
+                $request->title
+            );
 
             return response()->json([
                 'result' => true,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -20,6 +20,7 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
+use App\Services\Chapter\CreateChapterService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -68,7 +69,7 @@ class ChapterController extends Controller
      *
      * @return JsonResponse
      */
-    public function store(StoreRequest $request)
+    public function store(StoreRequest $request, CreateChapterService $createChapterService)
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
@@ -87,14 +88,10 @@ class ChapterController extends Controller
         }
 
         try {
-            $order = $course->chapters->count();
-            $newOrder = $order + 1;
-            $chapter = Chapter::create([
-                'course_id' => $request->course_id,
-                'title' => $request->input('title'),
-                'order' => $newOrder,
-                'status' => Chapter::STATUS_PUBLIC,
-            ]);
+            $chapter = $createChapterService(
+                $course,
+                $request->title
+            );
 
             return response()->json([
                 'result' => true,
@@ -178,7 +175,7 @@ class ChapterController extends Controller
 
         if (
             LessonAttendance::whereIn('lesson_id', $lessonIds)
-                ->exists()
+            ->exists()
         ) {
             // 指定したチャプター内に受講中のレッスンがあればエラー応答
             throw new AuthorizationException('Forbidden, this lesson has attendance.');

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -174,7 +174,7 @@ class ChapterController extends Controller
 
         if (
             LessonAttendance::whereIn('lesson_id', $lessonIds)
-            ->exists()
+                ->exists()
         ) {
             // 指定したチャプター内に受講中のレッスンがあればエラー応答
             throw new AuthorizationException('Forbidden, this lesson has attendance.');

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -90,8 +90,8 @@ class ChapterController extends Controller
 
         try {
             $chapter = $createChapterService(
-                $course,
-                $request->title
+                course: $course,
+                title: $request->title
             );
 
             return response()->json([

--- a/app/Services/Chapter/CreateChapterService.php
+++ b/app/Services/Chapter/CreateChapterService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services\Chapter;
+
+use App\Model\Chapter;
+use App\Model\Course;
+
+class CreateChapterService
+{
+    /**
+     * チャプター新規作成サービス
+     */
+    public function __invoke(Course $course, string $title): Chapter
+    {
+        $order = $course->chapters->count();
+        $newOrder = $order + 1;
+
+        // チャプター新規作成
+        return Chapter::create([
+            'course_id' => $course->id,
+            'title' => $title,
+            'order' => $newOrder,
+            'status' => Chapter::STATUS_PUBLIC,
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Chapter/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/StoreTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Chapter;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_チャプター登録_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+            'chapter_id',
+        ]);
+        $this->assertDatabaseHas('chapters', [
+            'course_id' => 1,
+            'title' => 'title',
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter', [
+            'title' => 'title',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Invalid instructor_id for this course.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/aaa/chapter', [
+            'title' => '',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'title',
+        ]);
+    }
+}


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1220

## 概要
- チャプター新規作成サービスクラスの実装

## 動作確認
- Postmanにて動作確認
1. 下記の講師(マネージャー)でログイン
    - HTTPメソッド：POST
    - URL：http://localhost:8080/login/instructor
    - email：test_instructor@example.com
    - password：password
    - 結果：200 OK
```
{
    "result": true,
    "message": "Authenticated."
}
```
2. 下記条件にてチャプター新規作成
    - HTTPメソッド：POST
    - URL：http://localhost:8080/api/v1/manager/course/1/chapter
    - title：PHPの応用にチャレンジしよう2
    - 結果：200 OK
```
{
    "result": true,
    "chapter_id": 7
}
```
3. 上記の講師をログアウトし下記の講師(インストラクター)でログイン
    - HTTPメソッド：POST
    - URL：http://localhost:8080/login/instructor
    - email：test_instructor2@example.com
    - password：password
    - 結果：200 OK
```
{
    "result": true,
    "message": "Authenticated."
}
```
4. 下記条件にてチャプター新規作成
    - HTTPメソッド：POST
    - URL：http://localhost:8080/api/v1/instructor/course/2/chapter
    - title：Laravelの応用にチャレンジしよう
    - 結果：200 OK
```
{
    "result": true
}
```

## 確認したいこと
- 今回実装したサービスクラスにて __invokeメソッドでChapterクラスをreturnしています。
こちらの件で確認ですが
Manager/ChapterController.phpではreturnされたオブジェクトを使用していますが
Instructor/ChapterController.phpではreturnされたオブジェクトを使用していません。
returnがChapterクラスの実装で問題ないでしょうか？