### PR TITLE
🚧【下書き】【jka-1415子課題】jka-1431 空の配列を返すルーターとコントローラの作成(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -196,6 +196,13 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+    /**
+     * お知らせ一覧-タイプ変更API
+     */
+    public function updateTypeAll()
+    {
+        return response()->json([]);
+    }
 
     /**
      * お知らせ一括削除

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -206,7 +206,7 @@ class NotificationController extends Controller
     }
 
     /**
-     * お知らせ一覧削除
+     * お知らせ一括削除
      */
     public function bulkDelete(BulkDeleteRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -205,7 +205,7 @@ class NotificationController extends Controller
     }
 
     /**
-     * お知らせ一括削除
+     * お知らせ一覧-タイプ変更API
      */
     public function bulkDelete(BulkDeleteRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -197,7 +197,7 @@ class NotificationController extends Controller
         }
     }
     /**
-     * お知らせ一覧-タイプ変更API
+     * 該当講師お知らせ タイプ一括変更API
      */
     public function updateTypeAll()
     {

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -196,6 +196,7 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+
     /**
      * 該当講師お知らせ タイプ一括変更API
      */
@@ -205,7 +206,7 @@ class NotificationController extends Controller
     }
 
     /**
-     * お知らせ一覧-タイプ変更API
+     * お知らせ一覧削除
      */
     public function bulkDelete(BulkDeleteRequest $request): JsonResponse
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,7 +151,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
-                Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                Route::prefix('type/{notification_type}')->group(function(){
+                    Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
+                });
                 Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {


### PR DESCRIPTION
## Issue
・jka-1431空の配列を返すルーターとコントローラの作成
※jla-1415 講師側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成 子課題

## 実装内容
①route: api.php
②controller: Instructor/notification.php
※空の配列を返却

## テスト （成功）
![スクリーンショット (138)](https://github.com/user-attachments/assets/584c9435-f37e-4a7d-b66e-23770be42dc2)

