### PR TITLE
【jka-1413子課題】jka-1418 空の配列を返すルータとコントローラの実装(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -283,4 +283,12 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+
+    /**
+     * お知らせ 一括公開・非公開API
+     */
+    public function putStatusAll()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -152,8 +152,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
-                Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
-                Route::put('status/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
+                Route::prefix('status')->group(function(){
+                    Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
+                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
+                });
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -152,7 +152,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
-                Route::prefix('status')->group(function(){
+                Route::prefix('status')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                     Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,6 +153,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
+                Route::put('status/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -154,7 +154,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
                 Route::prefix('status')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
-                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
+                    Route::put('all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
                 });
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {


### PR DESCRIPTION
## Issue
jka-1418 空の配列を返すルータとコントローラの実装
※jka-1413 講師側 お知らせ一覧-全て公開・非公開変更API 新規作成の子課題

## 実装内容
①api.phpへroute作成
②instructor/NotificationControllerにメソッド作成

## 6/15修正
api.phpのstatus箇所をprefix化しました
※下記同様のテストを実施確認をおこないました。

##テスト
メソッド作成後、instructor_id1のユーザで実施
![スクリーンショット 2025-06-15 211351](https://github.com/user-attachments/assets/351d61db-5836-4933-a633-aa35edcdea7d)
