### PR TITLE
JKA-1287 受講生側 お知らせ取得APIを修正して公開・非公開の情報を渡すように変更(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Student;
 
+use App\Enums\Notification\StatusEnum;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Student\Notification\IndexRequest;
 use App\Http\Requests\Student\Notification\ShowRequest;
@@ -36,7 +37,7 @@ class NotificationController extends Controller
 
         $notifications = Notification::with('course')
             ->whereIn('course_id', $courseIds)
-            ->where('status', 'public')
+            ->where('status', StatusEnum::PUBLIC)
             ->where('start_date', '<=', $currentDateTime)
             ->where('end_date', '>=', $currentDateTime)
             ->orderBy($sortBy, $order)

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -36,6 +36,7 @@ class NotificationController extends Controller
 
         $notifications = Notification::with('course')
             ->whereIn('course_id', $courseIds)
+            ->where('status', 'public')
             ->where('start_date', '<=', $currentDateTime)
             ->where('end_date', '>=', $currentDateTime)
             ->orderBy($sortBy, $order)

--- a/tests/Feature/Api/Student/Notification/IndexTest.php
+++ b/tests/Feature/Api/Student/Notification/IndexTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Api\Student\Notification;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ一覧取得_成功(): void
+    {
+        // arrange
+        $student = Student::find(1);
+        $this->actingAs($student, 'web');
+
+        // act
+        $response = $this->getJson('/api/v1/notification/index');
+
+        // assert
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Issue
#### JKA-受講生側 お知らせ取得APIを修正して公開・非公開の情報を渡すように変更
・受講生へお知らせ表示をstatusで表示・非表示の状態管理を行う

## 変更内容
・Student/NotificationController.php　indexメソッドを修正
returnで返却するjson内へstatus(publicのもの)を追加

## 6/5修正 Controller Status箇所Enum使用
修正後、下記同様のテストを実施し問題なく作動を確認しました。
参考までにControllerで使用しているStatusEnumのコード内容を書き記載いたします。
```
<?php

namespace App\Enums\Notification;

enum StatusEnum: string
{
    case PUBLIC = 'public';
    case PRIVATE = 'private';
}

```
## テスト
・student id_1でindexメソッドを実施
※期待する挙動：id_1及びid_9の２つを取得
・データベース(notificationテーブル)
![スクリーンショット 2025-06-04 131755](https://github.com/user-attachments/assets/4032cdfa-dd2b-48bd-9da5-add1c9e790ba)
・リクエスト(成功)
![スクリーンショット 2025-06-04 131805](https://github.com/user-attachments/assets/e402eb65-6b8d-4dcb-90b8-226d63d00fdc)
・json(id_1, id_9 を取得)
![スクリーンショット 2025-06-04 131811](https://github.com/user-attachments/assets/0e4138f3-497c-4062-92b6-855a9f5963da)
