### PR TITLE
jka-1242 空の配列を返すルーターとコントローラの作成(miyagi)

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -99,8 +99,6 @@ class TagController extends Controller
      */
     public function delete(): JsonResponse
     {
-        return response()->json([
-            
-        ]);
+        return response()->json([]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -93,4 +93,14 @@ class TagController extends Controller
             'result' => true,
         ]);
     }
+
+    /**
+     * タグ削除API
+     */
+    public function delete(): JsonResponse
+    {
+        return response()->json([
+            
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -168,8 +168,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('manager')->group(function () {
 
                 // マネージャー-タグ
-                Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'put']);
-
+                Route::prefix('tag')->group(function () {
+                    Route::prefix('{tag_id}')->group(function () {
+                        Route::put('/', [App\Http\Controllers\Api\Manager\TagController::class, 'put']);
+                        Route::delete('/', [App\Http\Controllers\Api\Manager\TagController::class, 'delete']);
+                    });
+                });
                 // マネージャー-講師
                 Route::prefix('instructor')->group(function () {
                     Route::post('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'store']);


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1242

## 概要
- マネージャー側 講座分類 削除APIの空の配列を返すルーターとコントローラ

## 動作確認
- Postmanにて動作確認
1. 下記の講師(マネージャー)でログイン
    - HTTPメソッド：POST
    - URL：http://localhost:8080/login/instructor
    - email：test_instructor@example.com
    - password：password
    - 結果：200 OK
```
{
    "result": true,
    "message": "Authenticated."
}
```
2. 下記条件にて空の配列を返すことを確認
    - HTTPメソッド：DELETE
    - URL：http://localhost:8080/api/v1/manager/tag/1
    - 結果：200 OK
```
[]
```
