### PR TITLE
JKA-1234 複数レッスン削除処理サービスクラスの実装(miyagi)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use App\Exceptions\ValidationErrorException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Lesson\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Lesson\DeleteAllRequest;
@@ -147,10 +146,8 @@ class LessonController extends Controller
 
     /**
      * 複数のレッスン削除API
-     *
-     * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete(BulkDeleteRequest $request, BulkDeleteLessonsService $service)
+    public function bulkDelete(BulkDeleteRequest $request, BulkDeleteLessonsService $service): JsonResponse
     {
         // ログイン中の講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -159,6 +156,7 @@ class LessonController extends Controller
         $chapterId = $request->input('chapter_id');
         $lessonIds = $request->input('lessons');
 
+        DB::beginTransaction();
         try {
             // レッスン情報を取得
             $lessons = Lesson::with('chapter.course', 'lessonAttendances')->whereIn('id', $lessonIds)->get();
@@ -166,37 +164,33 @@ class LessonController extends Controller
             $lessons->each(function (Lesson $lesson) use ($instructorId, $chapterId, $courseId) {
                 // 自身の講座・チャプターに紐づくレッスンでない場合は許可しない
                 if ((int) $instructorId !== $lesson->chapter->course->instructor_id) {
-                    throw new ValidationErrorException('Invalid instructor_id.');
+                    throw new AuthorizationException('Invalid instructor_id.');
                 }
                 // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
                 if ((int) $chapterId !== $lesson->chapter_id) {
-                    throw new ValidationErrorException('Invalid chapter.');
+                    throw new AuthorizationException('Invalid chapter.');
                 }
                 // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $lesson->chapter->course_id) {
-                    throw new ValidationErrorException('Invalid course.');
+                    throw new AuthorizationException('Invalid course.');
                 }
                 // 受講情報が登録されている場合は許可しない
                 if ($lesson->lessonAttendances->isNotEmpty()) {
-                    throw new ValidationErrorException('This lesson has attendance.');
+                    throw new AuthorizationException('This lesson has attendance.');
                 }
             });
 
-            DB::beginTransaction();
-
             // サービスクラスで対象レッスンの削除処理を実行
-            $service($lessonIds, $chapterId);
+            $service(
+                lessonIds: $lessons->pluck('id')->toArray(),
+                chapterId: $chapterId
+            );
 
             DB::commit();
 
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ValidationErrorException $e) {
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 403);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -19,6 +19,7 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
+use App\Services\Lesson\BulkDeleteLessonsService;
 use App\Services\Lesson\DeleteAllLessonsService;
 use App\Services\Lesson\DeleteLessonService;
 use App\Services\Lesson\SortLessonsService;
@@ -149,7 +150,7 @@ class LessonController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function bulkDelete(BulkDeleteRequest $request)
+    public function bulkDelete(BulkDeleteRequest $request, BulkDeleteLessonsService $service)
     {
         // ログイン中の講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
@@ -160,7 +161,7 @@ class LessonController extends Controller
 
         try {
             // レッスン情報を取得
-            $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
+            $lessons = Lesson::with('chapter.course', 'lessonAttendances')->whereIn('id', $lessonIds)->get();
 
             $lessons->each(function (Lesson $lesson) use ($instructorId, $chapterId, $courseId) {
                 // 自身の講座・チャプターに紐づくレッスンでない場合は許可しない
@@ -183,18 +184,8 @@ class LessonController extends Controller
 
             DB::beginTransaction();
 
-            // 削除対象レッスンのorderカラムを0に設定する
-            Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
-
-            Lesson::whereIn('id', $lessonIds)->delete();
-
-            //レッスン順序の更新
-            Lesson::where('chapter_id', $chapterId)
-                ->orderBy('order')
-                ->get()
-                ->each(function (Lesson $lesson, int $index) {
-                    $lesson->update(['order' => $index + 1]);
-                });
+            // サービスクラスで対象レッスンの削除処理を実行
+            $service($lessonIds, $chapterId);
 
             DB::commit();
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -198,7 +198,6 @@ class LessonController extends Controller
 
             // マネージャーが管理する講師を取得
             $manager = Instructor::with('managings')->find($managerId);
-            assert($manager instanceof Instructor);
 
             $instructorIds = $manager->managings->pluck('id')->toArray();
             $instructorIds[] = $manager->id;
@@ -395,41 +394,39 @@ class LessonController extends Controller
         // レッスン情報を取得
         /** @var Lesson $lesson */
         $lesson = Lesson::with('chapter.course', 'lessonAttendances')->whereIn('id', $lessonIds)->get();
-        try {
-            DB::beginTransaction();
+        DB::beginTransaction();
 
+        try {
             $lesson->each(function (Lesson $lesson) use ($instructorIds, $chapterId, $courseId) {
                 // 自身もしくは配下の講師の講座・チャプターに紐づくレッスンでない場合は許可しない
                 if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-                    throw new ValidationErrorException('Invalid instructor_id.');
+                    throw new AuthorizationException('Invalid instructor_id.');
                 }
                 // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $lesson->chapter->course->id) {
-                    throw new ValidationErrorException('Invalid course_id.');
+                    throw new AuthorizationException('Invalid course_id.');
                 }
                 // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
                 if ((int) $chapterId !== $lesson->chapter->id) {
-                    throw new ValidationErrorException('Invalid chapter_id.');
+                    throw new AuthorizationException('Invalid chapter_id.');
                 }
                 // 受講情報が登録されている場合は許可しない
                 if ($lesson->lessonAttendances->isNotEmpty()) {
-                    throw new ValidationErrorException('This lesson has attendance.');
+                    throw new AuthorizationException('This lesson has attendance.');
                 }
             });
 
             // サービスクラスで対象レッスンの削除処理を実行
