### PR TITLE
(JKA-1283子課題) JKA-1311 空の配列を返す確認（街）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -239,4 +239,12 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+
+    /**
+     * 選択されたお知らせ 一括公開・非公開API
+     */
+    public function putStatus()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,7 +151,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
-                Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);                
+                Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -107,6 +107,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     // 講師-講座-お知らせ
                     Route::prefix('notification')->group(function () {
                         Route::post('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'store']);
+                        Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                     });
 
                     // 講師-講座-受講

--- a/routes/api.php
+++ b/routes/api.php
@@ -107,7 +107,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     // 講師-講座-お知らせ
                     Route::prefix('notification')->group(function () {
                         Route::post('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'store']);
-                        Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                     });
 
                     // 講師-講座-受講
@@ -152,6 +151,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);                
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'show']);


### PR DESCRIPTION
## issue
(JKA-1283子課題) JKA-1311 空の配列を返す確認

## 実装内容
１）【app/Http/Controllers/Api/Instructor/NotificationController.php】のコントローラーファイルに、選択されたお知らせ 一括公開・非公開APIのメソッドputStatus()を作成
２）putStatus()の中は、空の配列を返すようにした。

## 動作確認
１）instructorでログイン
２）postmanで下記の設定でリクエスト。　200OKと空の配列[]が返ることを確認。
・putリクエスト
・url: http://localhost:8080/api/v1/instructor/course/1/notification/status
<img width="697" alt="image" src="https://github.com/user-attachments/assets/fa48c644-c0f0-4706-8fde-cb68d4d1e93c" />
