### PR TITLE
【jka-1415子課題】jka-1431 空の配列を返すルーターとコントローラの作成(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -197,7 +197,7 @@ class NotificationController extends Controller
         }
     }
 
-        /**
+    /**
      * 該当講師お知らせ一覧タイプ　一括変更
      */
     public function updateTypeAll()

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -197,6 +197,14 @@ class NotificationController extends Controller
         }
     }
 
+        /**
+     * 該当講師お知らせ一覧タイプ　一括変更
+     */
+    public function updateTypeAll()
+    {
+        return response()->json([]);
+    }
+
     /**
      * お知らせ一括削除
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,7 +151,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
-                Route::put('type/{notification_type}', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                Route::prefix('type/{notification_type}')->group(function(){
+                    Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
+                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
+                });
                 Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);
                 Route::prefix('{notification_id}')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,7 +151,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
-                Route::prefix('type/{notification_type}')->group(function(){
+                Route::prefix('type/{notification_type}')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
                     Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
                 });

--- a/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
+++ b/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Model\Instructor;
+
+class UpdateTypeAllTest extends TestCase
+{
+    // データベース初期化
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_空の配列返却_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $notificationType = 'once';
+
+        $response = $this->putJson("/api/v1/instructor/notification/type/{$notificationType}/all");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([]);
+    }
+}

--- a/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
+++ b/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
@@ -2,10 +2,9 @@
 
 namespace Tests\Feature\Api\Instructor\Notification;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class UpdateTypeAllTest extends TestCase
 {


### PR DESCRIPTION
## Issue
・jka-1431空の配列を返すルーターとコントローラの作成
※jla-1415 講師側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成 子課題

## 実装内容
①route: api.php
②controller: Instructor/notification.php
※空の配列を返却

## 6/18 :UpdateTypeAllTest を実装
実装確認、異常なし

## テスト （成功）
![スクリーンショット 2025-06-18 101424](https://github.com/user-attachments/assets/151a1944-66d9-430a-9228-174820a60012)
