### PR TITLE
JKA-1305 マネージャー側 お知らせ一覧取得APIを修正して公開・非公開を返すようにする（街）

### DIFF
--- a/app/Http/Resources/Manager/NotificationIndexResource.php
+++ b/app/Http/Resources/Manager/NotificationIndexResource.php
@@ -49,6 +49,7 @@ class NotificationIndexResource extends JsonResource
             'instructor' => new InstructorResource($notification->instructor),
             'start_date' => $notification->start_date,
             'end_date' => $notification->end_date,
+            'status' => $notification->status,
         ])
             ->toArray();
     }


### PR DESCRIPTION
## issue
JKA-1305 マネージャー側 お知らせ一覧取得APIを修正して公開・非公開を返すようにする

## 実装内容
【app/Http/Controllers/Api/Manager/NotificationController.php】のindex()メソッドにて、出力整形ファイルNotificationIndexResourceを使用している。これに、statusカラムを追加。

## 動作確認
１）manager権限を持つinstructor(id=1)でログイン
２）下記をリクエスト
url:http://localhost:8080/api/v1/manager/notification/index
body:なし
３）レスポンスとして、下記が得られた。"status"カラムの値も出力されている。フロント側にて、”status”の値に応じて色を変えるコードを書けば良い。
<img width="512" alt="image" src="https://github.com/user-attachments/assets/c49e1075-cea5-4340-9d1c-c9779f04cbba" />
