### PR TITLE
【保留中】jka-1369 講師/マネージャー チャプター削除機能(deleteメソッド)へのPolicyパターンを用いた認可機能の実装(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -168,7 +168,7 @@ class ChapterController extends Controller
         }
     }
 
-        /**
+    /**
      * チャプター削除API
      */
     public function delete(DeleteRequest $request): JsonResponse

--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Chapter\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Chapter\DeleteAllRequest;
+use App\Http\Requests\Instructor\Chapter\DeleteRequest;
 use App\Http\Requests\Instructor\Chapter\PatchRequest;
 use App\Http\Requests\Instructor\Chapter\PatchStatusRequest;
 use App\Http\Requests\Instructor\Chapter\PutStatusRequest;
@@ -165,6 +166,40 @@ class ChapterController extends Controller
             Log::error($e);
             throw $e;
         }
+    }
+
+        /**
+     * チャプター削除API
+     */
+    public function delete(DeleteRequest $request): JsonResponse
+    {
+        // チャプターを取得
+        $chapter = Chapter::with(['course', 'lessons'])->findOrFail($request->chapter_id);
+
+        // チャプターに紐づく全レッスンIDを取得
+        $lessonIds = $chapter->lessons->pluck('id')->toArray();
+
+        // 認可処理 policy使用
+        $this->authorize('delete', [Chapter::class, $chapter]);
+
+        if ((int) $request->course_id !== $chapter->course->id) {
+            // 指定した講座に属するチャプターでなければエラー応答
+            throw new AuthorizationException('Forbidden, invalid course_id.');
+        }
+
+        if (
+            LessonAttendance::whereIn('lesson_id', $lessonIds)
+                ->exists()
+        ) {
+            // 指定したチャプター内に受講中のレッスンがあればエラー応答
+            throw new AuthorizationException('Forbidden, this lesson has attendance.');
+        }
+
+        $chapter->delete();
+
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -146,25 +146,13 @@ class ChapterController extends Controller
      */
     public function delete(DeleteRequest $request): JsonResponse
     {
-        // // ログイン中の講師IDを取得
-        // $managerId = Auth::guard('instructor')->user()->id;
-
-        // // マネージャーが管理する講師を取得
-        // $manager = Instructor::with('managings')->find($managerId);
-        // $instructorIds = $manager->managings->pluck('id')->toArray();
-        // $instructorIds[] = $manager->id;
-
         // チャプターを取得
         $chapter = Chapter::with(['course', 'lessons'])->findOrFail($request->chapter_id);
 
         // チャプターに紐づく全レッスンIDを取得
         $lessonIds = $chapter->lessons->pluck('id')->toArray();
 
-        // if (! in_array($chapter->course->instructor_id, $instructorIds, true)) {
-        //     // 自分、または配下の講師の講座のチャプターでなければエラー応答
-        //     throw new AuthorizationException('Forbidden, not allowed to delete this chapter.');
-        // }
-
+        // 認可処理 policy使用
         $this->authorize('delete', [Chapter::class, $chapter]);
 
         if ((int) $request->course_id !== $chapter->course->id) {

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -146,13 +146,13 @@ class ChapterController extends Controller
      */
     public function delete(DeleteRequest $request): JsonResponse
     {
-        // ログイン中の講師IDを取得
-        $managerId = Auth::guard('instructor')->user()->id;
+        // // ログイン中の講師IDを取得
+        // $managerId = Auth::guard('instructor')->user()->id;
 
-        // マネージャーが管理する講師を取得
-        $manager = Instructor::with('managings')->find($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
+        // // マネージャーが管理する講師を取得
+        // $manager = Instructor::with('managings')->find($managerId);
+        // $instructorIds = $manager->managings->pluck('id')->toArray();
+        // $instructorIds[] = $manager->id;
 
         // チャプターを取得
         $chapter = Chapter::with(['course', 'lessons'])->findOrFail($request->chapter_id);
@@ -160,10 +160,12 @@ class ChapterController extends Controller
         // チャプターに紐づく全レッスンIDを取得
         $lessonIds = $chapter->lessons->pluck('id')->toArray();
 
-        if (! in_array($chapter->course->instructor_id, $instructorIds, true)) {
-            // 自分、または配下の講師の講座のチャプターでなければエラー応答
-            throw new AuthorizationException('Forbidden, not allowed to delete this chapter.');
-        }
+        // if (! in_array($chapter->course->instructor_id, $instructorIds, true)) {
+        //     // 自分、または配下の講師の講座のチャプターでなければエラー応答
+        //     throw new AuthorizationException('Forbidden, not allowed to delete this chapter.');
+        // }
+
+        $this->authorize('delete', [Chapter::class, $chapter]);
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座に属するチャプターでなければエラー応答

--- a/app/Http/Requests/Instructor/Chapter/DeleteRequest.php
+++ b/app/Http/Requests/Instructor/Chapter/DeleteRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Chapter;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
+        ];
+    }
+
+    #[\Override]
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+            'chapter_id' => $this->route('chapter_id'),
+        ]);
+    }
+}

