### PR TITLE
JKA-1244 マネージャ側 講座分類削除API フォームリクエストの作成(miyagi)

### DIFF
--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Manager\Tag\DeleteRequest;
 use App\Http\Requests\Manager\Tag\IndexRequest;
 use App\Http\Requests\Manager\Tag\PutRequest;
-use App\Http\Requests\Manager\Tag\DeleteRequest;
 use App\Http\Resources\Manager\TagIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Manager;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Tag\IndexRequest;
 use App\Http\Requests\Manager\Tag\PutRequest;
+use App\Http\Requests\Manager\Tag\DeleteRequest;
 use App\Http\Resources\Manager\TagIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
@@ -97,7 +98,7 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(int $tag_id): JsonResponse
+    public function delete(DeleteRequest $request): JsonResponse
     {
         // マネージャーが管理する講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -108,7 +109,7 @@ class TagController extends Controller
         $instructorIds[] = $manager->id; // 自身のIDも追加
 
         // タグの取得
-        $tag = Tag::findOrFail($tag_id);
+        $tag = Tag::findOrFail($request->tag_id);
 
         // 自身または配下のインストラクターが作成したタグ以外は削除不可
         if (! in_array($tag->instructor_id, $instructorIds, true)) {

--- a/app/Http/Requests/Manager/Tag/DeleteRequest.php
+++ b/app/Http/Requests/Manager/Tag/DeleteRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Manager\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'tag_id' => $this->route('tag_id'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'tag_id' => ['required', 'integer', 'exists:tags,id'],
+        ];
+    }
+}

--- a/tests/Feature/Api/Manager/Tag/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Tag/DeleteTest.php
@@ -83,19 +83,19 @@ class DeleteTest extends TestCase
         ]);
     }
 
-    // public function test_バリデーションエラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(1);
-    //     $this->actingAs($instructor, 'instructor');
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
 
-    //     // act
-    //     $response = $this->deleteJson('/api/v1/manager/tag/aaa');
+        // act
+        $response = $this->deleteJson('/api/v1/manager/tag/aaa');
 
-    //     // assert
-    //     $response->assertStatus(422);
-    //     $response->assertJsonValidationErrors([
-    //         'tag_id',
-    //     ]);
-    // }
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'tag_id',
+        ]);
+    }
 }


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1244

## 概要
- マネージャ側 講座分類削除API フォームリクエストの作成

## 動作確認（Postman）
1. **異常系テスト（`tag_id` が数値ではない、文字列など）**
   - DELETE http://localhost:8080/api/v1/manager/tag/abc
   - 結果：`422 Unprocessable Content`
     ```json
     {
        "message": "The tag id must be an integer.",
        "errors": {
            "tag_id": [
                "The tag id must be an integer."
            ]
        }
     }
     ```

2. **異常系テスト（`tag_id` が `tags` テーブルに存在しない）**
   - DELETE http://localhost:8080/api/v1/manager/tag/999
   - 結果：`422 Unprocessable Content`
     ```json
     {
         "message": "The selected tag id is invalid.",
         "errors": {
             "tag_id": [
                "The selected tag id is invalid."
             ]
         }
     }
     ```
