### PR TITLE
JKA-1372 講師/マネージャー レッスン更新機能へのPolicyパターンを用いた認可機能の実装(miyagi)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -85,13 +85,11 @@ class LessonController extends Controller
      */
     public function put(PutRequest $request, UpdateLessonService $service): JsonResponse
     {
-        $user = Instructor::find($request->user()->id);
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
         assert($lesson instanceof Lesson);
 
-        if ($lesson->chapter->course->instructor_id !== $user->id) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        // Policy による認可チェック
+        $this->authorize('update', $lesson);
 
         if ((int) $request->course_id !== $lesson->chapter->course_id) {
             throw new AuthorizationException('Forbidden, invalid course_id.');

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -98,22 +98,11 @@ class LessonController extends Controller
      */
     public function put(PutRequest $request, UpdateLessonService $service): JsonResponse
     {
-        $managerId = Auth::guard('instructor')->user()->id;
-
-        // 配下の講師情報を取得
-        $manager = Instructor::with('managings')->find($managerId);
-        assert($manager instanceof Instructor);
-
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
         $lesson = Lesson::with('chapter.course')->findOrFail($request->lesson_id);
         assert($lesson instanceof Lesson);
 
-        if (! in_array($lesson->chapter->course->instructor_id, $instructorIds, true)) {
-            // 配下の講師でない場合は403エラー
-            throw new AuthorizationException('Forbidden, not allowed to this lesson.');
-        }
+        // Policy による認可チェック
+        $this->authorize('update', $lesson);
 
         if ((int) $request->course_id !== $lesson->chapter->course_id) {
             // 講座IDが不正な場合は403エラー

--- a/app/Policies/LessonPolicy.php
+++ b/app/Policies/LessonPolicy.php
@@ -9,11 +9,6 @@ class LessonPolicy
 {
     /**
      * レッスンの更新処理に関する認可処理
-     * 
-     * @param Instructor $instructor
-     * @param Lesson $lesson
-     * 
-     * @return bool
      */
     public function update(Instructor $instructor, Lesson $lesson): bool
     {

--- a/app/Policies/LessonPolicy.php
+++ b/app/Policies/LessonPolicy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Lesson;
+use App\Model\Instructor;
+
+class LessonPolicy
+{
+    /**
+     * レッスンの更新処理に関する認可処理
+     * 
+     * @param Instructor $instructor
+     * @param Lesson $lesson
+     * 
+     * @return bool
+     */
+    public function update(Instructor $instructor, Lesson $lesson): bool
+    {
+        // マネージャーの場合は配下の講師のレッスンも更新可能
+        if ($instructor->isManager()) {
+            $manager = Instructor::with('managings')->find($instructor->id);
+            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($lesson->chapter->course->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師の場合は自分のレッスンのみ更新可能
+        return $lesson->chapter->course->instructor_id === $instructor->id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Model\Course;
+use App\Model\Lesson;
 use App\Policies\CoursePolicy;
+use App\Policies\LessonPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -15,6 +17,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Course::class => CoursePolicy::class,
+        Lesson::class => LessonPolicy::class,
     ];
 
     /**

--- a/tests/Feature/Api/Instructor/Lesson/PutTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/PutTest.php
@@ -61,7 +61,7 @@ class PutTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Instructor/Notification/PutTest.php
+++ b/tests/Feature/Api/Instructor/Notification/PutTest.php
@@ -32,6 +32,7 @@ class PutTest extends TestCase
             'start_date' => '2024-01-01 00:00:00',
             'end_date' => '2024-01-02 00:00:00',
             'content' => 'content',
+            'status' => 'public',
         ]);
 
         // assert
@@ -43,6 +44,7 @@ class PutTest extends TestCase
             'start_date' => '2024-01-01 00:00:00',
             'end_date' => '2024-01-02 00:00:00',
             'content' => 'content',
+            'status' => 'public',
         ]);
     }
 
@@ -59,6 +61,7 @@ class PutTest extends TestCase
             'start_date' => '2024-01-01 00:00:00',
             'end_date' => '2024-01-02 00:00:00',
             'content' => 'content',
+            'status' => 'public',
         ]);
 
         // assert
@@ -81,6 +84,7 @@ class PutTest extends TestCase
             'start_date' => '',
             'end_date' => '',
             'content' => '',
+            'status' => '',
         ]);
 
         // assert
@@ -92,6 +96,7 @@ class PutTest extends TestCase
             'start_date',
             'end_date',
             'content',
+            'status',
         ]);
     }
 }

--- a/tests/Feature/Api/Manager/Lesson/PutTest.php
+++ b/tests/Feature/Api/Manager/Lesson/PutTest.php
@@ -88,7 +88,7 @@ class PutTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, not allowed to this lesson.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1372

## 概要
- 講師/マネージャー レッスン更新機能へのPolicyパターンを用いた認可機能の実装

## 動作確認
1. 正常系: 講師が自身のレッスンを更新できることを確認する
    - 下記の講師(Instructor)でログイン
        - メソッド：POST
        - URL：http://localhost:8080/login/instructor
        - email：test_instructor2@example.com
        - password：password
        - 結果：`200 OK`
          ``` json
          {
            "result": true,
            "message": "Authenticated."
          }
          ```
    - 下記の条件でレッスン更新処理を実行する
        <img width="680" alt="image" src="https://github.com/user-attachments/assets/45eaa207-5fd7-4c7f-b465-f188bc4538fe" />
    - 結果 `200 OK`
        ``` json
          {
            "result": true
          }
        ```
    - Adminerにて対象のレッスンが更新されていることを確認
        <img width="841" alt="image" src="https://github.com/user-attachments/assets/4658233a-5b54-4075-9dd2-3814daa00847" />

2. 正常系: マネージャーが配下講師のレッスンを更新できることを確認
    - 下記の講師(Manager)でログイン
        - メソッド：POST
        - URL：http://localhost:8080/login/instructor
        - email：test_instructor@example.com
        - password：password
        - 結果：`200 OK`
          ``` json
          {
            "result": true,
            "message": "Authenticated."
          }
          ```
    - 下記の条件でレッスン更新処理を実行する
        <img width="677" alt="image" src="https://github.com/user-attachments/assets/b9c9202f-1023-4e29-ab4a-cf2de3957b81" />
    - 結果 `200 OK`
        ``` json
          {
            "result": true
          }
        ```
    - Adminerにて対象のレッスンが更新されていることを確認
        <img width="938" alt="image" src="https://github.com/user-attachments/assets/f1203e63-5c6c-4d8f-b984-d4849fdb7a1c" />

3. 異常系: 権限のないレッスンへのアクセス時に適切なエラーレスポンスが返ることを確認
    - 下記の講師(Manager)でログイン
        - メソッド：POST
        - URL：http://localhost:8080/login/instructor
        - email：test_instructor@example.com
        - password：password
        - 結果：`200 OK`
          ``` json
          {
            "result": true,
            "message": "Authenticated."
          }
          ```
    - 下記の条件でレッスン更新処理を実行する
        <img width="697" alt="image" src="https://github.com/user-attachments/assets/925d2b46-e84d-47de-9426-43e83bd9518f" />
    - 結果 `403 Forbidden`
        ``` json
          {
            "message": "This action is unauthorized.",
            "exception": "Symfony\\Component\\HttpKernel\\Exception\\AccessDeniedHttpException",
            :
            :
          }
        ```
