### PR TITLE
jka-1348 講座削除サービスクラスの実装（芦野）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -193,9 +193,9 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        }catch(AuthorizationException $e){
+        } catch (AuthorizationException $e) {
             throw $e;
-        }catch (Exception $e) {
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
         }

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -188,13 +188,11 @@ class CourseController extends Controller
             // ログイン講師のidと削除講座の講師IDが一致しないと削除できない
             $this->authorize('delete', $course);
 
-            $service($course);
+            $service(course: $course);
 
             return response()->json([
                 'result' => true,
             ]);
-        } catch (AuthorizationException $e) {
-            throw $e;
         } catch (Exception $e) {
             Log::error($e);
             throw $e;

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -11,10 +11,10 @@ use App\Http\Requests\Instructor\Course\StoreRequest;
 use App\Http\Requests\Instructor\Course\UpdateRequest;
 use App\Http\Resources\Instructor\CourseIndexResource;
 use App\Http\Resources\Instructor\CourseShowResource;
-use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Tag;
+use App\Services\Course\DeleteService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
@@ -180,7 +180,7 @@ class CourseController extends Controller
     /**
      * 講座削除API
      */
-    public function delete(DeleteRequest $request): JsonResponse
+    public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {
         try {
             $course = Course::findOrFail($request->course_id);
@@ -188,17 +188,7 @@ class CourseController extends Controller
             // ログイン講師のidと削除講座の講師IDが一致しないと削除できない
             $this->authorize('delete', $course);
 
-            // 受講者がいる場合は削除できない
-            if (Attendance::where('course_id', $request->course_id)->exists()) {
-                throw new AuthorizationException('This course has already been taken by students.');
-            }
-
-            // publicディレクトリ配下の画像ファイルを削除
-            if (Storage::exists('public/'.$course->image)) {
-                Storage::delete('public/'.$course->image);
-            }
-
-            $course->delete();
+            $service($course);
 
             return response()->json([
                 'result' => true,

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -193,7 +193,9 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (Exception $e) {
+        }catch(AuthorizationException $e){
+            throw $e;
+        }catch (Exception $e) {
             Log::error($e);
             throw $e;
         }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -180,7 +180,6 @@ class CourseController extends Controller
     /**
      * 講座削除API
      *      *
-     * @return JsonResponse
      */
     public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -11,9 +11,9 @@ use App\Http\Requests\Manager\Course\StoreRequest;
 use App\Http\Requests\Manager\Course\UpdateRequest;
 use App\Http\Resources\Manager\CourseIndexResource;
 use App\Http\Resources\Manager\CourseShowResource;
-use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Services\Course\DeleteService;
 use App\Services\Course\QueryService;
 use Carbon\Carbon;
 use Exception;
@@ -182,7 +182,7 @@ class CourseController extends Controller
      *
      * @return JsonResponse
      */
-    public function delete(DeleteRequest $request)
+    public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {
         try {
             $course = Course::findOrFail($request->course_id);
@@ -190,17 +190,7 @@ class CourseController extends Controller
             // 自分、または配下の講師の講座でないと削除できない
             $this->authorize('delete', $course);
 
-            // 受講者がいる場合は削除できない
-            if (Attendance::where('course_id', $request->course_id)->exists()) {
-                throw new AuthorizationException('This course has already been taken by students.');
-            }
-
-            // publicディレクトリ配下の画像ファイルを削除
-            if (Storage::disk('public')->exists($course->image)) {
-                Storage::disk('public')->delete($course->image);
-            }
-
-            $course->delete();
+            $service($course);
 
             return response()->json([
                 'result' => true,

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -195,7 +195,7 @@ class CourseController extends Controller
             return response()->json([
                 'result' => true,
             ]);
-        } catch (ModelNotFoundException $e) {
+        } catch (AuthorizationException $e) {
             throw $e;
         } catch (Exception $e) {
             Log::error($e);

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -179,8 +179,6 @@ class CourseController extends Controller
 
     /**
      * 講座削除API
-     *
-     * @return JsonResponse
      */
     public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -179,6 +179,8 @@ class CourseController extends Controller
 
     /**
      * 講座削除API
+     *      *
+     * @return JsonResponse
      */
     public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -73,10 +73,8 @@ class CourseController extends Controller
 
     /**
      * 講座情報取得API
-     *
-     * @return CourseShowResource|JsonResponse
      */
-    public function show(ShowRequest $request, QueryService $queryService)
+    public function show(ShowRequest $request, QueryService $queryService): CourseShowResource
     {
         // ログイン中の講師IDを取得
         $userId = Auth::guard('instructor')->user()->id;
@@ -98,10 +96,8 @@ class CourseController extends Controller
 
     /**
      * 講座登録API
-     *
-     * @return JsonResponse
      */
-    public function store(StoreRequest $request)
+    public function store(StoreRequest $request): JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
@@ -127,10 +123,8 @@ class CourseController extends Controller
 
     /**
      * 講座情報更新API
-     *
-     * @return JsonResponse
      */
-    public function update(UpdateRequest $request)
+    public function update(UpdateRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $instructor = Instructor::with('managings')->find($instructorId);
@@ -179,7 +173,6 @@ class CourseController extends Controller
 
     /**
      * 講座削除API
-     *      *
      */
     public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {
@@ -189,7 +182,7 @@ class CourseController extends Controller
             // 自分、または配下の講師の講座でないと削除できない
             $this->authorize('delete', $course);
 
-            $service($course);
+            $service(course: $course);
 
             return response()->json([
                 'result' => true,
@@ -204,10 +197,8 @@ class CourseController extends Controller
 
     /**
      * 講座ステータス更新API
-     *
-     * @return JsonResponse
      */
-    public function status(StatusRequest $request)
+    public function status(StatusRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 

--- a/app/Services/Course/DeleteService.php
+++ b/app/Services/Course/DeleteService.php
@@ -11,6 +11,10 @@ class DeleteService
 {
     /**
      * 講座情報を削除
+     *
+     * @param Course $course
+     * @throws AuthorizationException
+     * @return void
      */
     public function __invoke(Course $course): void
     {

--- a/app/Services/Course/DeleteService.php
+++ b/app/Services/Course/DeleteService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\Course;
+
+use App\Model\Course;
+use App\Model\Attendance;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Storage;
+
+class DeleteService
+{
+    /**
+     * 講座情報を削除
+     */
+    public function __invoke(Course $course): void
+    {
+        // 該当講座に受講生者がいる場合、削除不可
+        if (Attendance::where('course_id', $course->id)->exists()) {
+            throw new AuthorizationException('This course has already been taken by students.');
+        }
+
+        // publicディレクトリに画像がある場合、削除
+        $disk = Storage::disk('public');
+        if ($disk->exists($course->image)) {
+            $disk->delete($course->image);
+        }
+        // 講座データ削除
+        $course->delete();
+    }
+}

--- a/app/Services/Course/DeleteService.php
+++ b/app/Services/Course/DeleteService.php
@@ -2,8 +2,8 @@
 
 namespace App\Services\Course;
 
-use App\Model\Course;
 use App\Model\Attendance;
+use App\Model\Course;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Services/Course/DeleteService.php
+++ b/app/Services/Course/DeleteService.php
@@ -12,9 +12,7 @@ class DeleteService
     /**
      * 講座情報を削除
      *
-     * @param Course $course
      * @throws AuthorizationException
-     * @return void
      */
     public function __invoke(Course $course): void
     {

--- a/tests/Feature/Api/Instructor/Course/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Course/DeleteTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/5');
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertSoftDeleted('courses', [
+            'id' => 5,
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/4');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
+    public function test_バリデーションエラー_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/instructor/course/aaa'); // 存在しないID
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['course_id']);
+    }
+}

--- a/tests/Feature/Api/Manager/Course/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Course/DeleteTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Course;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座削除_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/5');
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertSoftDeleted('courses', [
+            'id' => 5,
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/5');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
+    public function test_マネージャー権限がない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    public function test_バリデーションエラー_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->deleteJson('/api/v1/manager/course/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['course_id']);
+    }
+}


### PR DESCRIPTION
## Issue
jka-1348 講座削除サービスクラスの実装

## 背景
[ App/Http/Controller/Manager/CourseController.php ] 
[ App/Http/Controller/instructor/CourseController.php ] の
deleteメソッド、削除処理の共通化による保守性の向上

##  [DeleteService.php] 仕様確認
①重複している削除処理の共通化
②受講者存在チェックの共通化
③画像ファイル削除処理の共通化

## 実装内容
①[ App/Service/Course] 内へ [ DeleteService.php ] を作成、上記仕様内容を実装
②[ App/Http/Controller/Manager/CourseController.php ] の共通部分削除、 [ DeleteService.php ] 呼び出しを実装
③上記同様の処理を[ App/Http/Controller/instructor/CourseController.php ]で実装

## テスト
#### 参考
・instructorsテーブル
![スクリーンショット (103)](https://github.com/user-attachments/assets/67f077e4-14c2-4a0f-86a1-657f1cd5b8fc)

・coursesテーブ
![スクリーンショット (104)](https://github.com/user-attachments/assets/417f67ef-9a61-4277-ad97-8881e2e10cd3)
ル

・attendancesテーブル
![スクリーンショット (105)](https://github.com/user-attachments/assets/175cbab9-2741-4660-9154-a26a62b83a12)


#### テスト１　instructorId_2のユーザでinstructor側メソッドを実施
1-1 courseId_9を削除【期待挙動　成功】
![スクリーンショット (106)](https://github.com/user-attachments/assets/b9b4993c-423c-4c12-982d-6d253749c957)

1-2 courseId_2を削除【期待挙動　失敗：受講者有】
![スクリーンショット (107)](https://github.com/user-attachments/assets/0eaa0e1f-4321-44f8-b912-6e6bdadff802)

1-3 courseId_4を削除【期待挙動　失敗：権限無】
![スクリーンショット (108)](https://github.com/user-attachments/assets/d6c4a3a7-26cd-4f49-94a6-1063ee3d5746)

#### テスト２　instructorId_1のユーザでmanager側メソッドを実施
1-1 courseId_8を削除【期待挙動　成功】
![スクリーンショット (109)](https://github.com/user-attachments/assets/8ea7a8bd-4466-4549-9b0d-c3de84d09c64)

1-2 courseId_1を削除【期待挙動　失敗：受講者有】
![スクリーンショット (110)](https://github.com/user-attachments/assets/97ab3625-b986-435b-a8d0-23684d822451)

1-3 courseId_4を削除【期待挙動　失敗：権限無】
![スクリーンショット (111)](https://github.com/user-attachments/assets/07d10d7f-ac31-42e0-9a98-533d7b8d4acc)
