### PR TITLE
JKA-1334 講師/マネージャー 講座更新機能へのPolicyパターンを用いた認可機能の実装（芦野）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -145,7 +145,7 @@ class CourseController extends Controller
             $imagePath = $course->image;
 
             // 認可チェック(policy 利用)
-            $this->authorize('instructorPolicy', $course);
+            $this->authorize('update', $course);
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除
@@ -155,7 +155,7 @@ class CourseController extends Controller
 
                 // 画像ファイル保存処理
                 $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString().'.'.$extension;
+                $filename = Str::uuid()->toString() . '.' . $extension;
                 $imagePath = Storage::putFileAs('public/course', $file, $filename);
                 $imagePath = Course::convertImagePath($imagePath);
             }
@@ -169,17 +169,14 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-    } catch (AuthorizationException $e) {
-        return response()->json([
-            'result' => false,
-            'message' => $e->getMessage(),
-        ], 403);
-    } catch (Exception $e) {
-        Log::error($e);
+        } catch (AuthorizationException $e) {
+            throw $e;
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
+        }
     }
-}
+
 
     /**
      * 講座削除API

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -146,7 +146,7 @@ class CourseController extends Controller
 
             // 管理者の場合、自分の講座以外処理を出来なくする処理
             $instructor = Auth::guard('instructor')->user();
-            if($instructor->isManager() && $instructor->id !== $course->instructor_id){
+            if ($instructor->isManager() && $instructor->id !== $course->instructor_id) {
                 throw new AuthorizationException('Invalid instructor_id.');
             }
 
@@ -161,7 +161,7 @@ class CourseController extends Controller
 
                 // 画像ファイル保存処理
                 $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString() . ' . ' . $extension;
+                $filename = Str::uuid()->toString().' . '.$extension;
                 $imagePath = Storage::putFileAs('public/course', $file, $filename);
                 $imagePath = Course::convertImagePath($imagePath);
             }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -144,12 +144,6 @@ class CourseController extends Controller
             $course = Course::FindOrFail($request->course_id);
             $imagePath = $course->image;
 
-            // 管理者の場合、自分の講座以外処理を出来なくする処理
-            $instructor = Auth::guard('instructor')->user();
-            if($instructor->isManager() && $instructor->id !== $course->instructor_id){
-                throw new AuthorizationException('Invalid instructor_id.');
-            }
-
             // 認可チェック(policy 利用)
             $this->authorize('update', $course);
 

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -155,7 +155,7 @@ class CourseController extends Controller
 
                 // 画像ファイル保存処理
                 $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString() . '.' . $extension;
+                $filename = Str::uuid()->toString().'.'.$extension;
                 $imagePath = Storage::putFileAs('public/course', $file, $filename);
                 $imagePath = Course::convertImagePath($imagePath);
             }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -170,25 +170,12 @@ class CourseController extends Controller
                 'result' => true,
             ]);
         } catch (AuthorizationException $e) {
-<<<<<<< HEAD
             throw $e;
         } catch (Exception $e) {
-=======
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 403);
-        } catch (Exception $e) {
-            Log::error($e);
->>>>>>> 739deea8370c4049427a58286a9ef4ff51833823
             Log::error($e);
             throw $e;
         }
     }
-<<<<<<< HEAD
-
-=======
->>>>>>> 739deea8370c4049427a58286a9ef4ff51833823
 
     /**
      * 講座削除API

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -155,7 +155,7 @@ class CourseController extends Controller
 
                 // 画像ファイル保存処理
                 $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString().' . '.$extension;
+                $filename = Str::uuid()->toString().'.'.$extension;
                 $imagePath = Storage::putFileAs('public/course', $file, $filename);
                 $imagePath = Course::convertImagePath($imagePath);
             }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -141,13 +141,11 @@ class CourseController extends Controller
         $file = $request->file('image');
 
         try {
-            $user = Instructor::find(Auth::guard('instructor')->user()->id);
             $course = Course::FindOrFail($request->course_id);
             $imagePath = $course->image;
 
-            if ($user->id !== $course->instructor_id) {
-                throw new AuthorizationException('Invalid instructor_id.');
-            }
+            // 認可チェック(policy 利用)
+            $this->authorize('instructorPolicy', $course);
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除
@@ -171,11 +169,17 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (Exception $e) {
+    } catch (AuthorizationException $e) {
+        return response()->json([
+            'result' => false,
+            'message' => $e->getMessage(),
+        ], 403);
+    } catch (Exception $e) {
+        Log::error($e);
             Log::error($e);
             throw $e;
-        }
     }
+}
 
     /**
      * 講座削除API

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -169,17 +169,17 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-    } catch (AuthorizationException $e) {
-        return response()->json([
-            'result' => false,
-            'message' => $e->getMessage(),
-        ], 403);
-    } catch (Exception $e) {
-        Log::error($e);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ], 403);
+        } catch (Exception $e) {
+            Log::error($e);
             Log::error($e);
             throw $e;
+        }
     }
-}
 
     /**
      * 講座削除API

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -144,6 +144,12 @@ class CourseController extends Controller
             $course = Course::FindOrFail($request->course_id);
             $imagePath = $course->image;
 
+            // 管理者の場合、自分の講座以外処理を出来なくする処理
+            $instructor = Auth::guard('instructor')->user();
+            if($instructor->isManager() && $instructor->id !== $course->instructor_id){
+                throw new AuthorizationException('Invalid instructor_id.');
+            }
+
             // 認可チェック(policy 利用)
             $this->authorize('update', $course);
 

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -164,21 +164,10 @@ class CourseController extends Controller
                 'result' => true,
             ]);
         } catch (AuthorizationException $e) {
-<<<<<<< HEAD
             throw $e;
         } catch (Exception $e) {
             log::error($e);
             throw $e;
-=======
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 403);
-        } catch (Exception $e) {
-            Log::error($e);
-            Log::error($e);
-            throw $e;
->>>>>>> 739deea8370c4049427a58286a9ef4ff51833823
         }
     }
 

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -166,7 +166,7 @@ class CourseController extends Controller
         } catch (AuthorizationException $e) {
             throw $e;
         } catch (Exception $e) {
-            log::error($e);
+            Log::error($e);
             throw $e;
         }
     }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -139,7 +139,7 @@ class CourseController extends Controller
             $imagePath = $course->image;
 
             // 認可チェック(Policy 利用)
-            $this->authorize('managerPolicy', $course);
+            $this->authorize('update', $course);
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除
@@ -163,17 +163,13 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-    } catch (AuthorizationException $e) {
-        return response()->json([
-            'result' => false,
-            'message' => $e->getMessage(),
-        ], 403);
-    } catch (Exception $e) {
-        Log::error($e);
-            Log::error($e);
+        } catch (AuthorizationException $e) {
             throw $e;
+        } catch (Exception $e) {
+            log::error($e);
+            throw $e;
+        }
     }
-}
 
     /**
      * 講座削除API

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -132,20 +132,14 @@ class CourseController extends Controller
      */
     public function update(UpdateRequest $request)
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-        $instructor = Instructor::with('managings')->find($instructorId);
-        $managingIds = $instructor->managings->pluck('id')->toArray();
-        $managingIds[] = $instructorId;
         $file = $request->file('image');
 
         try {
             $course = Course::FindOrFail($request->course_id);
             $imagePath = $course->image;
 
-            if (! in_array($course->instructor_id, $managingIds, true)) {
-                // 自分、または配下の講師の講座でなければエラー応答
-                throw new AuthorizationException('Invalid instructor_id.');
-            }
+            // 認可チェック(Policy 利用)
+            $this->authorize('managerPolicy', $course);
 
             if (isset($file)) {
                 // 更新前の画像ファイルを削除
@@ -169,13 +163,17 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        } catch (Exception $e) {
+    } catch (AuthorizationException $e) {
+        return response()->json([
+            'result' => false,
+            'message' => $e->getMessage(),
+        ], 403);
+    } catch (Exception $e) {
+        Log::error($e);
             Log::error($e);
             throw $e;
-        }
     }
