### PR TITLE
複数レッスンステータス更新処理サービスクラスの実装 （nako）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -19,6 +19,7 @@ use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\BulkDeleteLessonsService;
+use App\Services\Lesson\BulkUpdateLessonStatusService;
 use App\Services\Lesson\DeleteAllLessonsService;
 use App\Services\Lesson\DeleteLessonService;
 use App\Services\Lesson\SortLessonsService;
@@ -335,16 +336,18 @@ class LessonController extends Controller
     /**
      * 選択済みのレッスンステータス一括更新API
      */
-    public function putStatus(PutStatusRequest $request): JsonResponse
+    public function putStatus(PutStatusRequest $request, BulkUpdateLessonStatusService $service): JsonResponse
     {
-        // リクエストから必要なデータを取得
+        // ログイン中の講師IDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+        
+        // リクエストからデータを取得
         $courseId = $request->input('course_id');
         $chapterId = $request->input('chapter_id');
         $lessonIds = $request->input('lessons');
         $status = $request->input('status');
-        // ログイン中の講師IDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-        // クエリ実行
+        
+        // レッスンデータの取得
         $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
         try {
             // 認可
@@ -362,8 +365,8 @@ class LessonController extends Controller
                     throw new AuthorizationException('Invalid chapter_id.');
                 }
             });
-            // ステータスを一括更新
-            Lesson::whereIn('id', $lessonIds)->update(['status' => $status]);
+            //サービス呼び出し
+            $service($lessons, $status);
 
             return response()->json([
                 'result' => true,

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -340,13 +340,13 @@ class LessonController extends Controller
     {
         // ログイン中の講師IDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
-        
+
         // リクエストからデータを取得
         $courseId = $request->input('course_id');
         $chapterId = $request->input('chapter_id');
         $lessonIds = $request->input('lessons');
         $status = $request->input('status');
-        
+
         // レッスンデータの取得
         $lessons = Lesson::with('chapter.course')->whereIn('id', $lessonIds)->get();
         try {

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -365,8 +365,11 @@ class LessonController extends Controller
                     throw new AuthorizationException('Invalid chapter_id.');
                 }
             });
-            //サービス呼び出し
-            $service($lessons, $status);
+
+            $service(
+                lessons: $lessons,
+                status: $status
+            );
 
             return response()->json([
                 'result' => true,

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -359,8 +359,10 @@ class LessonController extends Controller
                 }
             });
 
-            //サービス呼び出し
-            $service($lessons, $status);
+            $service(
+                lessons: $lessons,
+                status: $status
+            );
 
             return response()->json([
                 'result' => true,

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -20,6 +20,7 @@ use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\BulkDeleteLessonsService;
+use App\Services\Lesson\BulkUpdateLessonStatusService;
 use App\Services\Lesson\DeleteAllLessonsService;
 use App\Services\Lesson\DeleteLessonService;
 use App\Services\Lesson\SortLessonsService;
@@ -323,7 +324,7 @@ class LessonController extends Controller
     /**
      * 選択済みレッスンステータス一括更新API
      */
-    public function putStatus(PutStatusRequest $request): JsonResponse
+    public function putStatus(PutStatusRequest $request, BulkUpdateLessonStatusService $service): JsonResponse
     {
         // ログイン中の講師IDを取得
         $managerId = Auth::guard('instructor')->user()->id;
@@ -358,8 +359,8 @@ class LessonController extends Controller
                 }
             });
 
-            // レッスンのステータスを一括更新
-            Lesson::whereIn('id', $lessons->pluck('id')->toArray())->update(['status' => $status]);
+            //サービス呼び出し
+            $service($lessons, $status);
 
             return response()->json([
                 'result' => true,

--- a/app/Services/Lesson/BulkUpdateLessonStatusService.php
+++ b/app/Services/Lesson/BulkUpdateLessonStatusService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services\Lesson;
+
+use App\Model\Lesson;
+use Illuminate\Support\Collection;
+
+class BulkUpdateLessonStatusService
+{
+    /**
+     * レッスンのステータスを一括更新する
+     */
+    public function __invoke(Collection $lessons, string $status): void
+    {
+        Lesson::whereIn('id', $lessons->pluck('id'))->update(['status' => $status]);
+    }
+}

--- a/app/Services/Lesson/BulkUpdateLessonStatusService.php
+++ b/app/Services/Lesson/BulkUpdateLessonStatusService.php
@@ -9,6 +9,9 @@ class BulkUpdateLessonStatusService
 {
     /**
      * レッスンのステータスを一括更新する
+     * 
+     * @param Collection<int, Lesson> $lessons
+     * @param 'public'|'private' $status
      */
     public function __invoke(Collection $lessons, string $status): void
     {

--- a/app/Services/Lesson/BulkUpdateLessonStatusService.php
+++ b/app/Services/Lesson/BulkUpdateLessonStatusService.php
@@ -9,9 +9,9 @@ class BulkUpdateLessonStatusService
 {
     /**
      * レッスンのステータスを一括更新する
-     * 
-     * @param Collection<int, Lesson> $lessons
-     * @param 'public'|'private' $status
+     *
+     * @param  Collection<int, Lesson>  $lessons
+     * @param  'public'|'private'  $status
      */
     public function __invoke(Collection $lessons, string $status): void
     {


### PR DESCRIPTION
## Issue
・JKA-1236　複数レッスンステータス更新処理サービスクラスの実装

## 概要
※サービスクラスの追加
※LessonController修正
※Postman検証

## 処理内容
①app/Services/Lesson/BulkUpdateLessonStatusService.php
　を作成し、invokeを使用した処理を記述

②Manager/Instructorそれぞれ
　LexxonControllerのコードを修正

③Postmanで検証。

## テスト
◇Manager
※instructor Id-1のユーザーのlesson_id 2, 3, 4, 5 のstatusを変更する。
　以下アクセスURL　
　http://localhost:8080/api/v1/manager/course/1/chapter/2/lesson/status
　bodyはこのように記述
{
  "course_id": 1,
  "chapter_id": 2,
  "lessons": [2, 3, 4, 5],
  "status": "private"
}

●期待される結果：ステータスがprivateに変更。

●結果：成功
![image](https://github.com/user-attachments/assets/1f6bbc41-b5e2-4ea6-a763-d172a9ed0dfd)
![image](https://github.com/user-attachments/assets/f7fe64a2-2fad-4e10-abaf-3f6c41bd1b9f)

◇Instructor
※instructor Id-2のユーザーのlesson_id 8,9 のstatusを変更する。
　以下アクセスURL　
　http://localhost:8080/api/v1/manager/course/2/chapter/5/lesson/status
　bodyはこのように記述
{
  "course_id": 2,
  "chapter_id": 5,
  "lessons": [8, 9],
  "status": "private"
}

●期待される結果：ステータスがprivateに変更。

●結果：成功
![image](https://github.com/user-attachments/assets/cfb7e8c2-31ad-43b7-8051-4fb3bea0319a)
![image](https://github.com/user-attachments/assets/e3c88828-aa14-4901-8c61-85789b380de1)
