### PR TITLE
（再作成ブランチ）JKA-1280 講師側 お知らせ登録APIを修正して公開・非公開を登録できるようにする_2（街

### DIFF
--- a/app/Http/Requests/Instructor/Notification/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Notification/StoreRequest.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Requests\Instructor\Notification;
 
-use App\Rules\NotificationStoreStatusRule;
 use App\Enums\Instructor\Notification\NotificationStatus;
+use App\Rules\NotificationStoreStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Rules\Enum;
 
 class StoreRequest extends FormRequest
 {

--- a/app/Http/Requests/Instructor/Notification/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Notification/StoreRequest.php
@@ -3,7 +3,10 @@
 namespace App\Http\Requests\Instructor\Notification;
 
 use App\Rules\NotificationStoreStatusRule;
+use App\Enums\Instructor\Notification\NotificationStatus;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
 
 class StoreRequest extends FormRequest
 {
@@ -38,6 +41,7 @@ class StoreRequest extends FormRequest
             'type' => ['required', new NotificationStoreStatusRule],
             'start_date' => ['required', 'date_format:Y-m-d H:i:s'],
             'end_date' => ['required', 'date_format:Y-m-d H:i:s', 'after:start_date'],
+            'status' => ['required', Rule::enum(NotificationStatus::class)],
             'content' => ['required', 'string', 'max:500'],
         ];
     }

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -5,6 +5,7 @@ namespace App\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Enums\Instructor\Notification\NotificationStatus;
 
 class Notification extends Model
 {

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -31,6 +31,11 @@ class Notification extends Model
         'content',
     ];
 
+    // カラムのキャスト
+    protected $casts = [
+    'status' => NotificationStatus::class
+    ];
+
     // 表示区分 定数
     const TYPE_ALWAYS_INT = 1;
 

--- a/app/Model/Notification.php
+++ b/app/Model/Notification.php
@@ -2,10 +2,10 @@
 
 namespace App\Model;
 
+use App\Enums\Instructor\Notification\NotificationStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use App\Enums\Instructor\Notification\NotificationStatus;
 
 class Notification extends Model
 {
@@ -34,7 +34,7 @@ class Notification extends Model
 
     // カラムのキャスト
     protected $casts = [
-    'status' => NotificationStatus::class
+        'status' => NotificationStatus::class,
     ];
 
     // 表示区分 定数


### PR DESCRIPTION
## issue
（再作成ブランチ）JKA-1280 講師側 お知らせ登録APIを修正して公開・非公開を登録できるようにする_2

## 実装内容

最初のブランチ「feature/KosukeChimata/JKA-1280/edit_status_function_to_notifications_table」ですが、ほかの人のコミットが混ざってしまいました。よって、このブランチを削除して再度作り直しました。これをレビューお願い致します。

１）【laravel_next_docker/backend/laravelapp/app/Http/Controllers/Api/Instructor/NotificationController.php】のコントローラーファイルの、お知らせ登録関数store()の中身を変更
２）登録フォームからの、公開/非公開設定を受け取るようにした。

## 動作確認
１）postmanで、instructor_id=1でログイン
２）postmanで下記設定
・postリクエスト選択、
・url：http://localhost:8080/api/v1/instructor/course/1/notification
・Body：statusカラム値として、privateを指定（デフォルトはpublic）
{
  "title": "レッスン「変数とは？」閲覧について",
  "content": "10月1日〜10日の間、レッスン「変数とは？」がメンテナンスにつき閲覧できなくなります。",
  "start_date": "2021-10-01 00:00:00",
  "end_date": "2021-10-10 00:00:00",
  "status": "private",　←これを追加
  "type": "once"
}
<img width="540" alt="image" src="https://github.com/user-attachments/assets/9b01846f-5e1c-430d-a8b0-4086cecfc8c5" />

４）sendすると、下記結果。status値がprivateのお知らせレコードを追加できた。
![image](https://github.com/user-attachments/assets/ebf59e2b-1465-4b36-8895-b07d1a65a6d8)


バリデーションの動作確認
store()メソッドのバリデーションファイル【/Users/kosuke_chimata/myDocker/laravel_next_docker/backend/laravelapp/app/Http/Requests/Instructor/Notification/StoreRequest.php】へstatusを追記
![image](https://github.com/user-attachments/assets/d805c0d0-1bf0-4b1e-885e-bcfdb2fe19c4)

statusに'public'を書き、リクエスト
<img width="691" alt="image" src="https://github.com/user-attachments/assets/5670efbe-c905-4c13-939a-3a23954fd3a1" />

statusに'private'を書き、リクエスト
<img width="702" alt="image" src="https://github.com/user-attachments/assets/9b1f5ef2-4eb7-4c3e-9752-1dab9771d7f8" />

statusに'no_status'を書き、リクエストすると、エラー。バリデーションが効いてると思われる。
<img width="698" alt="image" src="https://github.com/user-attachments/assets/8c8e3564-3e6f-40d1-aee5-05e566a25fbc" />