+}
 
     /**
      * 講座削除API

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -163,17 +163,17 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-    } catch (AuthorizationException $e) {
-        return response()->json([
-            'result' => false,
-            'message' => $e->getMessage(),
-        ], 403);
-    } catch (Exception $e) {
-        Log::error($e);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'result' => false,
+                'message' => $e->getMessage(),
+            ], 403);
+        } catch (Exception $e) {
+            Log::error($e);
             Log::error($e);
             throw $e;
+        }
     }
-}
 
     /**
      * 講座削除API

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -114,12 +114,11 @@ class Instructor extends Authenticatable
         ];
     }
 
-        /**
+    /**
      * 講師か管理者か判定(管理者)
-     *
-     * @return bool
      */
-    public function isManager(): bool{
+    public function isManager(): bool
+    {
         return $this->type === self::TYPE_MANAGER;
     }
 }

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -113,4 +113,13 @@ class Instructor extends Authenticatable
             'updated_at' => 'immutable_datetime',
         ];
     }
+
+        /**
+     * 講師か管理者か判定(管理者)
+     *
+     * @return bool
+     */
+    public function isManager(): bool{
+        return $this->type === self::TYPE_MANAGER;
+    }
 }

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -118,5 +118,4 @@ class Instructor extends Authenticatable
             'updated_at' => 'immutable_datetime',
         ];
     }
