### PR TITLE
JKA-1229 レッスン更新サービスクラスの実装(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -20,6 +20,7 @@ use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\SortLessonsService;
+use App\Services\Lesson\UpdateLessonService;
 use App\Services\Lesson\UpdateLessonStatusService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -79,7 +80,7 @@ class LessonController extends Controller
     /**
      * レッスン更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, UpdateLessonService $service): JsonResponse
     {
         $user = Instructor::find($request->user()->id);
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
@@ -97,12 +98,8 @@ class LessonController extends Controller
             throw new AuthorizationException('Forbidden, invalid chapter_id.');
         }
 
-        $lesson->update([
-            'title' => $request->title,
-            'url' => $request->url,
-            'remarks' => $request->remarks,
-            'status' => $request->status,
-        ]);
+        // UpdateLessonServiceを呼び出し更新処理
+        $service($lesson, $request->only(['title', 'url', 'remarks', 'status']));
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -99,7 +99,7 @@ class LessonController extends Controller
         }
 
         // UpdateLessonServiceを呼び出し更新処理
-        $service($lesson, $request->only(['title', 'url', 'remarks', 'status']));
+        $service($lesson, $request->title, $request->url, $request->remarks, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -122,7 +122,7 @@ class LessonController extends Controller
         }
 
         // UpdateLessonServiceを呼び出し更新処理
-        $service($lesson, $request->only(['title', 'url', 'remarks', 'status']));
+        $service($lesson, $request->title, $request->url, $request->remarks, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -20,6 +20,7 @@ use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\SortLessonsService;
+use App\Services\Lesson\UpdateLessonService;
 use App\Services\Lesson\UpdateLessonStatusService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -91,7 +92,7 @@ class LessonController extends Controller
     /**
      * レッスン更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, UpdateLessonService $service): JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -120,12 +121,8 @@ class LessonController extends Controller
             throw new AuthorizationException('Invalid chapter_id.');
         }
 
-        $lesson->update([
-            'title' => $request->title,
-            'url' => $request->url,
-            'remarks' => $request->remarks,
-            'status' => $request->status,
-        ]);
+        // UpdateLessonServiceを呼び出し更新処理
+        $service($lesson, $request->only(['title', 'url', 'remarks', 'status']));
 
         return response()->json([
             'result' => true,

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -5,18 +5,18 @@ namespace App\Services\Lesson;
 use App\Model\Lesson;
 
 class UpdateLessonService
-    /**
-    * レッスン内容を更新する
-     *
-     * @param Lesson $lesson
-     * @param array{
-     *     title: string,
-     *     url: string,
-     *     remarks: string|null,
-     *     status: string
-     * } $data 更新するデータ
-     * @return void
-     */
+/**
+ * レッスン内容を更新する
+ *
+ * @param  Lesson  $lesson
+ * @param array{
+ *     title: string,
+ *     url: string,
+ *     remarks: string|null,
+ *     status: string
+ * } $data 更新するデータ
+ * @return void
+ */
 {
     public function __invoke(Lesson $lesson, string $title, string $url, ?string $remarks, string $status): void
     {

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -10,8 +10,16 @@ class UpdateLessonService
     {
         /**
          * レッスン内容を更新する
+         *
+         * @param Lesson $lesson
+         * @param array{
+         *     title: string,
+         *     url: string,
+         *     remarks: string|null,
+         *     status: int
+         * } $data 更新するデータ
+         * @return void
          */
-
         $lesson->update([
             'title' => $data['title'],
             'url' => $data['url'],

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Lesson;
+
+use App\Model\Lesson;
+
+class UpdateLessonService
+{
+    public function __invoke(Lesson $lesson, array $data): void
+    {
+        /**
+         * レッスン内容を更新する
+         */
+
+        $lesson->update([
+            'title' => $data['title'],
+            'url' => $data['url'],
+            'remarks' => $data['remarks'],
+            'status' => $data['status'],
+        ]);
+    }
+}

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -8,13 +8,6 @@ class UpdateLessonService
 {
     /**
      * レッスン内容を更新する
-     *
-     * @param array{
-     *     title: string,
-     *     url: string,
-     *     remarks: string|null,
-     *     status: string
-     * } $data 更新するデータ
      */
     public function __invoke(Lesson $lesson, string $title, string $url, ?string $remarks, string $status): void
     {

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -5,26 +5,26 @@ namespace App\Services\Lesson;
 use App\Model\Lesson;
 
 class UpdateLessonService
+    /**
+    * レッスン内容を更新する
+     *
+     * @param Lesson $lesson
+     * @param array{
+     *     title: string,
+     *     url: string,
+     *     remarks: string|null,
+     *     status: string
+     * } $data 更新するデータ
+     * @return void
+     */
 {
-    public function __invoke(Lesson $lesson, array $data): void
+    public function __invoke(Lesson $lesson, string $title, string $url, ?string $remarks, string $status): void
     {
-        /**
-         * レッスン内容を更新する
-         *
-         * @param Lesson $lesson
-         * @param array{
-         *     title: string,
-         *     url: string,
-         *     remarks: string|null,
-         *     status: string
-         * } $data 更新するデータ
-         * @return void
-         */
         $lesson->update([
-            'title' => $data['title'],
-            'url' => $data['url'],
-            'remarks' => $data['remarks'],
-            'status' => $data['status'],
+            'title' => $title,
+            'url' => $url,
+            'remarks' => $remarks,
+            'status' => $status,
         ]);
     }
 }

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -11,7 +11,7 @@ class UpdateLessonService
         /**
          * レッスン内容を更新する
          *
-         * @param Lesson $lesson
+         * @param  Lesson  $lesson
          * @param array{
          *     title: string,
          *     url: string,

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -7,16 +7,14 @@ use App\Model\Lesson;
 class UpdateLessonService
 {
     /**
-    * レッスン内容を更新する
+     * レッスン内容を更新する
      *
-     * @param Lesson $lesson
      * @param array{
      *     title: string,
      *     url: string,
      *     remarks: string|null,
      *     status: string
      * } $data 更新するデータ
-     * @return void
      */
     public function __invoke(Lesson $lesson, string $title, string $url, ?string $remarks, string $status): void
     {

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -5,6 +5,7 @@ namespace App\Services\Lesson;
 use App\Model\Lesson;
 
 class UpdateLessonService
+{
     /**
     * レッスン内容を更新する
      *
@@ -17,7 +18,6 @@ class UpdateLessonService
      * } $data 更新するデータ
      * @return void
      */
-{
     public function __invoke(Lesson $lesson, string $title, string $url, ?string $remarks, string $status): void
     {
         $lesson->update([

--- a/app/Services/Lesson/UpdateLessonService.php
+++ b/app/Services/Lesson/UpdateLessonService.php
@@ -16,7 +16,7 @@ class UpdateLessonService
          *     title: string,
          *     url: string,
          *     remarks: string|null,
-         *     status: int
+         *     status: string
          * } $data 更新するデータ
          * @return void
          */


### PR DESCRIPTION
## issue
・JKA-1229 レッスン更新サービスクラスの実装

## 処理内容
・【app/Services/Lesson/UpdateLessonService.php】を作成
　*Manager及びInstructor用Controllerの更新ロジックを実装
・Manager及びInstructor用のLessonController内の ``` put ```メソッドの更新部分をUpdateLessonService.php呼び出しに修正

## テスト
・Manegerでないユーザ ``(UserId:1)`` 及びManagerのユーザ ``(UserId:2)`` による更新処理を実施
![スクリーンショット (39)](https://github.com/user-attachments/assets/a61129c8-2c33-49ef-be68-6b681f527df3)
![スクリーンショット (38)](https://github.com/user-attachments/assets/1a65b214-3373-4c6a-838e-92856dbc6dbc)

*ケース1:Manager以外のユーザ ``(UserId:1)``による更新処理
![スクリーンショット (34)](https://github.com/user-attachments/assets/ec3bb3ef-a6fb-4f1e-851b-42fc3cfcf7b9)
![スクリーンショット (35)](https://github.com/user-attachments/assets/17aa87d3-50b3-440f-b7cf-e8b7e174bdf6)

*ケース2:Managerのユーザ ``(UserId:2)``による更新処理
![スクリーンショット (36)](https://github.com/user-attachments/assets/cd59180b-37ab-4734-8a1a-558f49027ad5)
![スクリーンショット (37)](https://github.com/user-attachments/assets/73a862b2-2834-483e-9591-a26c44fe6ad0)

・データベース更新状況
![スクリーンショット (40)](https://github.com/user-attachments/assets/ef3ec1a9-9338-4672-b1fa-a3eda0d723d6)

## その他
・Jiraの実装説明指示通り、developから直接featureブランチを切って実装