### PR TITLE
JKA-1320　空の配列を返すルーターとコントローラーの実装(芦野)【JKA-1304子課題】

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -293,11 +293,12 @@ class NotificationController extends Controller
         }
     }
 
-    /**
+        /**
      * お知らせ一覧-一括更新API
      */
-    public function bulkUpdate(): JsonResponse
+    public function bulkUpdateStatus(): JsonResponse
     {
         return response()->json([]);
     }
+
 }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -293,12 +293,11 @@ class NotificationController extends Controller
         }
     }
 
-        /**
+    /**
      * お知らせ一覧-一括更新API
      */
     public function bulkUpdate(): JsonResponse
     {
         return response()->json([]);
     }
-
 }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -292,4 +292,13 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+
+        /**
+     * お知らせ一覧-一括更新API
+     */
+    public function bulkUpdate(): JsonResponse
+    {
+        return response()->json([]);
+    }
+
 }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -293,12 +293,11 @@ class NotificationController extends Controller
         }
     }
 
-        /**
+    /**
      * お知らせ一覧-一括更新API
      */
     public function bulkUpdateStatus(): JsonResponse
     {
         return response()->json([]);
     }
-
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -260,7 +260,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\NotificationController::class, 'index']);
                     Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
-                    Route::put('/status', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkUpdate']);
+                    Route::put('/status', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkUpdateStatus']);
 
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -260,6 +260,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\NotificationController::class, 'index']);
                     Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
+                    Route::put('/status', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkUpdate']);
 
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'show']);


### PR DESCRIPTION
## Issue
・jka-1320【空の配列を返すルーターとコントローラの作成】

## 概要
※jka-1304【マネージャー側 お知らせ一覧-一括公開・非公開変更API 新規作成】の子課題

## 処理内容
①route実装【api.php】
manager-notification関係下にputメソッド追加
②controller実装【Manager/NotificationController.php】
putメソッド追加(空の配列を返す実装内容)

## テスト
※インストラクター　id_1のユーザで上記メソッドを実施
・対象インストラクター
![スクリーンショット 2025-05-19 145340](https://github.com/user-attachments/assets/1b486dc5-be27-4760-874e-961db0685a45)
・ログイン
![スクリーンショット 2025-05-19 145030](https://github.com/user-attachments/assets/c80ecbcd-ed86-4668-b63e-25f5c9c5452c)
・成功（空の配列返却）
![スクリーンショット 2025-05-22 213346](https://github.com/user-attachments/assets/c66b695d-e3e1-49ad-8065-c95276187f9a)
