### PR TITLE
JKA-1226 講座の全チャプターステータス更新サービスクラスの実装(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -288,7 +288,7 @@ class ChapterController extends Controller
 
         if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
             // ログインしていない講師の更新を許可しない
-            throw new AuthorizationException('Not authorized.');
+            throw new AuthorizationException('Forbidden, invalid course_id.');
         }
 
         $service($request->course_id, $request->status);

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -21,6 +21,7 @@ use App\Services\Chapter\BulkDeleteChapterService;
 use App\Services\Chapter\CreateChapterService;
 use App\Services\Chapter\QueryService;
 use App\Services\Chapter\SortChaptersService;
+use App\Services\Chapter\UpdateAllChaptersStatusService;
 use App\Services\Chapter\UpdateChapterService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -280,7 +281,7 @@ class ChapterController extends Controller
     /**
      * チャプター一括更新API
      */
-    public function putStatus(PutStatusRequest $request): JsonResponse
+    public function putStatus(PutStatusRequest $request, UpdateAllChaptersStatusService $service): JsonResponse
     {
         /** @var Course $course */
         $course = Course::findOrFail($request->course_id);
@@ -290,7 +291,7 @@ class ChapterController extends Controller
             throw new AuthorizationException('Not authorized.');
         }
 
-        Chapter::chapterUpdateAll($request->course_id, $request->status);
+        $service($request->course_id, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -390,16 +390,11 @@ class ChapterController extends Controller
         // 認証されたマネージャーとマネージャーが管理する講師の講座IDのリストを取得
         $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id')->toArray();
 
-        if (! in_array($request->course_id, $courseIds)) {
+        if (! in_array((int) $request->course_id, $courseIds, true)) {
             // 講座IDがマネージャーが管理する講座IDのリストに含まれていない場合はエラー応答
-            throw new ValidationErrorException('Not authorized.');
+            throw new AuthorizationException('Forbidden, invalid course_id.');
         }
 
-        $course = Course::findOrFail($request->course_id);
-        if (Auth::guard('instructor')->user()->id !== $course->instructor_id) {
-            // ログイン中の講師IDが講座の講師IDと一致しない場合はエラー応答
-            throw new ValidationErrorException('Not authorized.');
-        }
         $service($request->course_id, $request->status);
 
         return response()->json([

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -23,6 +23,7 @@ use App\Model\LessonAttendance;
 use App\Services\Chapter\BulkDeleteChapterService;
 use App\Services\Chapter\CreateChapterService;
 use App\Services\Chapter\SortChaptersService;
+use App\Services\Chapter\UpdateAllChaptersStatusService;
 use App\Services\Chapter\UpdateChapterService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -376,7 +377,7 @@ class ChapterController extends Controller
      *
      * @return JsonResponse
      */
-    public function putStatus(PutStatusRequest $request)
+    public function putStatus(PutStatusRequest $request, UpdateAllChaptersStatusService $service)
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
@@ -399,7 +400,7 @@ class ChapterController extends Controller
             // ログイン中の講師IDが講座の講師IDと一致しない場合はエラー応答
             throw new ValidationErrorException('Not authorized.');
         }
-        Chapter::chapterUpdateAll($request->course_id, $request->status);
+        $service($request->course_id, $request->status);
 
         return response()->json([
             'result' => true,

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -87,19 +87,6 @@ class Chapter extends Model
     }
 
     /**
-     * チャプターのステータスを一括更新
-     *
-     * @param  'public'|'private'  $status
-     */
-    public static function chapterUpdateAll(int $courseId, string $status): void
-    {
-        Chapter::where('course_id', $courseId)
-            ->update([
-                'status' => $status,
-            ]);
-    }
-
-    /**
      * チャプターの進捗計算
      */
     public function calculateChapterProgress(Attendance $attendance): int

--- a/app/Services/Chapter/UpdateAllChaptersStatusService.php
+++ b/app/Services/Chapter/UpdateAllChaptersStatusService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Services\Chapter;
+
+use App\Model\Chapter;
+
+class UpdateAllChaptersStatusService
+{
+    /**
+     * 対象の講義の全チャプターのステータスを一括更新
+     */
+    public function __invoke(int $courseId, string $status): void
+    {
+        Chapter::where('course_id', $courseId)->update(['status' => $status]);
+    }
+}

--- a/app/Services/Chapter/UpdateAllChaptersStatusService.php
+++ b/app/Services/Chapter/UpdateAllChaptersStatusService.php
@@ -8,6 +8,8 @@ class UpdateAllChaptersStatusService
 {
     /**
      * 対象の講義の全チャプターのステータスを一括更新
+     *
+     * @param  'public'|'private'  $status
      */
     public function __invoke(int $courseId, string $status): void
     {

--- a/tests/Feature/Api/Instructor/Chapter/PutStatusTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/PutStatusTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Chapter;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_チャプターのステータス一括更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/1/chapter/status', [
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        $this->assertDatabaseHas('chapters', [
+            'course_id' => 1,
+            'status' => 'private',
+        ]);
+    }
+
+    public function test_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/1/chapter/status', [
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/course/aaa/chapter/status', [
+            'status' => 'string',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'status',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Chapter/PutStatusTest.php
+++ b/tests/Feature/Api/Manager/Chapter/PutStatusTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Chapter;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_チャプターのステータス一括更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/manager/course/1/chapter/status', [
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'result',
+        ]);
+        $this->assertDatabaseHas('chapters', [
+            'course_id' => 1,
+            'status' => 'private',
+        ]);
+    }
+
+    public function test_講師が一致しない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/manager/course/1/chapter/status', [
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, invalid course_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/manager/course/aaa/chapter/status', [
+            'status' => 'string',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'status',
+        ]);
+    }
+
+    public function test_マネージャーではない講師のレッスン登録_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/manager/course/1/chapter/status', [
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
JKA-1226 講座の全チャプターステータス更新サービスクラスの実装

