### PR TITLE
(JKA1283子課題) JKA-1325putStatusメソッドの中身作成（街）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -7,12 +7,12 @@ use App\Http\Requests\Instructor\Notification\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Notification\DeleteRequest;
 use App\Http\Requests\Instructor\Notification\IndexRequest;
 use App\Http\Requests\Instructor\Notification\PutRequest;
+use App\Http\Requests\Instructor\Notification\PutStatusRequest;
 use App\Http\Requests\Instructor\Notification\ShowRequest;
 use App\Http\Requests\Instructor\Notification\StoreRequest;
 use App\Http\Requests\Instructor\Notification\UpdateTypeRequest;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Http\Resources\Instructor\NotificationShowResource;
-use App\Http\Requests\Instructor\Notification\PutStatusRequest;
 use App\Model\Course;
 use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
@@ -266,11 +266,8 @@ class NotificationController extends Controller
         DB::beginTransaction();
 
         try {
-            // ログイン講師のお知らせを取得
             Notification::where('instructor_id', $instructorId)
-                // 選択されたお知らせidを取得
                 ->whereIn('id', $notificationIds)
-                // ステータスを更新（「公開」ボタンの時：status="public", 「非公開」ボタンの時：status="private"）
                 ->update(['status' => $request->status]);
 
             // コミット

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -252,6 +252,16 @@ class NotificationController extends Controller
         // 選択されたお知らせidを取得
         $notificationIds = $request->input('notifications', []);
 
+        // 選択されたお知らせを取得
+        $chosenNotifications = Notification::whereIn('id', $notificationIds)->get();
+
+        // 選択されたお知らせの中に、講師と一致しないお知らせが含まれている場合はエラー
+        if (
+            $chosenNotifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
+        ) {
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
         // トランザクション開始
         DB::beginTransaction();
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -19,6 +19,7 @@ use App\Model\ViewedOnceNotification;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Collection;
+use lluminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -246,29 +247,16 @@ class NotificationController extends Controller
      */
     public function putStatus(PutStatusRequest $request): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // ログイン講師のお知らせのみを抽出
-        $notifications = Notification::where('instructor_id', $instructorId)->get();
-
-        // 選択されたお知らせを取得
+        // 選択されたお知らせidを取得
         $notificationIds = $request->input('notifications', []);
-        // そもそも、ログインユーザが持ってるお知らせ一覧を取得してれば、講師と一致しないお知らせが含まれてることはない。よってそのthrowは必要ない。
-        // 講師と一致しないお知らせが含まれている場合はエラー
-        //$notifications = Notification::whereIn('id', $notificationIds)->get();
-        //if (
-        //    $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
-        //) {
-        //    throw new AuthorizationException('Invalid instructor_id.');
-        //}
 
         // トランザクション開始
         DB::beginTransaction();
 
         try {
-            // 選択されたお知らせを抽出
-            $notifidations->whereIn('id', $notificationIds)
-                // ステータスを更新
+            // 選択されたお知らせidを取得
+            Notification::whereIn('id', $notificationIds)
+                // ステータスを更新（「公開」ボタンの時：status="public", 「非公開」ボタンの時：status="private"）
                 ->update(['status' => $request->status]);
 
             // コミット

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Instructor\Notification\StoreRequest;
 use App\Http\Requests\Instructor\Notification\UpdateTypeRequest;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Http\Resources\Instructor\NotificationShowResource;
+use App\Http\Requests\Instructor\Notification\PutStatusRequest;
 use App\Model\Course;
 use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
@@ -243,25 +244,31 @@ class NotificationController extends Controller
     /**
      * 選択されたお知らせ 一括公開・非公開API
      */
-    public function putStatus(PutRequest $request): JsonResponse
+    public function putStatus(PutStatusRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $notificationIds = $request->input('notifications', []);
 
+        // ログイン講師のお知らせのみを抽出
+        $notifications = Notification::where('instructor_id', $instructorId)->get();
+
+        // 選択されたお知らせを取得
+        $notificationIds = $request->input('notifications', []);
+        // そもそも、ログインユーザが持ってるお知らせ一覧を取得してれば、講師と一致しないお知らせが含まれてることはない。よってそのthrowは必要ない。
         // 講師と一致しないお知らせが含まれている場合はエラー
-        $notifications = Notification::whereIn('id', $notificationIds)->get();
-        if (
-            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
-        ) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        //$notifications = Notification::whereIn('id', $notificationIds)->get();
+        //if (
+        //    $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
+        //) {
+        //    throw new AuthorizationException('Invalid instructor_id.');
+        //}
 
         // トランザクション開始
         DB::beginTransaction();
 
         try {
-            // お知らせのステータスを更新
-            Notification::whereIn('id', $notificationIds)
+            // 選択されたお知らせを抽出
+            $notifidations->whereIn('id', $notificationIds)
+                // ステータスを更新
                 ->update(['status' => $request->status]);
 
             // コミット

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -239,4 +239,41 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+
+    /**
+     * 選択されたお知らせ 一括公開・非公開API
+     */
+    public function putStatus(PutRequest $request): JsonResponse
+    {
+        $instructorId = Auth::guard('instructor')->user()->id;
+        $notificationIds = $request->input('notifications', []);
+
+        // 講師と一致しないお知らせが含まれている場合はエラー
+        $notifications = Notification::whereIn('id', $notificationIds)->get();
+        if (
+            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
+        ) {
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
+        // トランザクション開始
+        DB::beginTransaction();
+
+        try {
+            // お知らせのステータスを更新
+            Notification::whereIn('id', $notificationIds)
+                ->update(['status' => $request->status]);
+
+            // コミット
+            DB::commit();
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
+    }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -19,7 +19,6 @@ use App\Model\ViewedOnceNotification;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Collection;
-use lluminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -247,6 +246,9 @@ class NotificationController extends Controller
      */
     public function putStatus(PutStatusRequest $request): JsonResponse
     {
+        // ログインしている講師のIDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+
         // 選択されたお知らせidを取得
         $notificationIds = $request->input('notifications', []);
 
@@ -254,8 +256,10 @@ class NotificationController extends Controller
         DB::beginTransaction();
 
         try {
-            // 選択されたお知らせidを取得
-            Notification::whereIn('id', $notificationIds)
+            // ログイン講師のお知らせを取得
+            Notification::where('instructor_id', $instructorId)
+                // 選択されたお知らせidを取得
+                ->whereIn('id', $notificationIds)
                 // ステータスを更新（「公開」ボタンの時：status="public", 「非公開」ボタンの時：status="private"）
                 ->update(['status' => $request->status]);
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -253,11 +253,11 @@ class NotificationController extends Controller
         $notificationIds = $request->input('notifications', []);
 
         // 選択されたお知らせを取得
-        $chosenNotifications = Notification::whereIn('id', $notificationIds)->get();
+        $chosenNotifications = Notification::whereIn('id', $notificationIds)->pluck('instructor_id');
 
-        // 選択されたお知らせの中に、講師と一致しないお知らせが含まれている場合はエラー
+        // 選択されたお知らせの中に、講師と一致しないお知らせが、１つでも含まれている場合はエラー
         if (
-            $chosenNotifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
+            $chosenNotifications->contains(fn ($notificationInstructorId) => $notificationInstructorId !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -257,7 +257,7 @@ class NotificationController extends Controller
 
         // 選択されたお知らせの中に、講師と一致しないお知らせが、１つでも含まれている場合はエラー
         if (
-            $chosenNotifications->contains(fn ($notificationInstructorId) => $notificationInstructorId !== $instructorId)
+            $chosenNotifications->contains(fn ($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -420,7 +420,6 @@ class ChapterController extends Controller
         // リクエストから必要なデータを取得
         $chapterIds = $request->input('chapters');
         $courseId = $request->input('course_id');
-        $status = $request->input('status');
 
         // チャプターデータの取得
         $chapters = Chapter::with('course')->whereIn('id', $chapterIds)->get();

--- a/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
@@ -4,5 +4,5 @@ namespace App\Http\Requests\Instructor\Notification;
 use Illuminate\Foundation\Http\FormRequest;
 
 class PutStatusRequest extends FormRequest{
-
+    //
 }

--- a/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Notification;
+use Illuminate\Foundation\Http\FormRequest;
+
+class PutStatusRequest extends FormRequest{
+
+}

--- a/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
@@ -1,8 +1,10 @@
 <?php
 
 namespace App\Http\Requests\Instructor\Notification;
+
 use Illuminate\Foundation\Http\FormRequest;
 
-class PutStatusRequest extends FormRequest{
+class PutStatusRequest extends FormRequest
+{
     //
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,6 +151,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'show']);

--- a/tests/Feature/Api/Instructor/Notification/PutStatusTest.php
+++ b/tests/Feature/Api/Instructor/Notification/PutStatusTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/status', [
+            'notifications' => [
+                1,
+            ],
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('notifications', [
+            'id' => 1,
+            'status' => 'private',
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/status', [
+            'notifications' => [
+                1,
+            ],
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Invalid instructor_id.',
+        ]);
+    }
+
+    // public function test_バリデーションエラー(): void
+    // {
+    //     // arrange
+    //     $instructor = Instructor::find(1);
+    //     $this->actingAs($instructor, 'instructor');
+
+    //     // act
+    //     $response = $this->putJson('/api/v1/instructor/notification/aaaa', [
+    //         'title' => '',
+    //         'type' => '',
+    //         'start_date' => '',
+    //         'end_date' => '',
+    //         'content' => '',
+    //     ]);
+
+    //     // assert
+    //     $response->assertStatus(422);
+    //     $response->assertJsonValidationErrors([
+    //         'notification_id',
+    //         'title',
+    //         'type',
+    //         'start_date',
+    //         'end_date',
+    //         'content',
+    //     ]);
+    // }
+}


### PR DESCRIPTION
## issue
(JKA1283子課題) JKA-1325putStatusメソッドの中身作成
## 実装内容
１）【app/Http/Controllers/Api/Instructor/NotificationController.php】のコントローラーファイルに、選択されたお知らせ 一括公開・非公開APIのメソッドputStatus()を作成

２）putStatus()の中で、下記の処理を記述
　・ログイン講師のお知らせ一覧を取得
　・選択されたお知らせのidを取得
　・選択されたお知らせのstatusのみを更新

３）大変申し訳ございませんでした。前回の空の配列レスポンスは、developに対してPRしてました。
今回はtopicブランチにPRしました。

## 動作確認
### ケース１：ログインユーザのレコードを更新試みる
１）instructor_id=1でログイン
お知らせテーブルは下図の状態：デフォルトではstatusはprivate
![image](https://github.com/user-attachments/assets/fbfb9fe9-4725-4e82-9287-f0d8931851ec)

２）postmanで下記の設定でリクエスト。　
・putリクエスト
・url: http://localhost:8080/api/v1/instructor/course/1/notification/status
・body:ログインユーザのお知らせidを記述
{
    "status": "public",
    "notifications": [
        1,
        4,
        5
    ]
}
・リクエストすると下図のように、ログインユーザのレコード（id=1, 4, 5）は更新された。
![image](https://github.com/user-attachments/assets/ed59fa8f-b9a2-4262-9ca5-6b0c636730dc)

### ケース２：ログインユーザ以外のレコードidを記述、更新試みる。
１）instructor_id=1でログイン
お知らせテーブルは下図の状態：デフォルトではstatusはprivate
![image](https://github.com/user-attachments/assets/fbfb9fe9-4725-4e82-9287-f0d8931851ec)

２）postmanで下記の設定でリクエスト。　
・putリクエスト
・url: http://localhost:8080/api/v1/instructor/course/1/notification/status
・body:ログインユーザ以外のお知らせid（id=2）を記述
{
    "status": "public",
    "notifications": [
        2
    ]
}
・リクエストすると、お知らせid=2のレコードはprivateのまま。更新されてないことを確認（200OKは出る）。
![image](https://github.com/user-attachments/assets/57065dfb-2c67-431e-9fd1-da2c2751b148)

## 質問
下記点、ご教示お願い致します。
ログインユーザ以外のレコードは更新できませんが、jsonレスポンスで200OKが出ます。何らかのエラー出力をさせた方が良いでしょうか。
