### PR TITLE
【下書き】【jka-1415子課題】jka-1432 講師側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成 [ ロジック実装 ](芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -196,6 +196,13 @@ class NotificationController extends Controller
             throw $e;
         }
     }
+    /**
+     * お知らせ一覧-タイプ変更API
+     */
+    public function updateTypeAll()
+    {
+        return response()->json([]);
+    }
 
     /**
      * お知らせ一括削除

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\Instructor\Notification\PutRequest;
 use App\Http\Requests\Instructor\Notification\PutStatusRequest;
 use App\Http\Requests\Instructor\Notification\ShowRequest;
 use App\Http\Requests\Instructor\Notification\StoreRequest;
+use App\Http\Requests\Instructor\notification\UpdateTypeAllRequest;
 use App\Http\Requests\Instructor\Notification\UpdateTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Instructor\NotificationIndexResource;
@@ -199,9 +200,18 @@ class NotificationController extends Controller
     /**
      * お知らせ一覧-タイプ変更API
      */
-    public function updateTypeAll()
+    public function updateTypeAll(UpdateTypeAllRequest $request): JsonResponse
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        Notification::where('instructor_id', $instructorId)
+        ->update([
+            'type' => $request->notification_type,
+        ]);
+
+        return response()->json([
+            'result' => true
+        ]);
     }
 
     /**

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Instructor\notification;
+
+use App\Enums\Notification\TypeEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTypeAllRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_type' => $this->route('notification_type'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'notification_type' => ['required', Rule::enum(TypeEnum::class)]
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,7 +151,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
-                Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                Route::prefix('type/{notification_type}')->group(function(){
+                    Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
+                });
                 Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {


### PR DESCRIPTION
## Issue
jka-1432 講師側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成 [ ロジック実装 ]
※jka-1415子課題

## 仕様内容
該当講師のお知らせ内容のtypeを一括変更するAPIの実装

## 実装内容
①ルーティング:：api.php
・新規ルート作成
②コントローラ：Instructor/notification.php
・更新メソッド(putTypeAllメソッド)
③フォームリクエスト：Instrucntor/notification/putTypeAllRequest
・バリデーション

## テスト
#### instructor id_1のユーザで処理実施
##### お知らせタイプを `` once ``  から　`` always `` へ変更する(下記画像の状態からテスト実施)
![スクリーンショット 2025-06-17 200938](https://github.com/user-attachments/assets/537e6183-afb6-4422-8643-51f58c3f0808)

① `` once `` -> `` always `` 【成功】
![スクリーンショット (139)](https://github.com/user-attachments/assets/2b85c19e-db2e-45ae-8f00-95f264e064db)