-            $service($lessonIds, $chapterId);
+            $service(
+                lessonIds: $lesson->pluck('id')->toArray(),
+                chapterId: $chapterId
+            );
 
             DB::commit();
 
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ValidationErrorException $e) {
-            return response()->json([
-                'result' => false,
-                'message' => $e->getMessage(),
-            ], 403);
         } catch (Exception $e) {
             DB::rollBack();
             Log::error($e);

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -19,6 +19,7 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
+use App\Services\Lesson\BulkDeleteLessonsService;
 use App\Services\Lesson\DeleteAllLessonsService;
 use App\Services\Lesson\DeleteLessonService;
 use App\Services\Lesson\SortLessonsService;
@@ -376,7 +377,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスン削除API
      */
-    public function bulkDelete(BulkDeleteRequest $request): JsonResponse
+    public function bulkDelete(BulkDeleteRequest $request, BulkDeleteLessonsService $service): JsonResponse
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
@@ -416,15 +417,9 @@ class LessonController extends Controller
                 }
             });
 
-            Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
-            Lesson::whereIn('id', $lessonIds)->delete();
-            //レッスン順序の更新
-            Lesson::where('chapter_id', $chapterId)
-                ->orderBy('order')
-                ->get()
-                ->each(function (Lesson $lesson, int $index) {
-                    $lesson->update(['order' => $index + 1]);
-                });
+            // サービスクラスで対象レッスンの削除処理を実行
+            $service($lessonIds, $chapterId);
+
             DB::commit();
 
             return response()->json([

--- a/app/Services/Lesson/BulkDeleteLessonsService.php
+++ b/app/Services/Lesson/BulkDeleteLessonsService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\Lesson;
+
+use App\Model\Lesson;
+
+class BulkDeleteLessonsService
+{
+    /**
+     * 複数レッスンの削除
+     * 
+     * @param array<int> $lessonIds
+     * @param int $chapterId
+     */
+    public function __invoke(array $lessonIds, int $chapterId): void
+    {
+        // 削除対象レッスンのorderカラムを0に設定する
+        Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
+        // 対象レッスンの削除
+        Lesson::whereIn('id', $lessonIds)->delete();
+
+        //レッスン順序の更新
+        Lesson::where('chapter_id', $chapterId)
+            ->orderBy('order')
+            ->get()
+            ->each(function (Lesson $lesson, int $index) {
+                $lesson->update(['order' => $index + 1]);
+            });
+    }
+}

--- a/app/Services/Lesson/BulkDeleteLessonsService.php
+++ b/app/Services/Lesson/BulkDeleteLessonsService.php
@@ -8,9 +8,8 @@ class BulkDeleteLessonsService
 {
     /**
      * 複数レッスンの削除
-     * 
-     * @param array<int> $lessonIds
-     * @param int $chapterId
+     *
+     * @param  array<int>  $lessonIds
      */
     public function __invoke(array $lessonIds, int $chapterId): void
     {


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1234

## 概要
- 複数レッスン削除処理サービスクラスの実装

## 動作確認前作業_Adminer
- テストデータ準備
下記4件分のテストデータ作成  
    <img width="954" alt="image" src="https://github.com/user-attachments/assets/35d16441-0e8f-4cf2-9a72-0b82d6fc2a1b" />


## 動作確認_Manager
1. 下記の講師(Manager)でログイン
    - メソッド：POST
    - URL：http://localhost:8080/login/instructor
    - email：test_instructor@example.com
    - password：password
    - 結果：200 OK
      ``` json
      {
          "result": true,
          "message": "Authenticated."
      }
      ```

2. 下記リクエストの削除処理を実行し、正常に動作することを確認
    <img width="753" alt="image" src="https://github.com/user-attachments/assets/99296e12-db01-4f56-90aa-6574eeaa69d2" />
結果：200 OK
    ``` json
    {
      "result": true
    }
    ```

3. Adminerにて`deleted_at`カラムが削除処理実行日時か確認
`order`カラムが更新されていることを確認
    <img width="1007" alt="image" src="https://github.com/user-attachments/assets/32ef3bcb-04ca-4cd0-8df4-7413cc387b6f" />

## 動作確認_Instructor
1. 下記の講師(Instructor)でログイン
    - メソッド：POST
    - URL：http://localhost:8080/login/instructor
    - email：test_instructor2@example.com
    - password：password
    - 結果：200 OK
      ``` json
      {
          "result": true,
          "message": "Authenticated."
      }
      ```

2. 下記リクエストの削除処理を実行し、正常に動作することを確認
    <img width="742" alt="スクリーンショット 2025-05-30 16 29 41" src="https://github.com/user-attachments/assets/b8ea1721-fddf-4c28-8487-a8012bf03bc8" />
結果：200 OK
     ``` json
     {
       "result": true
     }
     ```

3. Adminerにて`deleted_at`カラムが削除処理実行日時か確認
`order`カラムが更新されていることを確認
    <img width="1012" alt="image" src="https://github.com/user-attachments/assets/d6926559-4753-424e-993a-70b540f70f33" />