-
 }

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -119,11 +119,4 @@ class Instructor extends Authenticatable
         ];
     }
 
-    /**
-     * 講師か管理者か判定(管理者)
-     */
-    public function isManager(): bool
-    {
-        return $this->type === self::TYPE_MANAGER;
-    }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -8,25 +8,28 @@ use App\Model\Instructor;
 class CoursePolicy
 {
     /**
-     * Determine whether the user can update the model.
+     * 講師本人またはその講師が管理している講師の講座であれば更新を許可する
      */
-    public function managerPolicy(Instructor $instructor, Course $course): bool
+    public function update(Instructor $instructor, Course $course): bool
     {
+        // 本人の場合は許可
+        if ($instructor->id === $course->instructor_id) {
+            return true;
+        }
+
+        // 管理している講師の中に対象講座の講師が含まれているかチェック
         $manager = Instructor::with('managings')->find($instructor->id);
 
-        if(!$manager){
+        if (!$manager) {
             return false;
         }
 
         $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $instructor->id;
 
-        return in_array($course->instructor_id, $instructorIds);
-    }
+        if (in_array($course->instructor_id, $instructorIds)) {
+            return true;
+        }
 
-    public function instructorPolicy(Instructor $instructor, Course $course): bool
-    {
-        // 講師が保有する講座なら処理可能
-        return $instructor->id === $course->instructor_id;
+        return false;
     }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -7,25 +7,21 @@ use App\Model\Instructor;
 
 class CoursePolicy
 {
-    public function update(Instructor $instructor, Course $course): bool
+    /**
+     * Determine whether the instructor can delete the course.
+     */
+    public function delete(Instructor $instructor, Course $course): bool
     {
-        // 管理者以外の場合
-        if($instructor->id === $course->instructor_id){
-            return true;
-        }
-
-        // 管理者の場合
-        if($instructor->isManager()){
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
             $manager = Instructor::with('managings')->find($instructor->id);
+            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
 
-            if(!$manager){
-                return false;
-            }
-
-            $managerIds = $manager->managings->pluck('id')->toArray();
-            return in_array($course->instructor_id, $managerIds);
+            return in_array($course->instructor_id, $instructorIds, true);
         }
 
-        return false;
+        // マネージャー権限のない講師
+        return $instructor->id === $course->instructor_id;
     }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -20,7 +20,7 @@ class CoursePolicy
         // 管理している講師の中に対象講座の講師が含まれているかチェック
         $manager = Instructor::with('managings')->find($instructor->id);
 
-        if (!$manager) {
+        if (! $manager) {
             return false;
         }
 

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -7,27 +7,23 @@ use App\Model\Instructor;
 
 class CoursePolicy
 {
-    /**
-     * 講師本人またはその講師が管理している講師の講座であれば更新を許可する
-     */
     public function update(Instructor $instructor, Course $course): bool
     {
-        // 本人の場合は許可
-        if ($instructor->id === $course->instructor_id) {
+        // 講師の場合の処理
+        if($instructor->id === $course->instructor_id){
             return true;
         }
 
-        // 管理している講師の中に対象講座の講師が含まれているかチェック
-        $manager = Instructor::with('managings')->find($instructor->id);
+        // 管理者の場合の処理
+        if($instructor->isManager()){
+            $manager = Instructor::with('managings')->find($instructor->id);
 
-        if (!$manager) {
-            return false;
-        }
+            if(!$manager){
+                return false;
+            }
 
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-
-        if (in_array($course->instructor_id, $instructorIds)) {
-            return true;
+            $managerIds = $manager->managings->pluck('id')->toArray();
+            return in_array($course->instructor_id, $managerIds);
         }
 
         return false;

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -10,20 +10,23 @@ class CoursePolicy
     /**
      * Determine whether the user can update the model.
      */
-    public function update(Instructor $user, Course $course): bool
+    public function managerPolicy(Instructor $instructor, Course $course): bool
+    {
+        $manager = Instructor::with('managings')->find($instructor->id);
+
+        if(!$manager){
+            return false;
+        }
+
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructor->id;
+
+        return in_array($course->instructor_id, $instructorIds);
+    }
+
+    public function instructorPolicy(Instructor $instructor, Course $course): bool
     {
         // 講師が保有する講座なら処理可能
-        if($user->type === Instructor::TYPE_INSTRUCTOR){
-            return $user->id === $course->instructor_id;
-        }
-
-        // マネージャーでかつ、配下の講師の講座であれば処理可能
-        if($user->type === Instructor::TYPE_MANAGER){
-            return $user->managing->pluck('id')->contains($course->instructor_id);
-        }
-
-        // 上記以外は処理不可
-        return false;
-
+        return $instructor->id === $course->instructor_id;
     }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Course;
+use App\Model\Instructor;
+
+class CoursePolicy
+{
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(Instructor $user, Course $course): bool
+    {
+        // 講師が保有する講座なら処理可能
+        if($user->type === Instructor::TYPE_INSTRUCTOR){
+            return $user->id === $course->instructor_id;
+        }
+
+        // マネージャーでかつ、配下の講師の講座であれば処理可能
+        if($user->type === Instructor::TYPE_MANAGER){
+            return $user->managing->pluck('id')->contains($course->instructor_id);
+        }
+
+        // 上記以外は処理不可
+        return false;
+
+    }
+}

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -13,8 +13,10 @@ class CoursePolicy
             // 管理者の場合、配下の講師の講座も更新可能
             $managerIds = $instructor->managings->pluck('id')->toArray();
             $managerIds[] = $instructor->id;
+
             return in_array($course->instructor_id, $managerIds, true);
         }
+
         // 講師の場合、自分の講座のみ更新可能
         return $instructor->id === $course->instructor_id;
     }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -7,21 +7,15 @@ use App\Model\Instructor;
 
 class CoursePolicy
 {
-    /**
-     * Determine whether the instructor can delete the course.
-     */
-    public function delete(Instructor $instructor, Course $course): bool
+    public function update(Instructor $instructor, Course $course): bool
     {
-        // マネージャー権限のある講師か判定
         if ($instructor->isManager()) {
-            $manager = Instructor::with('managings')->find($instructor->id);
-            $instructorIds = $manager->managings->pluck('id')->toArray();
-            $instructorIds[] = $instructor->id;
-
-            return in_array($course->instructor_id, $instructorIds, true);
+            // 管理者の場合、配下の講師の講座も更新可能
+            $managerIds = $instructor->managings->pluck('id')->toArray();
+            $managerIds[] = $instructor->id;
+            return in_array($course->instructor_id, $managerIds, true);
         }
-
-        // マネージャー権限のない講師
+        // 講師の場合、自分の講座のみ更新可能
         return $instructor->id === $course->instructor_id;
     }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -10,19 +10,20 @@ class CoursePolicy
     public function update(Instructor $instructor, Course $course): bool
     {
         // 管理者以外の場合
-        if($instructor->id === $course->instructor_id){
+        if ($instructor->id === $course->instructor_id) {
             return true;
         }
 
         // 管理者の場合
-        if($instructor->isManager()){
+        if ($instructor->isManager()) {
             $manager = Instructor::with('managings')->find($instructor->id);
 
-            if(!$manager){
+            if (! $manager) {
                 return false;
             }
 
             $managerIds = $manager->managings->pluck('id')->toArray();
+
             return in_array($course->instructor_id, $managerIds);
         }
 

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -14,7 +14,7 @@ class CoursePolicy
     {
         $manager = Instructor::with('managings')->find($instructor->id);
 
-        if(!$manager){
+        if (! $manager) {
             return false;
         }
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -22,8 +22,5 @@ class AuthServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
-    {
-        $this->registerPolicies();
-    }
+    public function boot() {}
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Model\Course;
+use App\Policies\CoursePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -13,6 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         // 'App\Model' => 'App\Policies\ModelPolicy',
+        Course::class => CoursePolicy::class,
     ];
 
     /**
@@ -22,6 +25,6 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->registerPolicies();
     }
 }

--- a/tests/Feature/Api/Instructor/Course/UpdateTest.php
+++ b/tests/Feature/Api/Instructor/Course/UpdateTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/instructor/course/1', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('courses', [
+            'id' => 1,
+            'title' => 'テスト講座',
+            'status' => 'private',
+        ]);
+    }
+
+    public function test_権限がない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/instructor/course/1', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->post('/api/v1/instructor/course/aaa', [
+            'title' => '', // 空のタイトル
+            'image' => null, // 画像なし
+            'status' => 'invalid_status', // 無効なステータス
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id', 'title', 'image', 'status',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Course/UpdateTest.php
+++ b/tests/Feature/Api/Manager/Course/UpdateTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/manager/course/1', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('courses', [
+            'id' => 1,
+            'title' => 'テスト講座',
+            'status' => 'private',
+        ]);
+    }
+
+    public function test_マネージャー権限がない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/manager/course/1', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    public function test_配下の講師でない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/manager/course/1', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->post('/api/v1/manager/course/aaa', [
+            'title' => '', // 空のタイトル
+            'image' => null, // 画像なし
+            'status' => 'invalid_status', // 無効なステータス
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id', 'title', 'image', 'status',
+        ]);
+    }
+}


### PR DESCRIPTION
## Issue
JKA-1334 講師/マネージャー 講座更新機能へのPolicyパターンを用いた認可機能の実装

## 背景
Course(講座)更新機能の認可処理をpolicyクラスへ書き換え
この処理を行うことで以後のCourseにおける認可処理の作業工数削減が見込めcontrollerの負担軽減における可読性、役割が明確化し保守性の向上になる。

## 実装内容
①app/Policy/CourcePolicy.php作成
・managerPolicyメソッド実装
・instructorPolicyメソッド実装
②app/Providers/AuthServiceProvider.php修正
・policyマッピング実装
③Controller/Api/Instructor/CourseController.php修正
・updateメソッドへinstructorPolicyメソッド反映
④Controller/Api/Manager/CourseController.php修正
・updateメソッドへmanagerPolicyメソッド反映

## 6/1 修正内容
・controller 修正
・policy 修正
## 6/2修正内容
・contoller修正
・policy修正
・model修正
## 6/6 修正内容
・policy修正
下記同様のテストを実施、挙動に問題ありませんでした。

## テスト実施
### ※instructor Id_1, Id_2のユーザでテスト実施
#### instructor id_1 
![スクリーンショット (77)](https://github.com/user-attachments/assets/94effc8f-0f39-44b1-9a5f-9adeb9006c8c)

##### instructor側 updateメソッド
・instructor_id1 の講座を更新【成功】
![スクリーンショット (80)](https://github.com/user-attachments/assets/19c51305-6c2a-4ccb-86b0-dd4ad723fed4)
・instructor_id2 の講座を更新【失敗】
![スクリーンショット (78)](https://github.com/user-attachments/assets/baaecf3b-cc07-4bd2-95ed-1de609b67de4)
※その他
・titleを空欄でリクエスト　【422エラー】
・statusをルール外の文字及び空欄でリクエスト　【422エラー】

#### manager側 updateメソッド
・instructor_id2 の講座を更新【成功】
![スクリーンショット (81)](https://github.com/user-attachments/assets/6da5eca3-ccb6-4af0-a367-0098fc90c107)
・instructor_id4 の講座を更新【失敗】
![スクリーンショット (82)](https://github.com/user-attachments/assets/183683e7-ec46-4a1c-be64-8b0e5ec5e742)
※その他
・instructor_id1 自身の講座を更新【成功】
・titleを空欄でリクエスト　【422エラー】
・statusをルール外の文字及び空欄でリクエスト　【422エラー】


#### instructor id_2
![スクリーンショット (83)](https://github.com/user-attachments/assets/e1a8b149-87ab-45c4-aede-216caea05df6)
##### instructor側 updateメソッド
・instructor_id1 の講座を更新【失敗】
![スクリーンショット (85)](https://github.com/user-attachments/assets/291b6953-4413-4b5e-b702-ddf5c0853eec)
・instructor_id2 の講座を更新【成功】
![スクリーンショット (86)](https://github.com/user-attachments/assets/e90f61a0-62cc-4a3a-b971-85302c97cf1c)
・titleを空欄でリクエスト　【422エラー】
・statusをルール外の文字及び空欄でリクエスト　【422エラー】

#### manager側 updateメソッド
・instructor_id2 の講座を更新【失敗】
![スクリーンショット (84)](https://github.com/user-attachments/assets/41c38182-9cfb-49a5-9bff-1daf5857079d)