### PR TITLE
jka-1434 講師/マネージャー お知らせ更新機能へのPolicyパターンを用いた認可機能の実装(芦野)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: PHP CI
 
 on:
   pull_request:
+    branches:
+      - develop
+      - 'topic/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -102,9 +102,8 @@ class NotificationController extends Controller
     {
         $notification = Notification::findOrFail($request->notification_id);
 
-        if ($notification->instructor_id !== Auth::guard('instructor')->user()->id) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        // policyによる認可チェック
+        $this->authorize('update', $notification);
 
         DB::beginTransaction();
         try {

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -6,9 +6,9 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Notification\BulkDeleteRequest;
 use App\Http\Requests\Manager\Notification\DeleteRequest;
 use App\Http\Requests\Manager\Notification\IndexRequest;
+use App\Http\Requests\Manager\Notification\PutRequest;
 use App\Http\Requests\Manager\Notification\ShowRequest;
 use App\Http\Requests\Manager\Notification\StoreRequest;
-use App\Http\Requests\Manager\Notification\UpdateRequest;
 use App\Http\Requests\Manager\Notification\UpdateTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Manager\NotificationIndexResource;
@@ -124,11 +124,10 @@ class NotificationController extends Controller
     /**
      * お知らせ更新API
      */
-    public function update(UpdateRequest $request): JsonResponse
+    public function put(PutRequest $request): JsonResponse
     {
         // 指定されたお知らせIDでお知らせを取得
         $notification = Notification::with('course')->findOrFail($request->notification_id);
-        assert($notification instanceof Notification);
 
         // policyによる認可チェック
         $this->authorize('update', $notification);

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -126,23 +126,12 @@ class NotificationController extends Controller
      */
     public function update(UpdateRequest $request): JsonResponse
     {
-        // 認証している講師のIDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // 配下の講師情報を取得
-        $manager = Instructor::with('managings')->find($instructorId);
-        assert($manager instanceof Instructor);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
         // 指定されたお知らせIDでお知らせを取得
         $notification = Notification::with('course')->findOrFail($request->notification_id);
         assert($notification instanceof Notification);
 
-        // アクセス権限のチェック
-        if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        // policyによる認可チェック
+        $this->authorize('update', $notification);
 
         DB::beginTransaction();
         try {

--- a/app/Http/Requests/Manager/Notification/PutRequest.php
+++ b/app/Http/Requests/Manager/Notification/PutRequest.php
@@ -7,7 +7,7 @@ use App\Enums\Notification\TypeEnum;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class UpdateRequest extends FormRequest
+class PutRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -13,7 +13,7 @@ class NotificationPolicy
     public function update(Instructor $instructor, Notification $notification)
     {
         // マネージャーの場合は配下の講師レッスンも更新可能
-        if($instructor->isManager()){
+        if ($instructor->isManager()) {
             $manager = Instructor::with('managings')->find($instructor->id);
             $instructorIds = $manager->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Instructor;
+use App\Model\Notification;
+
+class NotificationPolicy
+{
+    /**
+     * お知らせの更新処理に関する認可処理
+     */
+    public function update(Instructor $instructor, Notification $notification)
+    {
+        // マネージャーの場合は配下の講師レッスンも更新可能
+        if($instructor->isManager()){
+            $manager = Instructor::with('managings')->find($instructor->id);
+            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return is_array($notification->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師の場合は自分のレッスンのみ更新可能
+        return $notification->instructor_id === $instructor->id;
+    }
+}

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -18,7 +18,7 @@ class NotificationPolicy
             $instructorIds = $manager->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;
 
-            return is_array($notification->instructor_id, $instructorIds, true);
+            return in_array($notification->instructor_id, $instructorIds, true);
         }
 
         // マネージャー権限のない講師の場合は自分のレッスンのみ更新可能

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -14,8 +14,7 @@ class NotificationPolicy
     {
         // マネージャーの場合は配下の講師レッスンも更新可能
         if ($instructor->isManager()) {
-            $manager = Instructor::with('managings')->find($instructor->id);
-            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;
 
             return in_array($notification->instructor_id, $instructorIds, true);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,9 +5,11 @@ namespace App\Providers;
 use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Lesson;
+use App\Model\Notification;
 use App\Policies\ChapterPolicy;
 use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
+use App\Policies\NotificationPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -21,6 +23,7 @@ class AuthServiceProvider extends ServiceProvider
         Course::class => CoursePolicy::class,
         Chapter::class => ChapterPolicy::class,
         Lesson::class => LessonPolicy::class,
+        Notification::class => NotificationPolicy::class,
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -268,7 +268,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'show']);
-                        Route::patch('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'put']);
+                        Route::put('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'put']);
                         Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'delete']);
                     });
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -268,7 +268,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'show']);
-                        Route::patch('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'update']);
+                        Route::patch('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'put']);
                         Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'delete']);
                     });
                 });

--- a/tests/Feature/Api/Instructor/Notification/PutTest.php
+++ b/tests/Feature/Api/Instructor/Notification/PutTest.php
@@ -67,7 +67,7 @@ class PutTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Notification/PutTest.php
+++ b/tests/Feature/Api/Manager/Notification/PutTest.php
@@ -8,7 +8,7 @@ use App\Model\Notification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class UpdateTest extends TestCase
+class PutTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -30,7 +30,7 @@ class UpdateTest extends TestCase
         ]);
 
         // act
-        $response = $this->patchJson('/api/v1/manager/notification/'.$notification->id, [
+        $response = $this->putJson('/api/v1/manager/notification/'.$notification->id, [
             'title' => 'update',
             'type' => 'once',
             'start_date' => '2025-01-01 10:00:00',
@@ -62,7 +62,7 @@ class UpdateTest extends TestCase
         ]);
 
         // act
-        $response = $this->patchJson('/api/v1/manager/notification/'.$notification->id, [
+        $response = $this->putJson('/api/v1/manager/notification/'.$notification->id, [
             'title' => '', // 空
             'type' => '',  // 空
             'start_date' => 'invalid-date', // 無効な日付
@@ -94,7 +94,7 @@ class UpdateTest extends TestCase
         ]);
 
         // act
-        $response = $this->patchJson('/api/v1/manager/notification/'.$notification->id, [
+        $response = $this->putJson('/api/v1/manager/notification/'.$notification->id, [
             'title' => '権限なしテスト',
             'type' => 'once',
             'start_date' => '2025-01-01 10:00:00',


### PR DESCRIPTION
## Issue
jka-1434 講師/マネージャー お知らせ更新機能へのPolicyパターンを用いた認可機能の実装

## 仕様確認
マネージャー/講師　お知らせ更新機能の認可処理をpolicyクラスで共通化

## 実装内容
①マッピング
②NotificationPolisy作成
③Manager/Instructor: Conrtoller修正
④Instructor PutTest修正

## テスト
### postman及び既存のPHPUnitで実施
#### postman
![スクリーンショット (144)](https://github.com/user-attachments/assets/618b203d-01e4-462d-bb22-0a9cdd3e4108)

#### PHPUnit
![スクリーンショット (143)](https://github.com/user-attachments/assets/a5dfea96-a067-43cd-b8bd-faf353a59ed5)
