### PR TITLE
JKA-1416 マネージャー側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成（街）

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Instructor\Notification\UpdateAllTypeRequest as NotificationUpdateAllTypeRequest;
 use App\Http\Requests\Manager\Notification\BulkDeleteRequest;
 use App\Http\Requests\Manager\Notification\DeleteRequest;
 use App\Http\Requests\Manager\Notification\IndexRequest;
@@ -258,13 +257,12 @@ class NotificationController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 配下の講師情報を取得
-        /** @var Instructor $manager */
         $manager = Instructor::with('managings')->find($instructorId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
         // ログイン講師のお知らせを取得
-        $notifications = Notification::with(['course', 'instructor'])->whereIn('instructor_id', $instructorIds);
+        $notifications = Notification::whereIn('instructor_id', $instructorIds);
         $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
 
         // 自分以外のお知らせは更新できない

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -10,7 +10,6 @@ use App\Http\Requests\Manager\Notification\PutRequest;
 use App\Http\Requests\Manager\Notification\ShowRequest;
 use App\Http\Requests\Manager\Notification\StoreRequest;
 use App\Http\Requests\Manager\Notification\UpdateAllTypeRequest;
-use App\Http\Requests\Manager\Notification\UpdateRequest;
 use App\Http\Requests\Manager\Notification\UpdateTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Manager\NotificationIndexResource;

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -251,12 +251,6 @@ class NotificationController extends Controller
 
         // ログイン講師のお知らせを取得
         $notifications = Notification::whereIn('instructor_id', $instructorIds);
-        $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
-
-        // 自分以外のお知らせは更新できない
-        if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
 
         try {
             $notifications->update([

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -9,7 +9,7 @@ use App\Http\Requests\Manager\Notification\IndexRequest;
 use App\Http\Requests\Manager\Notification\PutRequest;
 use App\Http\Requests\Manager\Notification\ShowRequest;
 use App\Http\Requests\Manager\Notification\StoreRequest;
-use App\Http\Requests\Manager\Notification\UpdateAllTypeRequest;
+use App\Http\Requests\Manager\Notification\UpdateTypeAllRequest;
 use App\Http\Requests\Manager\Notification\UpdateTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Manager\NotificationIndexResource;
@@ -239,7 +239,7 @@ class NotificationController extends Controller
         }
     }
 
-    public function updateAllType(UpdateAllTypeRequest $request)
+    public function updateTypeAll(UpdateTypeAllRequest $request)
     {
         // ログインしている講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -8,9 +8,9 @@ use App\Http\Requests\Manager\Notification\DeleteRequest;
 use App\Http\Requests\Manager\Notification\IndexRequest;
 use App\Http\Requests\Manager\Notification\ShowRequest;
 use App\Http\Requests\Manager\Notification\StoreRequest;
+use App\Http\Requests\Manager\Notification\UpdateAllTypeRequest;
 use App\Http\Requests\Manager\Notification\UpdateRequest;
 use App\Http\Requests\Manager\Notification\UpdateTypeRequest;
-use App\Http\Requests\Manager\Notification\UpdateAllTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Manager\NotificationIndexResource;
 use App\Model\Course;
@@ -274,6 +274,7 @@ class NotificationController extends Controller
             $notifications->update([
                 'type' => $request->notification_type,
             ]);
+
             return response()->json([
                 'result' => true,
             ]);

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Instructor\Notification\UpdateAllTypeRequest as NotificationUpdateAllTypeRequest;
 use App\Http\Requests\Manager\Notification\BulkDeleteRequest;
 use App\Http\Requests\Manager\Notification\DeleteRequest;
 use App\Http\Requests\Manager\Notification\IndexRequest;
@@ -10,6 +11,7 @@ use App\Http\Requests\Manager\Notification\ShowRequest;
 use App\Http\Requests\Manager\Notification\StoreRequest;
 use App\Http\Requests\Manager\Notification\UpdateRequest;
 use App\Http\Requests\Manager\Notification\UpdateTypeRequest;
+use App\Http\Requests\Manager\Notification\UpdateAllTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Manager\NotificationIndexResource;
 use App\Model\Course;
@@ -245,6 +247,39 @@ class NotificationController extends Controller
             ]);
         } catch (Exception $e) {
             DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
+    }
+
+    public function updateAllType(UpdateAllTypeRequest $request)
+    {
+        // ログインしている講師のIDを取得
+        $instructorId = Auth::guard('instructor')->user()->id;
+
+        // 配下の講師情報を取得
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->find($instructorId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        // ログイン講師のお知らせを取得
+        $notifications = Notification::with(['course', 'instructor'])->whereIn('instructor_id', $instructorIds);
+        $notificationsInstructorIds = $notifications->pluck('instructor_id')->toArray();
+
+        // 自分以外のお知らせは更新できない
+        if (array_diff($notificationsInstructorIds, $instructorIds) !== []) {
+            throw new AuthorizationException('Invalid instructor_id.');
+        }
+
+        try {
+            $notifications->update([
+                'type' => $request->notification_type,
+            ]);
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (Exception $e) {
             Log::error($e);
             throw $e;
         }

--- a/app/Http/Requests/Manager/Notification/UpdateAllTypeRequest.php
+++ b/app/Http/Requests/Manager/Notification/UpdateAllTypeRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Manager\Notification;
+
+use App\Enums\Notification\TypeEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAllTypeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'notification_type' => ['required', Rule::enum(TypeEnum::class)],
+        ];
+    }
+}

