### PR TITLE
JKA-1243 マネージャ側 講座分類削除API ロジックの作成(miyagi)

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -99,14 +99,13 @@ class TagController extends Controller
      */
     public function delete(int $tag_id): JsonResponse
     {
+        // マネージャーが管理する講師IDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
 
         /** @var Instructor $manager */
-        $manager = Auth::guard('instructor')->user();
-        $manager->load('managings');
-
-        // 自身のIDとその配下にいる講師のIDを取得
+        $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id; // 自身のIDを追加
+        $instructorIds[] = $manager->id; // 自身のIDも追加
 
         // タグの取得
         $tag = Tag::findOrFail($tag_id);
@@ -118,7 +117,7 @@ class TagController extends Controller
 
         // タグに関連付けられた講座がある場合は削除不可
         if ($tag->courses()->exists()) {
-            throw new AuthorizationException('Invalid tag_id.');
+            throw new AuthorizationException('There is a course linked to the tag.');
         }
 
         // タグの削除

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -117,7 +117,7 @@ class TagController extends Controller
 
         // タグに関連付けられた講座がある場合は削除不可
         if ($tag->courses()->exists()) {
-            throw new AuthorizationException('There is a course linked to the tag.');
+            throw new AuthorizationException('Forbidden, this tag is linked to courses.');
         }
 
         // タグの削除

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -97,8 +97,35 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(): JsonResponse
+    public function delete(int $tag_id): JsonResponse
     {
-        return response()->json([]);
+
+        /** @var Instructor $manager */
+        $manager = Auth::guard('instructor')->user();
+        $manager->load('managings');
+
+        // 自身のIDとその配下にいる講師のIDを取得
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id; // 自身のIDを追加
+
+        // タグの取得
+        $tag = Tag::findOrFail($tag_id);
+
+        // 自身または配下のインストラクターが作成したタグ以外は削除不可
+        if (! in_array($tag->instructor_id, $instructorIds, true)) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
+
+        // タグに関連付けられた講座がある場合は削除不可
+        if ($tag->courses()->exists()) {
+            throw new AuthorizationException('Invalid tag_id.');
+        }
+
+        // タグの削除
+        $tag->delete();
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 }

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -50,6 +50,12 @@ class TagSeeder extends Seeder
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ],
+            [
+                'instructor_id' => 1,
+                'content' => '削除用のタグ',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
         ]);
     }
 }

--- a/tests/Feature/Api/Instructor/Course/Tag/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Course/Tag/IndexTest.php
@@ -28,7 +28,7 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
-        $response->assertJsonCount(2, 'data');
+        $response->assertJsonCount(3, 'data');
     }
 
     public function test_パラメータ指定_成功(): void

--- a/tests/Feature/Api/Instructor/Tag/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Tag/IndexTest.php
@@ -28,6 +28,6 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
-        $response->assertJsonCount(2, 'data');
+        $response->assertJsonCount(3, 'data');
     }
 }

--- a/tests/Feature/Api/Manager/Tag/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Tag/DeleteTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Tag;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_タグ削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/tag/7');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'result' => true,
+        ]);
+        $this->assertDatabaseMissing('tags', [
+            'id' => 7,
+        ]);
+    }
+
+    public function test_タグに紐づく講座が存在_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/tag/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, this tag is linked to courses.',
+        ]);
+    }
+
+    public function test_権限がないマネージャーで認証_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/tag/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid instructor_id.',
+        ]);
+    }
+
+    public function test_権限エラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/tag/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+
+    //     // act
+    //     $response = $this->deleteJson('/api/v1/manager/tag/aaa');
+
+    //     // assert
+    //     $response->assertStatus(422);
+    //     $response->assertJsonValidationErrors([
+    //         'tag_id',
+    //     ]);
+    // }
+}

--- a/tests/Feature/Api/Manager/Tag/IndexTest.php
+++ b/tests/Feature/Api/Manager/Tag/IndexTest.php
@@ -27,7 +27,7 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
-        // $response->assertJsonCount(3, 'data');
+        $response->assertJsonCount(6, 'data');
     }
 
     public function test_パラメータ指定_成功(): void
@@ -41,40 +41,19 @@ class IndexTest extends TestCase
 
         // assert
         $response->assertStatus(200);
-        // $response->assertJsonCount(2, 'data');
+        $response->assertJsonCount(1, 'data');
     }
 
-    // public function test_権限エラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(2);
-    //     $this->actingAs($instructor, 'instructor');
+    public function test_権限エラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
 
-    //     // act
-    //     $response = $this->getJson('/api/v1/manager/tag/1', [
-    //         'content' => 'test',
-    //     ]);
+        // act
+        $response = $this->getJson('/api/v1/manager/course/tag/index');
 
-    //     // assert
-    //     $response->assertStatus(403);
-    // }
-
-    // public function test_バリデーションエラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(1);
-    //     $this->actingAs($instructor, 'instructor');
-
-    //     // act
-    //     $response = $this->getJson('/api/v1/manager/tag/aaa', [
-    //         'content' => '',
-    //     ]);
-
-    //     // assert
-    //     $response->assertStatus(422);
-    //     $response->assertJsonValidationErrors([
-    //         'tag_id',
-    //         'content',
-    //     ]);
-    // }
+        // assert
+        $response->assertStatus(403);
+    }
 }

--- a/tests/Feature/Api/Manager/Tag/PutTest.php
+++ b/tests/Feature/Api/Manager/Tag/PutTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api\Manager\Tag;
 
-use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -22,8 +21,6 @@ class PutTest extends TestCase
         // arrange
         $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
-
-        $course = Course::find(1);
 
         // act
         $response = $this->putJson('/api/v1/manager/tag/1', [


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1243

## 概要
- マネージャ側 講座分類削除API ロジックの作成

## 動作確認前作業
- テストデータ準備：Adminer にて下記の講座分類を追加する（id = 7）
  - テーブル：tags
  - instructor_id：1
  - content：バックエンド応用編_削除用
- 下記の講師(マネージャー)でログイン
  - メソッド：POST
  - URL：http://localhost:8080/login/instructor
  - email：test_instructor@example.com
  - password：password
  - 結果：`200 OK`
    ```json
    {
        "result": true,
        "message": "Authenticated."
    }
    ```

## 動作確認（Postman）

1. **異常系テスト（tagsテーブルに存在しない講座分類を削除）**
   - DELETE http://localhost:8080/api/v1/manager/tag/999
   - 結果：`404 Not Found`
     ```json
     {
         "message": "No query results for model [App\\Model\\Tag] 999",
         "exception": "Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException",
     }
     ```

2. **異常系テスト（自身または配下のインストラクター以外が作成した講座分類を削除）**
   - DELETE http://localhost:8080/api/v1/manager/tag/4
   - 結果：`403 Forbidden`
     ```json
     {
         "message": "Forbidden, invalid instructor_id."
     }
     ```

3. **異常系テスト（講座分類に関連付けられた講座がある場合に講座分類を削除）**
   - DELETE http://localhost:8080/api/v1/manager/tag/1
   - 結果：`403 Forbidden`
     ```json
     {
         "message": "Forbidden, this tag is linked to courses."
     }
     ```
4. **正常系テスト（動作確認前作業にて作成した講座を削除 id = 7）**
   - DELETE http://localhost:8080/api/v1/manager/tag/7
   - 結果：`200 OK`
     ```json
     {
         "result": true
     }
     ```
    - Adminer にて削除対象のデータ（id = 7）が削除されているか確認