### PR TITLE
JKA-1373 講師/マネージャー レッスン削除機能へのPolicyパターンを用いた認可機能の実装（街）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -118,15 +118,15 @@ class LessonController extends Controller
         try {
             $lesson = Lesson::with('chapter')->findOrFail($request->lesson_id);
 
-            if (Auth::guard('instructor')->user()->id !== $lesson->chapter->course->instructor_id) {
-                throw new AuthorizationException('Forbidden, invalid instructor_id.');
-            }
+            // ログイン講師のidと削除講座の講師IDが一致しないと削除できない
+            $this->authorize('delete', $lesson);
 
             if ((int) $request->chapter_id !== $lesson->chapter->id) {
                 // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は更新を許可しない
                 throw new AuthorizationException('Invalid chapter_id.');
             }
 
+            // 受講情報が登録されている場合は削除を許可しない
             if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
                 throw new AuthorizationException('Forbidden, this lesson has attendance.');
             }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -96,7 +96,7 @@ class CourseController extends Controller
     /**
      * 講座登録API
      */
-    public function store(StoreRequest $request)
+    public function store(StoreRequest $request): JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -97,16 +97,23 @@ class CourseController extends Controller
     /**
      * 講座登録API
      */
-    public function store(StoreRequest $request, CreateCourseService $createCourseService): JsonResponse
+    public function store(StoreRequest $request)
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
-        $course = $createCourseService(
-            title: $request->title,
-            image: $request->file('image'),
-            tagId: $request->tag_id,
-            instructorOrManagerId: $managerId
-        );
+        $file = $request->file('image');
+        $extension = $file->getClientOriginalExtension();
+        $filename = Str::uuid()->toString().'.'.$extension;
+        $filePath = Storage::disk('public')->putFileAs('course', $file, $filename);
+
+        $course = Course::create([
+            'instructor_id' => $managerId,
+            'title' => $request->title,
+            'image' => $filePath,
+            'status' => Course::STATUS_PRIVATE,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -19,7 +19,6 @@ use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Auth;

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -97,23 +97,16 @@ class CourseController extends Controller
     /**
      * 講座登録API
      */
-    public function store(StoreRequest $request): JsonResponse
+    public function store(StoreRequest $request, CreateCourseService $createCourseService): JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
-        $file = $request->file('image');
-        $extension = $file->getClientOriginalExtension();
-        $filename = Str::uuid()->toString().'.'.$extension;
-        $filePath = Storage::disk('public')->putFileAs('course', $file, $filename);
-
-        $course = Course::create([
-            'instructor_id' => $managerId,
-            'title' => $request->title,
-            'image' => $filePath,
-            'status' => Course::STATUS_PRIVATE,
-            'created_at' => Carbon::now(),
-            'updated_at' => Carbon::now(),
-        ]);
+        $course = $createCourseService(
+            title: $request->title,
+            image: $request->file('image'),
+            tagId: $request->tag_id,
+            instructorOrManagerId: $managerId
+        );
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -19,6 +19,7 @@ use Carbon\Carbon;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Auth;

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -140,23 +140,12 @@ class LessonController extends Controller
     {
         DB::beginTransaction();
         try {
-            // 自身と配下のinstructor情報を取得
-            $managerId = Auth::guard('instructor')->user()->id;
-
-            $manager = Instructor::with('managings')->find($managerId);
-            assert($manager instanceof Instructor);
-
-            $instructorIds = $manager->managings->pluck('id')->toArray();
-            $instructorIds[] = $manager->id;
-
             // レッスン情報を取得
             /** @var Lesson $lesson */
             $lesson = Lesson::with('chapter')->findOrFail($request->lesson_id);
 
-            // 自身もしくは配下のinstructorの講座・チャプターに紐づくレッスンでない場合は許可しない
-            if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-                throw new AuthorizationException('Forbidden, not allowed to delete this lesson.');
-            }
+            // 自分、または配下の講師の講座でないと削除できない
+            $this->authorize('delete', $lesson);
 
             // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
             if ((int) $request->chapter_id !== $lesson->chapter->id) {

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -21,9 +21,6 @@ class CoursePolicy
         return $instructor->id === $course->instructor_id;
     }
 
-    /**
-     * Determine whether the instructor can delete the course.
-     */
     public function delete(Instructor $instructor, Course $course): bool
     {
         // マネージャー権限のある講師か判定

--- a/app/Policies/LessonPolicy.php
+++ b/app/Policies/LessonPolicy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Lesson;
+use App\Model\Instructor;
+
+class LessonPolicy
+{
+    public function delete(Instructor $instructor, Lesson $lesson): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $manager = Instructor::with('managings')->find($instructor->id);
+            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($lesson->chapter->course->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $instructor->id === $lesson->chapter->course->instructor_id;
+    }
+}

--- a/app/Policies/LessonPolicy.php
+++ b/app/Policies/LessonPolicy.php
@@ -2,8 +2,8 @@
 
 namespace App\Policies;
 
-use App\Model\Lesson;
 use App\Model\Instructor;
+use App\Model\Lesson;
 
 class LessonPolicy
 {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Model\Course;
+use App\Model\Lesson;
 use App\Policies\CoursePolicy;
+use App\Policies\LessonPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -15,6 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Course::class => CoursePolicy::class,
+        Lesson::class => LessonPolicy::class,
     ];
 
     /**

--- a/tests/Feature/Api/Instructor/Lesson/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/DeleteTest.php
@@ -69,7 +69,7 @@ class DeleteTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Lesson/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Lesson/DeleteTest.php
@@ -89,7 +89,7 @@ class DeleteTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, not allowed to delete this lesson.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 


### PR DESCRIPTION
## issue
JKA-1373 講師/マネージャー レッスン削除機能へのPolicyパターンを用いた認可機能の実装

## 実装内容
講師/マネージャーのレッスン削除メソッドdelete()内部の、認可機能をpolicyパターンで書き換えた。

１）Policyファイルの作成
・appディレクトリ配下にPoliciesディレクトリ、その中にLessonPolicy.phpを作成。
・ログインユーザ情報の取得、認可のメソッドとしてdelete()を定義。ログインユーザのマネージャー権限有無で認可処理を分けた。

２）ポリシーマッピングの登録
・LessonPolicyを有効化するため、【app/Providers/AuthServiceProvider.php】にてLesson::class => LessonPolicy::classを記述。

３）インストラクター側コントローラーの削除メソッド訂正【app/Http/Controllers/Api/Instructor/LessonController.php】にて、下記のようにユーザ認可&受講記録からの認可を、LessonPolicy.phpのメソッド呼び出しに置き換えた。

４）マネージャー側コントローラーの削除メソッド訂正
【app/Http/Controllers/Api/Manager/LessonController.php】にて、下記のようにユーザ認可&受講記録からの認可を、LessonPolicy.phpのメソッド呼び出しに置き換えた。

## 動作確認
１）インストラクターロール
・instructor_id=2でログイン
・lessonsテーブルは、最初deleted_atは全てnullだった。
１−１）自分が所有するレッスンの時：
下図のリクエスト後、lesson_id=7のレコードのdeleted_atに日付が入った（＝削除された）。
<img width="533" alt="image" src="https://github.com/user-attachments/assets/0a74f1f2-7692-4b71-92e3-89f0285e77f4" />
![image](https://github.com/user-attachments/assets/8391660d-2266-496c-bea6-7ed08551c6eb)

１−２）自分が所有してないレッスンの時：
下図のリクエスト後、lesson_id=1のレコードのdeleted_atに日付は入らず（＝削除されず）。unauthorizedのエラー表示を確認。
<img width="536" alt="image" src="https://github.com/user-attachments/assets/bc104aa8-6179-4a57-b58a-896c9796ccce" />

２）マネージャーロール
・instructor_id=1でログイン
・lessonsテーブルは、最初deleted_atは全てnullだった。
２−１）自分が所有するレッスンの時：
下図のリクエスト後、lesson_id=10のレコードのdeleted_atに日付が入った（＝削除された）。
<img width="525" alt="image" src="https://github.com/user-attachments/assets/46a3319d-b962-481c-ba75-fa7aa144f251" />
![image](https://github.com/user-attachments/assets/f5854052-4943-4bff-87d6-10705120d77d)

２−２）自分の配下のインストラクターが所有するレッスンの時：
下図のリクエスト後、lesson_id=7のレコードのdeleted_atに日付が入った（＝削除された）。
<img width="531" alt="image" src="https://github.com/user-attachments/assets/fafeb1ca-87fd-4224-928b-f02ad1c3b1ab" />
![image](https://github.com/user-attachments/assets/ecef989b-3ee2-4dcb-bc03-ccd880727ad2)

２−３）自分と配下のインストラクター両者が所有してないレッスンの時：
下図のリクエスト後、lesson_id=11のレコードのdeleted_atに日付は入らず（＝削除されず）。
<img width="527" alt="image" src="https://github.com/user-attachments/assets/fdb7aad2-f9f7-4483-8a73-b9f9fb3e9c45" />
![image](https://github.com/user-attachments/assets/f5992f08-3b58-41da-915a-7006216b2430)



