### PR TITLE
【jka-1413子課題】jka-1420講師側 お知らせ一覧 - 全て公開・非公開変更API 新規作成 [ロジック作成] (芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -297,7 +297,7 @@ class NotificationController extends Controller
             ]);
 
         return response()->json([
-            'result' => 'true'
+            'result' => 'true',
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Instructor\Notification\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Notification\DeleteRequest;
 use App\Http\Requests\Instructor\Notification\IndexRequest;
 use App\Http\Requests\Instructor\Notification\PutRequest;
+use App\Http\Requests\Instructor\Notification\PutStatusAllRequest;
 use App\Http\Requests\Instructor\Notification\PutStatusRequest;
 use App\Http\Requests\Instructor\Notification\ShowRequest;
 use App\Http\Requests\Instructor\Notification\StoreRequest;
@@ -287,8 +288,16 @@ class NotificationController extends Controller
     /**
      * お知らせ 一括公開・非公開API
      */
-    public function putStatusAll()
+    public function putStatusAll(PutStatusAllRequest $request): JsonResponse
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+        Notification::where('instructor_id', $instructorId)
+            ->update([
+                'status' => $request->status,
+            ]);
+
+        return response()->json([
+            'result' => 'true'
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -283,4 +283,12 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+
+    /**
+     * お知らせ 一括公開・非公開API
+     */
+    public function putStatusAll()
+    {
+        return response()->json([]);
+    }
 }

--- a/app/Http/Requests/Instructor/Notification/PutStatusAllRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusAllRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Notification;
+
+use App\Enums\Notification\StatusEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class PutStatusAllRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', Rule::enum(StatusEnum::class)]
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/Notification/PutStatusAllRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusAllRequest.php
@@ -24,7 +24,7 @@ class PutStatusAllRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'status' => ['required', Rule::enum(StatusEnum::class)]
+            'status' => ['required', Rule::enum(StatusEnum::class)],
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -152,8 +152,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
-                Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
-                Route::put('status/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
+                Route::prefix('status')->group(function(){
+                    Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
+                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
+                });
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -152,7 +152,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
-                Route::prefix('status')->group(function(){
+                Route::prefix('status')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                     Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,6 +153,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
+                Route::put('status/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -154,7 +154,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
                 Route::prefix('status')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
-                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
+                    Route::put('all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatusAll']);
                 });
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {

--- a/tests/Feature/Api/Instructor/Notification/PutStatusAllTest.php
+++ b/tests/Feature/Api/Instructor/Notification/PutStatusAllTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutStatusAllTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/status/all', [
+            'status' => 'public',
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('notifications', [
+            'id' => 1,
+            'status' => 'public',
+            'instructor_id' => $instructor->id,
+        ]);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/status/all', [
+            'status' => '',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'status' => 'The status field is required.',
+        ]);
+    }
+
+    public function test_無効なステータス_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/status/all', [
+            'status' => 'invalid_status',
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'status' => 'The selected status is invalid.',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Notification/PutStatusTest.php
+++ b/tests/Feature/Api/Instructor/Notification/PutStatusTest.php
@@ -61,30 +61,30 @@ class PutStatusTest extends TestCase
         ]);
     }
 
-    // public function test_バリデーションエラー(): void
-    // {
-    //     // arrange
-    //     $instructor = Instructor::find(1);
-    //     $this->actingAs($instructor, 'instructor');
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
 
-    //     // act
-    //     $response = $this->putJson('/api/v1/instructor/notification/aaaa', [
-    //         'title' => '',
-    //         'type' => '',
-    //         'start_date' => '',
-    //         'end_date' => '',
-    //         'content' => '',
-    //     ]);
+        // act
+        $response = $this->putJson('/api/v1/instructor/notification/aaaa', [
+            'title' => '',
+            'type' => '',
+            'start_date' => '',
+            'end_date' => '',
+            'content' => '',
+        ]);
 
-    //     // assert
-    //     $response->assertStatus(422);
-    //     $response->assertJsonValidationErrors([
-    //         'notification_id',
-    //         'title',
-    //         'type',
-    //         'start_date',
-    //         'end_date',
-    //         'content',
-    //     ]);
-    // }
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'notification_id',
+            'title',
+            'type',
+            'start_date',
+            'end_date',
+            'content',
+        ]);
+    }
 }


### PR DESCRIPTION
## Issue
- jka-1420 本タスクロジック実装  
  ※親Issue: [jka-1413 講師側 お知らせ一覧 - 全て公開・非公開変更API 新規作成]

## 概要
Instructor が所持しているすべての Notification（お知らせ）の `status`（状態）を一括で変更できるようにする機能を実装。

## 実装内容
- `Instructor/NotificationController.php` を新規作成
- `Instructor/NotificationRequest.php` を新規作成

## テスト内容
Instructor ID: 1 のユーザーでテストを実施（初期状態: すべての `status` が `private`）

### ✅ 成功ケース
- `status: private → public` に一括変更  
  ![スクリーンショット (137)](https://github.com/user-attachments/assets/c4c58ecf-ba90-4b78-a087-93c94cccea67)

### ❌ 失敗ケース
- `status: active` へ変更（許可されていない値のため失敗）  
  ![スクリーンショット 2025-06-16 094001](https://github.com/user-attachments/assets/04bff313-0e09-4ea5-bf39-76d865ca9eed)

## 備考
- リクエストバリデーションで許可されたステータス以外は弾く仕様としています。
- コントローラー内で対象Instructorに紐づく Notification に対し、一括更新処理を行っています。
