### PR TITLE
Feature/yurika/jka 1246/make serviceclass

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -11,10 +11,8 @@ use App\Http\Requests\Instructor\Lesson\PutRequest;
 use App\Http\Requests\Instructor\Lesson\PutStatusRequest;
 use App\Http\Requests\Instructor\Lesson\SortRequest;
 use App\Http\Requests\Instructor\Lesson\StoreRequest;
-use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\Lesson\UpdateStatusRequest;
 use App\Http\Requests\Instructor\Lesson\UpdateTitleRequest;
-use App\Services\Lesson\UpdateLessonStatusService;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;
@@ -22,6 +20,7 @@ use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\SortLessonsService;
+use App\Services\Lesson\UpdateLessonStatusService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -228,7 +227,7 @@ class LessonController extends Controller
     /**
      * レッスンステータス更新API
      */
-    public function updateStatus(UpdateStatusRequest $request,UpdateLessonStatusService $updateLessonStatusService): JsonResponse 
+    public function updateStatus(UpdateStatusRequest $request, UpdateLessonStatusService $updateLessonStatusService): JsonResponse
     {
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -11,8 +11,10 @@ use App\Http\Requests\Instructor\Lesson\PutRequest;
 use App\Http\Requests\Instructor\Lesson\PutStatusRequest;
 use App\Http\Requests\Instructor\Lesson\SortRequest;
 use App\Http\Requests\Instructor\Lesson\StoreRequest;
+use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\Lesson\UpdateStatusRequest;
 use App\Http\Requests\Instructor\Lesson\UpdateTitleRequest;
+use App\services\Lesson\UpdateLessonStatusService;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;
@@ -226,7 +228,7 @@ class LessonController extends Controller
     /**
      * レッスンステータス更新API
      */
-    public function updateStatus(UpdateStatusRequest $request): JsonResponse
+    public function updateStatus(Request $request, UpdateLessonStatusService $updateLessonStatusService): JsonResponse
     {
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
 
@@ -239,9 +241,8 @@ class LessonController extends Controller
             throw new AuthorizationException('Invalid chapter_id.');
         }
 
-        $lesson->update([
-            'status' => $request->status,
-        ]);
+        // サービスの呼び出し（関数のように使える）
+        $updateLessonStatusService($lesson, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -14,7 +14,7 @@ use App\Http\Requests\Instructor\Lesson\StoreRequest;
 use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\Lesson\UpdateStatusRequest;
 use App\Http\Requests\Instructor\Lesson\UpdateTitleRequest;
-use App\services\Lesson\UpdateLessonStatusService;
+use App\Services\Lesson\UpdateLessonStatusService;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -228,7 +228,7 @@ class LessonController extends Controller
     /**
      * レッスンステータス更新API
      */
-    public function updateStatus(Request $request, UpdateLessonStatusService $updateLessonStatusService): JsonResponse
+    public function updateStatus(UpdateStatusRequest $request,UpdateLessonStatusService $updateLessonStatusService): JsonResponse 
     {
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -18,6 +18,7 @@ use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
+use App\services\Lesson\UpdateLessonStatusService;
 use App\Model\LessonAttendance;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -264,7 +265,7 @@ class LessonController extends Controller
     /**
      * レッスンステータス更新API
      */
-    public function updateStatus(UpdateStatusRequest $request): JsonResponse
+    public function updateStatus(lesson $request, UpdateLessonStatusService $updateLessonStatusService): JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -291,9 +292,9 @@ class LessonController extends Controller
             throw new ValidationErrorException('Invalid chapter_id.');
         }
 
-        $lesson->update([
-            'status' => $request->status,
-        ]);
+        $lesson = Lesson::findOrFail($request->lesson_id);
+        // サービスの呼び出し（関数のように使える）
+        $updateLessonStatusService($lesson, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -18,7 +18,7 @@ use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
-use App\services\Lesson\UpdateLessonStatusService;
+use App\Services\Lesson\UpdateLessonStatusService;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\SortLessonsService;
 use Exception;

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -253,7 +253,7 @@ class LessonController extends Controller
     /**
      * レッスンステータス更新API
      */
-    public function updateStatus(lesson $request, UpdateLessonStatusService $updateLessonStatusService): JsonResponse
+    public function updateStatus(UpdateStatusRequest $request,UpdateLessonStatusService $updateLessonStatusService): JsonResponse 
     {
         $managerId = Auth::guard('instructor')->user()->id;
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -18,9 +18,9 @@ use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
-use App\Services\Lesson\UpdateLessonStatusService;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\SortLessonsService;
+use App\Services\Lesson\UpdateLessonStatusService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -253,7 +253,7 @@ class LessonController extends Controller
     /**
      * レッスンステータス更新API
      */
-    public function updateStatus(UpdateStatusRequest $request,UpdateLessonStatusService $updateLessonStatusService): JsonResponse 
+    public function updateStatus(UpdateStatusRequest $request, UpdateLessonStatusService $updateLessonStatusService): JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 

--- a/app/Services/Lesson/UpdateLessonStatusService.php
+++ b/app/Services/Lesson/UpdateLessonStatusService.php
@@ -11,7 +11,6 @@ class UpdateLessonStatusService
      *
      * @param  Lesson  $lesson
      * @param  string  $status
-     * @return Lesson
      */
     public function __invoke(Lesson $lesson, string $status): void
     {

--- a/app/Services/Lesson/UpdateLessonStatusService.php
+++ b/app/Services/Lesson/UpdateLessonStatusService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Lesson;
+
+use App\Model\Lesson;
+
+class UpdateLessonStatusService
+{
+    /**
+     * レッスンのステータスを更新する
+     *
+     * @param  Lesson  $lesson
+     * @param  string  $status
+     * @return Lesson
+     */
+    public function __invoke(Lesson $lesson, string $status): void
+    {
+        $lesson->update([
+            'status' => $status,
+        ]);
+    }
+}

--- a/app/Services/Lesson/UpdateLessonStatusService.php
+++ b/app/Services/Lesson/UpdateLessonStatusService.php
@@ -8,9 +8,6 @@ class UpdateLessonStatusService
 {
     /**
      * レッスンのステータスを更新する
-     *
-     * @param  Lesson  $lesson
-     * @param  string  $status
      */
     public function __invoke(Lesson $lesson, string $status): void
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -166,8 +166,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
-                Route::patch('/lessons/status', [LessonController::class, 'updateLessonStatus']);
-
                 // マネージャー-タグ
                 Route::prefix('tag')->group(function () {
                     Route::prefix('{tag_id}')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -166,6 +166,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::middleware('manager')->group(function () {
             // マネージャーAPIはここに記述
             Route::prefix('manager')->group(function () {
+                Route::patch('/lessons/status', [LessonController::class, 'updateLessonStatus']);
 
                 // マネージャー-タグ
                 Route::put('tag/{tag_id}', [App\Http\Controllers\Api\Manager\TagController::class, 'put']);


### PR DESCRIPTION
## issue

## JKA-1230 レッスンステータス更新サービスクラスの実装

## ポストマンにて動作確認
manager/instructor　　ログイン
ボディ　Raw  Jsonを選択
ヘッダー　Content-type   aplication/json
スクリプト　Pre-request
pm.environment.set("variable_key", "variable_value");
pm.sendRequest({
    url: 'http://localhost:8080/sanctum/csrf-cookie',
    method: 'GET'
}, function (error, response, { cookies }) {
    let xsrfCookie = cookies.one('XSRF-TOKEN');
    if (xsrfCookie) {
        let xsrfToken = decodeURIComponent(xsrfCookie['value']);
        console.log(xsrfToken);
        pm.request.headers.upsert({
            key: 'X-XSRF-TOKEN',
            value: xsrfToken,
        });                
        pm.environment.set('XSRF-TOKEN', xsrfToken);
    }
})
送信　２００　OK
{
Patch　(http://localhost:8080/api/v1/instructor/course/:course_id/chapter/:chapter_id/lesson/:lesson_id/status?status=public)   
パラメーター　キー：status 値：public
パス変数　キー：course_id　値：１　キー：chapter_id　値：１　キー：lesson_id　値：１
ヘッダー　
キー：X-XSRF-TOKEN　値：{{XSRF-TOKEN}}
キー：Referer　値：(http://localhost:3000)
キー：Origin　値：(http://localhost:3000)
スクリプト　　同上
送信　２００　OK json
{
    "result": true
}