## 処理内容
※対象講座の全チャプターを一括して表示、非表示にする更新処理の共通化
・serviceクラス【UpdateAllChaptersStatusService.php】作成
・controller【maneger/ 及び instructor/ 内の ChapterController.php】putStatusメソッド編集
・model【chapter.php】の共通処理(chapterUpdateAll)メソッド削除

## テスト
※マネージャー権限インストラクター(InstractorId:2) 及び権限のないインストラクター(InstractorId:1) による更新処理を実施
・インストラクター一覧
![スクリーンショット (39)](https://github.com/user-attachments/assets/0c25226b-b9f2-48af-9cff-457507c34f39)
・マネージャー権限
![スクリーンショット (38)](https://github.com/user-attachments/assets/2541263d-d3c8-4ed3-be5a-7518c6b02ebb)

＊ケース１権限のないインストラクター(InstractorId:1)
・ログイン
![スクリーンショット 2025-05-17 222203](https://github.com/user-attachments/assets/78ec6ce6-6012-4273-8563-6b40b5cb9cd8)
・更新処理(status変更)
![スクリーンショット 2025-05-17 223314](https://github.com/user-attachments/assets/aafad632-24fe-415c-a538-3a624b417e6a)
・データベース
![スクリーンショット 2025-05-17 223331](https://github.com/user-attachments/assets/f700de66-3c4c-4e99-88e8-250b3e3763a0)

＊ケース２：権限のあるインストラクター(InstractorId:2)
・ログイン
![スクリーンショット 2025-05-17 223541](https://github.com/user-attachments/assets/04a7fd69-568a-4626-9687-3e624d02e290)
・更新処理(status変更)
![スクリーンショット 2025-05-17 223720](https://github.com/user-attachments/assets/b0e89e5d-9617-4aff-8f8f-03a7a2a54f19)
・データベース
![スクリーンショット 2025-05-17 223733](https://github.com/user-attachments/assets/ee2dca02-f46b-4bee-939d-d5746117b035)

## その他
・Jiraの実装説明指示通り、developから直接featureブランチを切って実装