### PR TITLE
JKA-1295 空の配列を返すルーターとコントローラの作成(芦野)【JIKA-1218 子課題】

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -111,4 +111,13 @@ class TagController extends Controller
             'result' => true,
         ]);
     }
+
+        /**
+     * タグ更新API
+     */
+    public function delete()
+    {
+        return response()->json([]);
+    }
+
 }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -112,12 +112,11 @@ class TagController extends Controller
         ]);
     }
 
-        /**
+    /**
      * タグ更新API
      */
     public function delete()
     {
         return response()->json([]);
     }
-
 }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -112,7 +112,7 @@ class TagController extends Controller
         ]);
     }
 
-        /**
+    /**
      * タグ削除API
      */
     public function delete()

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -113,7 +113,7 @@ class TagController extends Controller
     }
 
         /**
-     * タグ更新API
+     * タグ削除API
      */
     public function delete()
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -126,6 +126,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('{tag_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'show']);
                     Route::put('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
+                    Route::delete('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
                 });
             });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -126,7 +126,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('{tag_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'show']);
                     Route::put('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
-                    Route::delete('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'put']);
+                    Route::delete('/', [App\Http\Controllers\Api\Instructor\TagController::class, 'delete']);
                 });
             });
 


### PR DESCRIPTION
## Issue
・issue-1295【空の配列を返すルーターとコントローラの作成】

## 概要
※issue-1218【講師側 講座分類 削除APIの作成】の子課題

## 処理内容
①route実装【api.php】
講師-タグ関係下にdeleteメソッド追加
②controller実装【instructor/TagController.php】
deleteメソッド追加(空の配列を返す実装内容)

## テスト
※インストラクター　id_1のユーザで上記メソッドを実施
・対象インストラクター
![スクリーンショット 2025-05-19 145340](https://github.com/user-attachments/assets/1b486dc5-be27-4760-874e-961db0685a45)
・ログイン
![スクリーンショット 2025-05-19 145030](https://github.com/user-attachments/assets/c80ecbcd-ed86-4668-b63e-25f5c9c5452c)
・メソッド実行（成功）
![スクリーンショット 2025-05-19 145303](https://github.com/user-attachments/assets/c23c185f-0d34-4c67-9dc7-0cc70551bf0d)
・該当データ（参考）
![スクリーンショット 2025-05-19 145321](https://github.com/user-attachments/assets/eae6ed86-362e-4481-8c13-77750d29fef4)