### PR TITLE
JKA-1345 講師/マネージャー 講座削除機能へのPolicyパターンを用いた認可機能の実装（街）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -180,19 +180,14 @@ class CourseController extends Controller
     /**
      * 講座削除API
      */
-    public function delete(DeleteRequest $request): JsonResponse
+    public function delete(DeleteRequest $request, Course $course, Attendance $attendance): JsonResponse
     {
         try {
-            $user = Instructor::find(Auth::guard('instructor')->user()->id);
-            $course = Course::findOrFail($request->course_id);
+            // $user = Instructor::find(Auth::guard('instructor')->user()->id);
+            // $course = Course::findOrFail($request->course_id);
 
-            if ($user->id !== $course->instructor_id) {
-                throw new AuthorizationException('Invalid instructor_id.');
-            }
-
-            if (Attendance::where('course_id', $request->course_id)->exists()) {
-                throw new AuthorizationException('This course has already been taken by students.');
-            }
+            $this->authorize('delete', $course);
+            $this->authorize('delete', $attendance);
 
             // publicディレクトリ配下の画像ファイルを削除
             if (Storage::exists('public/'.$course->image)) {

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -180,14 +180,17 @@ class CourseController extends Controller
     /**
      * 講座削除API
      */
-    public function delete(DeleteRequest $request, Course $course, Attendance $attendance): JsonResponse
+    public function delete(DeleteRequest $request): JsonResponse
     {
         try {
-            // $user = Instructor::find(Auth::guard('instructor')->user()->id);
-            // $course = Course::findOrFail($request->course_id);
+            $course = Course::findOrFail($request->course_id);
+            // $attendance = Attendance::where('course_id', $request->course_id);
 
+            // ログイン講師のidと削除講座の講師IDが一致しないと削除できない
             $this->authorize('delete', $course);
-            $this->authorize('delete', $attendance);
+
+            // 受講者がいる場合は削除できない
+            $this->authorize('deletable', $course);
 
             // publicディレクトリ配下の画像ファイルを削除
             if (Storage::exists('public/'.$course->image)) {

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -184,22 +184,15 @@ class CourseController extends Controller
      */
     public function delete(DeleteRequest $request)
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-        $instructor = Instructor::with('managings')->find($instructorId);
-        $managingIds = $instructor->managings->pluck('id')->toArray();
-        $managingIds[] = $instructorId;
-
         try {
             $course = Course::findOrFail($request->course_id);
+            // $attendance = Attendance::where('course_id', $request->course_id)->id;
 
-            if (! in_array($course->instructor_id, $managingIds, true)) {
-                // 自分、または配下の講師の講座でなければエラー応答
-                throw new AuthorizationException('Invalid instructor_id.');
-            }
+            // 自分、または配下の講師の講座でないと削除できない
+            $this->authorize('delete', $course);
 
-            if (Attendance::where('course_id', $request->course_id)->exists()) {
-                throw new AuthorizationException('This course has already been taken by students.');
-            }
+            // 受講者がいる場合は削除できない
+            $this->authorize('deletable', $course);
 
             // publicディレクトリ配下の画像ファイルを削除
             if (Storage::disk('public')->exists($course->image)) {

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -2,17 +2,17 @@
 
 namespace App\Policies;
 
-use App\Model\Attendance;
+use App\Model\Instructor;
 use App\Model\Course;
-use Illuminate\Auth\Access\Response;
+use App\Model\Attendance;
 
 class AttendancePolicy
 {
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(Course $course): bool
+    public function deletable(Instructor $instructor, Course $course): bool
     {
-        return Attendance::where('course_id', $course->course_id)->exists();
+        return !Attendance::where('course_id', $course->course_id)->exists();
     }
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -15,5 +15,4 @@ class AttendancePolicy
     {
         return Attendance::where('course_id', $course->course_id)->exists();
     }
-        
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Attendance;
+use App\Model\Course;
+use Illuminate\Auth\Access\Response;
+
+class AttendancePolicy
+{
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(Course $course): bool
+    {
+        return Attendance::where('course_id', $course->course_id)->exists();
+    }
+        
+}

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -2,9 +2,9 @@
 
 namespace App\Policies;
 
-use App\Model\Instructor;
-use App\Model\Course;
 use App\Model\Attendance;
+use App\Model\Course;
+use App\Model\Instructor;
 
 class AttendancePolicy
 {
@@ -13,6 +13,6 @@ class AttendancePolicy
      */
     public function deletable(Instructor $instructor, Course $course): bool
     {
-        return !Attendance::where('course_id', $course->course_id)->exists();
+        return ! Attendance::where('course_id', $course->course_id)->exists();
     }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Instructor;
+use App\Model\Course;
+use App\Model\Attendance;
+use Illuminate\Auth\Access\Response;
+
+class CoursePolicy
+{
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(Instructor $instructor, Course $course): bool
+    {
+        return $instructor->id === $course->instructor_id;
+    }
+}

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -2,11 +2,10 @@
 
 namespace App\Policies;
 
+use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
-use App\Model\Attendance;
 use App\Model\ManageInstructor;
-
 
 class CoursePolicy
 {
@@ -23,6 +22,7 @@ class CoursePolicy
             }
             $instructorIds = $manager->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;
+
             return in_array($course->instructor_id, $instructorIds);
 
         } else {
@@ -33,6 +33,6 @@ class CoursePolicy
 
     public function deletable(Instructor $instructor, Course $course): bool
     {
-        return !Attendance::where('course_id', $course->id)->exists();
+        return ! Attendance::where('course_id', $course->id)->exists();
     }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -2,18 +2,37 @@
 
 namespace App\Policies;
 
-use App\Model\Instructor;
 use App\Model\Course;
+use App\Model\Instructor;
 use App\Model\Attendance;
-use Illuminate\Auth\Access\Response;
+use App\Model\ManageInstructor;
+
 
 class CoursePolicy
 {
     /**
-     * Determine whether the user can delete the model.
+     * Determine whether the instructor can delete the course.
      */
     public function delete(Instructor $instructor, Course $course): bool
     {
-        return $instructor->id === $course->instructor_id;
+        if (ManageInstructor::where('manager_id', $instructor->id)->exists()) {
+            // マネージャー権限のある講師
+            $manager = Instructor::with('managings')->find($instructor->id);
+            if (! $manager) {
+                return false;
+            }
+            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+            return in_array($course->instructor_id, $instructorIds);
+
+        } else {
+            // マネージャー権限のない講師
+            return $instructor->id === $course->instructor_id;
+        }
+    }
+
+    public function deletable(Instructor $instructor, Course $course): bool
+    {
+        return !Attendance::where('course_id', $course->id)->exists();
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,10 +2,10 @@
 
 namespace App\Providers;
 
-use App\Model\Course;
 use App\Model\Attendance;
-use App\Policies\CoursePolicy;
+use App\Model\Course;
 use App\Policies\AttendancePolicy;
+use App\Policies\CoursePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Model\Course;
+use App\Model\Attendance;
+use App\Policies\CoursePolicy;
+use App\Policies\AttendancePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -12,8 +16,8 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        'App\Course' => 'App\Policies\CoursePolicy',
-        'App\Attendance' => 'App\Policies\AttendancePolicy',
+        Course::class => CoursePolicy::class,
+        Attendance::class => AttendancePolicy::class,
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -12,7 +12,8 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        // 'App\Model' => 'App\Policies\ModelPolicy',
+        'App\Course' => 'App\Policies\CoursePolicy',
+        'App\Attendance' => 'App\Policies\AttendancePolicy',
     ];
 
     /**


### PR DESCRIPTION
## issue
JKA-1345 講師/マネージャー 講座削除機能へのPolicyパターンを用いた認可機能の実装

## 実装内容
講師/マネージャーの講座削除メソッドdelete()内部の、認可機能をpolicyパターンで書き換えた。

１）Policyファイルの作成
・appディレクトリ配下にPoliciesディレクトリ、その中にCoursePolicy.phpを作成。
・ログインユーザ情報の取得、認可のメソッドとしてdelete()を定義。ログインユーザのマネージャー権限有無で認可処理を分けた。
・受講記録の認可メソッドとしてdeletable()を定義。受講記録の判定処理を記述。

２）ポリシーマッピングの登録
・CoursePolicyを有効化するため、【app/Providers/AuthServiceProvider.php】にてCourse::class => CoursePolicy::classを記述。

３）インストラクター側コントローラーの削除メソッド訂正【app/Http/Controllers/Api/Instructor/CourseController.php】にて、下記のようにユーザ認可&受講記録からの認可を、CoursePolicy.phpのメソッド呼び出しに置き換えた。
<img width="676" alt="image" src="https://github.com/user-attachments/assets/90640dea-b146-4540-a3db-196fcb8f6bbe" />

４）マネージャー側コントローラーの削除メソッド訂正
【app/Http/Controllers/Api/Manager/CourseController.php】にて、下記のようにユーザ認可&受講記録からの認可を、CoursePolicy.phpのメソッド呼び出しに置き換えた。
<img width="820" alt="image" src="https://github.com/user-attachments/assets/af8190f4-916f-4814-85b6-6250b1df3b63" />

※補足
前記実装の他に、受講記録の認可を別Policyファイルに分ける方法があった（下記実装）。
・AttendancePolicy.phpを作成、if(Attendance::where~){throw new AuthorizationExcepion}を記述
・コントローラー側にattendance情報の取得を記述：$attendance = Attendance::where('course_id', $request->course_id);
・AuthServiceProviderへポリシー登録：Attendance::class => AttendancePolicy::class,

この実装は、
メリット：受講記録認可のポリシーファイルを他の機能でも呼び出しが容易になる
デメリット：ポリシーファイルが増える。受講記録データの取得$attendanceが必要、コントローラー側コードが増える。

対して、前記CoursePolicy.php内に受講記録認可も含める実装は、
メリット：ポリシーファイル数を１つにできる。データ取得はコースデータ$courseのみにできる。
デメリット：重大なものはない。

これより、CoursePlicy.phpに講座認可、受講記録認可を両方含める実装を選択した。

## 動作確認
[1] インストラクターロール
下記のケースを確認した。
<img width="301" alt="image" src="https://github.com/user-attachments/assets/a76ebf5e-ec01-4733-88b3-700547ff5624" />
・instructor_id=2（非マネージャ）でログイン
・coursesテーブルは、最初deleted_atは全てnullだった。

(1)の確認：
courseテーブルid=2の削除を試みた
200OK
<img width="531" alt="image" src="https://github.com/user-attachments/assets/4480caab-97f7-4c4b-85ce-67994d1678ad" />
coursesテーブルid=2のレコード、deleted_atに削除日時が入ることを確認（削除できた）
![image](https://github.com/user-attachments/assets/d9e00ac1-7802-413d-a510-67ef392e516b)

(2)の確認：
courseテーブルid=6の削除を試みた
このレコードは、受講者記録がある（attendanceテーブルにcourse_id=6のレコードあり）
![image](https://github.com/user-attachments/assets/86d12dfe-e97f-4668-8a81-ff5595430bbb)

リクエスト後、403Forbidden、unaurhorizedを確認
<img width="528" alt="image" src="https://github.com/user-attachments/assets/2f1c7cd0-9546-4c1d-8568-accd6b41adc0" />
courseテーブルid=6のレコード、deleted_atに削除日時が入らないことを確認（削除できず）
![image](https://github.com/user-attachments/assets/a05181c2-f6f2-4f28-a400-e74065a9d581)

(3)の確認：
courseテーブルid=3の削除を試みた
リクエスト後、deleted_atがnullのままを確認（削除出来ず）＆エラー確認
![image](https://github.com/user-attachments/assets/258393c6-5f60-4cd0-9989-75b1462c0099)

(4)の確認：
courseテーブルid=1のレコード削除を試みた。
このレコードは、受講者記録がある（attendanceテーブルにcourse_id=1のレコードあり）
![image](https://github.com/user-attachments/assets/64655981-1f1f-4f72-a08e-982ea47fea13)
リクエスト後、id=1のレコードのdeleted_atはnullのままを確認（削除出来ず）。かつ、エラー確認
![image](https://github.com/user-attachments/assets/ef95a04e-3906-4f92-89f1-255610ec394e)
<img width="544" alt="image" src="https://github.com/user-attachments/assets/34cc421b-2caa-4fc2-80a3-ceada0f80acb" />


[2] マネージャーロール
下記のケースを確認した。
<img width="302" alt="image" src="https://github.com/user-attachments/assets/f6f841f6-0c1f-4563-b4ac-704a4db71fbd" />
・instructor_id=1（マネージャ権限あり）でログイン
・coursesテーブルは、最初deleted_atは全てnullだった。

(1)の確認：
courseテーブルid=5のレコード削除を試みた
これはinstructor_id=1であり、自分が所有する講座。
リクエスト後、200OK
<img width="532" alt="image" src="https://github.com/user-attachments/assets/689c3a6a-36be-4799-a7d8-d7f4aefa6600" />
deleted_atへ日時が入った（削除出来た）
![image](https://github.com/user-attachments/assets/85d9ae87-8093-447c-8b05-e02863800aa2)

(2)の確認：
courseテーブルid=1のレコード（自分所有）削除を試みた。
このレコードは、受講者記録がある（attendanceテーブルにcourse_id=1のレコードあり）
![image](https://github.com/user-attachments/assets/64655981-1f1f-4f72-a08e-982ea47fea13)
リクエスト後、403&エラー表示確認
<img width="531" alt="image" src="https://github.com/user-attachments/assets/0c2603ba-0003-4773-aa0d-b2933e26d645" />
![image](https://github.com/user-attachments/assets/4df1ce99-50a3-46fd-b187-d75c73f11f23)

(3)の確認：
マネージャーinstructor_id=1は、instructor_id=2と3を配下に持つ。
![image](https://github.com/user-attachments/assets/743edb1b-5449-4efd-872b-f9a01f09df5a)

courseテーブルid=2のレコード（配下の講師が所有）削除を試みた。
リクエスト後、200OK、deleted_atへ日時が入った（削除出来た）
![image](https://github.com/user-attachments/assets/e0287803-166d-40b3-9198-a9acf4137f37)

(4)の確認：
courseテーブルid=6のレコード（配下の講師が所有）削除を試みた。
このレコードは、受講者記録がある（attendanceテーブルにcourse_id=6のレコードあり）
リクエスト後、403、エラー確認。deleted_atへ日時入らず。
![image](https://github.com/user-attachments/assets/b7903291-9da0-4eec-a5f8-b0ae2713cad3)

(5)の確認：
courseテーブルid=4のレコード（instructor_id=4が所有。自分＆配下の講師どちらでもない講座）の削除を試みた。
リクエスト後、エラー＆deleted_atへ日時入らず。
![image](https://github.com/user-attachments/assets/38ccd03d-ffe8-4343-aaba-ccaa4cf80a00)

(6)の確認：
courseテーブルid=8のレコード（instructor_id=4が所有。自分＆配下の講師どちらでもない講座）の削除を試みた。
このレコードは、受講者記録がある（attendanceテーブルにcourse_id=6のレコードあり）
![image](https://github.com/user-attachments/assets/e1f1fc25-6cb3-4aaf-9c7c-fc81f095dc4f)
りくリクエスト後、エラー＆deleted_atへ日時入らず。
![image](https://github.com/user-attachments/assets/08aaf8fe-b467-4f33-ac15-fd744f07afed)