--- a/app/Policies/ChapterPolicy.php
+++ b/app/Policies/ChapterPolicy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Policies\Policies;
+namespace App\Policies;
 
 use App\Model\Chapter;
 use App\Model\Instructor;

--- a/app/Policies/Policies/ChapterPolicy.php
+++ b/app/Policies/Policies/ChapterPolicy.php
@@ -2,13 +2,25 @@
 
 namespace App\Policies\Policies;
 
+use App\Model\Chapter;
+use App\Model\Instructor;
+
 class ChapterPolicy
 {
     /**
      * チャプター削除
      */
-    public function delete()
+    public function delete(Instructor $instructor, Chapter $chapter): bool
     {
-        //
+        if ($instructor->isManager()) {
+            // 管理者の場合、配下の講師の講座も削除可能
+            $managerIds = $instructor->managings->pluck('id')->toArray();
+            $managerIds[] = $instructor->id;
+
+            return in_array($chapter->course->instructor_id, $managerIds, true);
+        }
+
+        // 講師の場合、自分の講座のみ削除可能
+        return $instructor->id === $chapter->course->instructor_id;
     }
 }

--- a/app/Policies/Policies/ChapterPolicy.php
+++ b/app/Policies/Policies/ChapterPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Policies\Policies;
+
+class ChapterPolicy
+{
+    /**
+     * チャプター削除
+     */
+    public function delete()
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Model\Chapter;
 use App\Model\Course;
 use App\Policies\CoursePolicy;
+use App\Policies\Policies\ChapterPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -15,6 +17,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Course::class => CoursePolicy::class,
+        Chapter::class => ChapterPolicy::class,
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,8 +4,8 @@ namespace App\Providers;
 
 use App\Model\Chapter;
 use App\Model\Course;
-use App\Policies\CoursePolicy;
 use App\Policies\ChapterPolicy;
+use App\Policies\CoursePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,7 +5,7 @@ namespace App\Providers;
 use App\Model\Chapter;
 use App\Model\Course;
 use App\Policies\CoursePolicy;
-use App\Policies\Policies\ChapterPolicy;
+use App\Policies\ChapterPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/routes/api.php
+++ b/routes/api.php
@@ -87,6 +87,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('{chapter_id}')->group(function () {
                             Route::get('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'show']);
                             Route::put('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'put']);
+                            Route::delete('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'delete']);
                             // 講師-講座-チャプター-レッスン
                             Route::prefix('lesson')->group(function () {
                                 Route::post('/', [App\Http\Controllers\Api\Instructor\LessonController::class, 'store']);


### PR DESCRIPTION
## Issue
jka-1369 講師/マネージャー チャプター削除機能へのPolicyパターンを用いた認可機能の実装(Deleteメソッド)

## 仕様確認
①認可処理の共通化
②マネージャー/講師 における認可の分岐

## 背景
・認可ロジックの一元管理によるコードの保守性向上
・コントローラーのスリム化と単一責任の原則の遵守
・認可ロジックの再利用性の向上
・将来の権限要件変更への対応を容易にする

## 実装内容
① マッピング：Providers/AuthServiceProvider
② policy作成：Policies/ChapterPolicy
③controller, deleteメソッド修正：Manager/ChapterController 
④route Instructor, Chapter, deleteルート作成：Route/api
⑤controller, deleteメソッド作成：Instructor/ChapterController
⑥request作成：Request/Instructor/Chapter/DeleteRequest

## テスト
### 参考データテーブル
・instructor
![スクリーンショット 2025-06-10 125657](https://github.com/user-attachments/assets/e8b2d451-be26-48dd-9d42-1bc536fea6de)

・manage_instructor
![スクリーンショット 2025-06-10 125826](https://github.com/user-attachments/assets/055e514c-e45e-451b-b1ed-dae327955469)

・course
![スクリーンショット 2025-06-10 125810](https://github.com/user-attachments/assets/72058b59-665e-4a6b-8ca0-33b4e82977f3)

・chapter
![スクリーンショット 2025-06-10 125800](https://github.com/user-attachments/assets/9daf568c-1fbc-49c2-9c28-27efb7cb1bc0)



### instructor Id_1ユーザで下記テストを実施(manager側テスト)
①【成功】course_id, 9, chapter_id, 9 を削除(instructor_id, 2)
![スクリーンショット (128)](https://github.com/user-attachments/assets/988266e5-0277-4790-ae12-3af5de62e796)

②【失敗：権限無】course_id, 4, chapter_id, 11を削除(instructor_id, 4)
![スクリーンショット (129)](https://github.com/user-attachments/assets/975475a4-6b33-4b08-9db5-971bb1f9a691)

### instructor Id_2ユーザで下記テストを実施(instructor側テスト)
①【成功】course_id, 9, chap
![スクリーンショット (130)](https://github.com/user-attachments/assets/3e8d7ef6-e82d-4569-9341-1416a3c25568)
ter_id, 10 を削除(instructor_id, 2)

②【失敗：権限無】course_id, 8, chapter_id, 7 を削除(instructor_id, 1)
![スクリーンショット (131)](https://github.com/user-attachments/assets/ab97efe8-e41f-439c-9f3d-075621fb2f82)