### PR TITLE
（JKA-1283子課題）JKA-1312 バリデーション内容作成（街）

### DIFF
--- a/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
@@ -3,8 +3,27 @@
 namespace App\Http\Requests\Instructor\Notification;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use App\Enums\NotificationStatus;
 
 class PutStatusRequest extends FormRequest
 {
-    //
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+        /**
+        * Get the validation rules that apply to the request.
+        *
+        * @return array<string, mixed>
+        */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', Rule::enum(NotificationStatus::class)],
+            'notifications' => ['required', 'array', 'min:1'],
+            'notifications.*' => ['integer', 'exists:notifications,id']
+        ];
+    }
 }

--- a/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\Instructor\Notification;
 
+use App\Enums\NotificationStatus;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use App\Enums\NotificationStatus;
 
 class PutStatusRequest extends FormRequest
 {
@@ -13,17 +13,17 @@ class PutStatusRequest extends FormRequest
         return true;
     }
 
-        /**
-        * Get the validation rules that apply to the request.
-        *
-        * @return array<string, mixed>
-        */
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [
             'status' => ['required', Rule::enum(NotificationStatus::class)],
             'notifications' => ['required', 'array', 'min:1'],
-            'notifications.*' => ['integer', 'exists:notifications,id']
+            'notifications.*' => ['integer', 'exists:notifications,id'],
         ];
     }
 }


### PR DESCRIPTION
## issue
（JKA-1283子課題）JKA-1312 バリデーション内容作成（街）

## 実装内容
「JKA-1280 講師側 お知らせ登録APIを修正して公開・非公開を登録できるようにする」の子課題。
putStatus()メソッドで使用するバリデーションファイルを作成した（putStatusRequest）

１）【Requests/Notification/PutStatusRequest.php】を作成
２）Statusを変更するお知らせを複数選択、一括更新ボタンを押した際に送信されるデータ（選択したお知らせidの配列notifications、　statusの情報）に対してバリデーションをかけた
・選択したお知らせがゼロ個の時、エラー
・statusとして、publicとprivateのどちらかしかとらない
・選択したお知らせidは配列notificationsで

## 動作確認
１）選択したお知らせをゼロ個でリクエストするとエラーが出た。
<img width="539" alt="image" src="https://github.com/user-attachments/assets/0e68f11a-c332-443e-a249-fa05f18cda92" />
２）statusとしてpublic, private以外の値をリクエストすると、エラーが出た。
<img width="540" alt="image" src="https://github.com/user-attachments/assets/df8abe92-470e-443b-ae89-6027b3fbbef6" />