--- a/app/Http/Requests/Manager/Notification/UpdateAllTypeRequest.php
+++ b/app/Http/Requests/Manager/Notification/UpdateAllTypeRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\Manager\Notification;
 
+use App\Enums\Notification\TypeEnum;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use App\Enums\Notification\TypeEnum;
 
 class UpdateAllTypeRequest extends FormRequest
 {

--- a/app/Http/Requests/Manager/Notification/UpdateAllTypeRequest.php
+++ b/app/Http/Requests/Manager/Notification/UpdateAllTypeRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\Manager\Notification;
 
-use App\Enums\Notification\TypeEnum;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use App\Enums\Notification\TypeEnum;
 
 class UpdateAllTypeRequest extends FormRequest
 {

--- a/app/Http/Requests/Manager/Notification/UpdateTypeAllRequest.php
+++ b/app/Http/Requests/Manager/Notification/UpdateTypeAllRequest.php
@@ -6,7 +6,7 @@ use App\Enums\Notification\TypeEnum;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class UpdateAllTypeRequest extends FormRequest
+class UpdateTypeAllRequest extends FormRequest
 {
     public function authorize(): bool
     {

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -25,8 +25,7 @@ class CoursePolicy
     {
         // マネージャー権限のある講師か判定
         if ($instructor->isManager()) {
-            $manager = Instructor::with('managings')->find($instructor->id);
-            $instructorIds = $manager->managings->pluck('id')->toArray();
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;
 
             return in_array($course->instructor_id, $instructorIds, true);

--- a/routes/api.php
+++ b/routes/api.php
@@ -185,7 +185,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'show']);
                         Route::post('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'update']);
                         Route::prefix('course')->group(function () {
-                            Route::get('index', 'Api\Manager\Instructor\CourseController@index');
+                            Route::get('index', [App\Http\Controllers\Api\Manager\Instructor\CourseController::class, 'index']);
                         });
                     });
                 });
@@ -210,7 +210,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                 Route::get('/', [App\Http\Controllers\Api\Manager\ChapterController::class, 'show']);
                                 Route::put('/', [App\Http\Controllers\Api\Manager\ChapterController::class, 'put']);
                                 Route::delete('/', [App\Http\Controllers\Api\Manager\ChapterController::class, 'delete']);
-                                Route::patch('status', 'Api\Manager\ChapterController@updateStatus');
+                                Route::patch('status', [App\Http\Controllers\Api\Manager\ChapterController::class, 'updateStatus']);
+
                                 // マネージャー-講座-チャプター-レッスン
                                 Route::prefix('lesson')->group(function () {
                                     Route::post('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'store']);
@@ -263,7 +264,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-お知らせ
                 Route::prefix('notification')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\NotificationController::class, 'index']);
-                    Route::put('type/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateAllType']);
+                    Route::put('type/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateTypeAll']);
                     Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,7 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', fn(Request $request) => $request->user());
+Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());
 
 Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     // 受講生側API

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,7 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());
+Route::middleware('auth:sanctum')->get('/user', fn(Request $request) => $request->user());
 
 Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     // 受講生側API
@@ -264,6 +264,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::prefix('notification')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\NotificationController::class, 'index']);
                     Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
+                    Route::put('type/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateAllType']);
                     Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
 
                     Route::prefix('{notification_id}')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -263,8 +263,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-お知らせ
                 Route::prefix('notification')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\NotificationController::class, 'index']);
-                    Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::put('type/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateAllType']);
+                    Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
 
                     Route::prefix('{notification_id}')->group(function () {


### PR DESCRIPTION
## issue
JKA-1416 マネージャー側 お知らせ一覧-全て常に表示・全て一度だけ表示変更API 新規作成

## 実装内容
notificationsテーブルのtypeカラムの値を、一括でonce or alwaysに一括で変更するコードを実装

（１）【laravelapp/app/Http/Controllers/Api/Manager/NotificationController.php】に、updateAllType()メソッドを作成。
・フロント側「一括変更ボタン」を押した際、リクエストbodyでonceかalwaysを送信することを想定。このbodyの値を$requestとしてメソッドに入れ込む。

・bodyで送信されたstringの検査として、UpdateAllTypeRequest.phpを使用。typeEnumを用いた。※型安全性のためenumを使いたかった。

・今回はコントローラーにバリデーションのthrow文は書かなかった。理由は、今回はリクエストでテーブルレコードidを送信されないため。

・下記でテーブル全レコードのtypeカラム値を変更
```
$notifications->update([
                'type' => $request->notification_type,
]);
```
・トランザクションは書かなかった。理由は、今回のapiは不整合なデータを作成することはないと考えたため。

（２）api.phpに当該コントローラーのルートを作成
・type複数選択apiのルートの前に記述。
理由は、後に記述すると複数選択apiのルートが発動して、本タスクのルートが発動しないため。

・type/allというurlにした。
理由は、複数選択apiのルートと見分けをつけやすくするため。かつ、ルートから全件変更であることを分かりやすくするため。
```
Route::put('type/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateAllType']);
```

## 動作確認
（１）instructor_id=1でログイン。この講師は、配下にinsturctor_id=2と3を持つマネージャー権限を有する。
（２）notificationsテーブルは、最初下図のようであった。typeカラムは全てonceだった。
<img width="422" alt="image" src="https://github.com/user-attachments/assets/4a73e9c1-d85c-48d0-8405-c7e86da12c08" />
（３）下記をリクエスト。200OK.
![image](https://github.com/user-attachments/assets/af38cd25-1fba-49ee-83fb-3a1f78e8fbec)
ログイン講師instructor_id=1とその配下のid=2のお知らせのtypeカラム値が一括してalwaysに変更された。自分と配下の講師でないお知らせ（id=4）は更新されず。
<img width="437" alt="image" src="https://github.com/user-attachments/assets/420aa01f-cb67-4692-ad15-31c20245ff18" />

（４）Tests\Feature\Api\Manager\Notification\PutTestの実行
PASSした。
![image](https://github.com/user-attachments/assets/b096ef5b-2f18-4d29-940b-d3362989c9f1)


