### PR TITLE
jka-1446 講師／マネージャー お知らせ削除機能に対するビジネスロジックの実装(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -104,7 +104,7 @@ class NotificationController extends Controller
         $notification = Notification::findOrFail($request->notification_id);
 
         // policyによる認可チェック
-        $this->authorize('update', $notification);
+        $this->authorize('put', $notification);
 
         // 更新処理：serviceクラス呼び出し
         $service($notification,title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -17,6 +17,7 @@ use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Model\Course;
 use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
+use App\Services\Notification\PutService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Collection;
@@ -98,34 +99,19 @@ class NotificationController extends Controller
     /**
      * お知らせ更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, PutService $service): JsonResponse
     {
         $notification = Notification::findOrFail($request->notification_id);
 
         // policyによる認可チェック
         $this->authorize('update', $notification);
 
-        DB::beginTransaction();
-        try {
-            $notification->fill([
-                'type' => $request->type,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'title' => $request->title,
-                'content' => $request->content,
-                'status' => $request->status,
-            ])
-                ->save();
-            DB::commit();
+        // 更新処理：serviceクラス呼び出し
+        $service($notification,title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);
 
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
-        }
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -107,7 +107,7 @@ class NotificationController extends Controller
         $this->authorize('put', $notification);
 
         // 更新処理：serviceクラス呼び出し
-        $service($notification,title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);
+        $service($notification, title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -16,6 +16,7 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
+use App\Services\Notification\PutService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -124,7 +125,7 @@ class NotificationController extends Controller
     /**
      * お知らせ更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, PutService $service): JsonResponse
     {
         // 指定されたお知らせIDでお知らせを取得
         $notification = Notification::with('course')->findOrFail($request->notification_id);
@@ -132,27 +133,12 @@ class NotificationController extends Controller
         // policyによる認可チェック
         $this->authorize('update', $notification);
 
-        DB::beginTransaction();
-        try {
-            $notification->fill([
-                'type' => $request->type,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'title' => $request->title,
-                'content' => $request->content,
-                'status' => $request->status,
-            ])
-                ->save();
-            DB::commit();
+        // 更新処理：serviceクラス呼び出し
+        $service($notification,title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);
 
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
-        }
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -131,7 +131,7 @@ class NotificationController extends Controller
         $notification = Notification::with('course')->findOrFail($request->notification_id);
 
         // policyによる認可チェック
-        $this->authorize('update', $notification);
+        $this->authorize('put', $notification);
 
         // 更新処理：serviceクラス呼び出し
         $service($notification,title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -134,7 +134,7 @@ class NotificationController extends Controller
         $this->authorize('put', $notification);
 
         // 更新処理：serviceクラス呼び出し
-        $service($notification,title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);
+        $service($notification, title: $request->title, type: $request->type, start_date: $request->start_date, end_date: $request->end_date, status: $request->status, content: $request->content);
 
         return response()->json([
             'result' => true,

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -10,7 +10,7 @@ class NotificationPolicy
     /**
      * お知らせの更新処理に関する認可処理
      */
-    public function update(Instructor $instructor, Notification $notification)
+    public function put(Instructor $instructor, Notification $notification)
     {
         // マネージャーの場合は配下の講師レッスンも更新可能
         if ($instructor->isManager()) {

--- a/app/Services/Notification/PutService.php
+++ b/app/Services/Notification/PutService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services\Notification;
+
+use App\Model\Notification;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
+
+class PutService
+{
+    /**
+     * お知らせ内容を更新する
+     */
+    public function __invoke(Notification $notification, string $title, string $type, string $start_date, string $end_date, string $status, string $content): void
+    {
+        try {
+            DB::beginTransaction();
+            $notification->fill([
+                'title' => $title,
+                'type' => $type,
+                'start_date' => $start_date,
+                'end_date' => $end_date,
+                'status' => $status,
+                'content' => $content,
+            ])
+                ->save();
+            DB::commit();
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
+    }
+}

--- a/app/Services/Notification/PutService.php
+++ b/app/Services/Notification/PutService.php
@@ -4,8 +4,8 @@ namespace App\Services\Notification;
 
 use App\Model\Notification;
 use Exception;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class PutService
 {


### PR DESCRIPTION
## Issue 
jka-1446講師／マネージャー お知らせ削除機能に対するビジネスロジックの実装

## 仕様
マネージャー/講師　お知らせ更新機能のビジネスロジックを共通化

## 実装内容
①Notification/PutService作成
②Manager/Instructor: Conrtoller修正
③NotificationPolisy: メソッド名変更

## ご相談事項
今回のような引数が多いケースでは、DTOクラスで引数をひとまとめにする方が望ましいでしょうか？
必要であれば作成、再pushします。
・参考コード(Notification/PutService 抜粋)
```
public function __invoke(Notification $notification, string $title, string $type, string $start_date, string $end_date, string $status, string $content): void
```


## テスト
#### postman及び既存のPHPUnitで実施
##### postman
![スクリーンショット (147)](https://github.com/user-attachments/assets/ecc34c37-03b3-472f-bcfd-ee74b75bcf59)

##### PHPUnit
![スクリーンショット (146)](https://github.com/user-attachments/assets/2e2f2d8d-bd42-4a70-ba59-a788daafef1e)
