### PR TITLE
【jka-1415子課題】jka-1432 講師側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成 [ ロジック実装 ](芦野)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         tools: composer:v2.8.2
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --ansi --no-dev
+      run: composer install --prefer-dist --no-progress --ansi
 
     - name: Format code with Pint
       run: composer pint

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\Instructor\Notification\PutStatusRequest;
 use App\Http\Requests\Instructor\Notification\ShowRequest;
 use App\Http\Requests\Instructor\Notification\StoreRequest;
 use App\Http\Requests\Instructor\Notification\UpdateTypeRequest;
+use App\Http\Requests\Manager\Notification\UpdateTypeRequest as NotificationUpdateTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Model\Course;
@@ -200,9 +201,18 @@ class NotificationController extends Controller
         /**
      * 該当講師お知らせ一覧タイプ　一括変更
      */
-    public function updateTypeAll()
+    public function updateTypeAll(NotificationUpdateTypeRequest $request): JsonResponse
     {
-        return response()->json([]);
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        Notification::where('instructor_id', $instructorId)
+        ->update([
+            'type' => $request->notification_type,
+        ]);
+
+        return response()->json([
+            'result' => true
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -206,12 +206,12 @@ class NotificationController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
 
         Notification::where('instructor_id', $instructorId)
-        ->update([
-            'type' => $request->notification_type,
-        ]);
+            ->update([
+                'type' => $request->notification_type,
+            ]);
 
         return response()->json([
-            'result' => true
+            'result' => true,
         ]);
     }
 

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Notification;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\Notification\TypeEnum;
+
+class UpdateTypeAllRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'notification_type' => $this->route('notification_type'),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'notification_type' => ['required', Rule::enum(TypeEnum::class)]
+        ];
+    }
+}

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\Instructor\Notification;
 
-use Illuminate\Validation\Rule;
-use Illuminate\Foundation\Http\FormRequest;
 use App\Enums\Notification\TypeEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateTypeAllRequest extends FormRequest
 {
@@ -32,7 +32,7 @@ class UpdateTypeAllRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'notification_type' => ['required', Rule::enum(TypeEnum::class)]
+            'notification_type' => ['required', Rule::enum(TypeEnum::class)],
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,7 +153,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
                 Route::prefix('type/{notification_type}')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
-                    Route::put('/all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
+                    Route::put('all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
                 });
                 Route::put('status', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'putStatus']);
                 Route::delete('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'bulkDelete']);

--- a/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
+++ b/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
@@ -31,7 +31,7 @@ class UpdateTypeAllTest extends TestCase
 
         // assert
         $response->assertStatus(200);
-        $this->assertDatabaseHas('notifications',[
+        $this->assertDatabaseHas('notifications', [
             'id' => 1,
             'type' => 'once',
         ]);

--- a/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
+++ b/tests/Feature/Api/Instructor/Notification/UpdateTypeAllTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Api\Instructor\Notification;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Model\Instructor;
 
@@ -20,17 +19,38 @@ class UpdateTypeAllTest extends TestCase
         $this->seed();
     }
 
-    public function test_空の配列返却_成功(): void
+    public function test_お知らせ更新_成功(): void
     {
         // arrange
         $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
+        // act
         $notificationType = 'once';
-
         $response = $this->putJson("/api/v1/instructor/notification/type/{$notificationType}/all");
 
+        // assert
         $response->assertStatus(200);
-        $response->assertExactJson([]);
+        $this->assertDatabaseHas('notifications',[
+            'id' => 1,
+            'type' => 'once',
+        ]);
+    }
+
+    public function test_バリデーションエラー_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $notificationType = 'action';
+        $response = $this->putJson("/api/v1/instructor/notification/type/{$notificationType}/all");
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'The selected notification type is invalid.',
+        ]);
     }
 }


### PR DESCRIPTION
## Issue
jka-1432 講師側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成 [ ロジック実装 ]
※jka-1415子課題

## 仕様確認
該当講師のお知らせ内容のtypeを一括変更するAPIの実装

## 実装内容
①ルーティング:：api.php
・新規ルート作成
②コントローラ：Instructor/notification.php
・更新メソッド(putTypeAllメソッド)
③フォームリクエスト：Instrucntor/Notification/PutTypeAllRequest.php
・バリデーション

## テスト
### instructor id_1のユーザで処理実施
#### お知らせタイプを ``once`` から ``always`` へ変更する(下記画像の状態からテスト実施)
![スクリーンショット (137)](https://github.com/user-attachments/assets/d52617c6-fdaa-4085-9e28-519b35d55ae8)

① ``once`` -> ``always`` 【成功】
![スクリーンショット (139)](https://github.com/user-attachments/assets/cf280014-faa6-438e-8adb-875973ba229f)

②``always `` -> ``active`` 【失敗 422】
![スクリーンショット (141)](https://github.com/user-attachments/assets/fdbb3161-d590-4237-862f-67c4e4e4eabb)




