### PR TITLE
jka-1437 講師/マネージャー タグ削除機能へのPolicyパターンを用いた認可機能の実装(芦野)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -118,13 +118,11 @@ class TagController extends Controller
      */
     public function delete(DeleteRequest $request): JsonResponse
     {
-        $user = Auth::guard('instructor')->user();
+        // タグの取得
         $tag = Tag::findOrFail($request->tag_id);
 
-        // タグの所有者が現在のログイン講師でない場合は処理を中断（認可エラー）
-        if ($user->id !== $tag->instructor_id) {
-            throw new AuthorizationException('Forbidden, invalid instructor.');
-        }
+        // policyによる認可チェック
+        $this->authorize('delete', $tag);
 
         // タグに紐づく講座が存在する場合は削除処理を中止
         if ($tag->courses()->exists()) {

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -102,21 +102,11 @@ class TagController extends Controller
      */
     public function delete(DeleteRequest $request): JsonResponse
     {
-        // マネージャーが管理する講師IDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id; // 自身のIDも追加
-
         // タグの取得
         $tag = Tag::findOrFail($request->tag_id);
 
-        // 自身または配下のインストラクターが作成したタグ以外は削除不可
-        if (! in_array($tag->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        // policyによる認可チェック
+        $this->authorize('delete', $tag);
 
         // タグに関連付けられた講座がある場合は削除不可
         if ($tag->courses()->exists()) {

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Instructor;
+use App\Model\Tag;
+
+class TagPolicy
+{
+    /**
+     * タグの削除機能に関する認可処理
+     */
+    public function delete(Instructor $instructor, Tag $tag)
+    {
+        // マネージャーの場合は配下の講師レッスンも更新可能
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($tag->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師の場合は自分のレッスンのみ更新可能
+        return $tag->instructor_id === $instructor->id;
+
+    }
+}

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -12,7 +12,7 @@ class TagPolicy
      */
     public function delete(Instructor $instructor, Tag $tag)
     {
-        // マネージャーの場合は配下の講師レッスンも更新可能
+        // マネージャーの場合は配下の講師タグも削除可能
         if ($instructor->isManager()) {
             $instructorIds = $instructor->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;
@@ -20,7 +20,7 @@ class TagPolicy
             return in_array($tag->instructor_id, $instructorIds, true);
         }
 
-        // マネージャー権限のない講師の場合は自分のレッスンのみ更新可能
+        // マネージャー権限のない講師の場合は自分のタグのみ削除可能
         return $tag->instructor_id === $instructor->id;
 
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,10 +6,12 @@ use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Notification;
+use App\Model\Tag;
 use App\Policies\ChapterPolicy;
 use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
 use App\Policies\NotificationPolicy;
+use App\Policies\TagPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -24,6 +26,7 @@ class AuthServiceProvider extends ServiceProvider
         Chapter::class => ChapterPolicy::class,
         Lesson::class => LessonPolicy::class,
         Notification::class => NotificationPolicy::class,
+        Tag::class => TagPolicy::class,
     ];
 
     /**

--- a/tests/Feature/Api/Instructor/Tag/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Tag/DeleteTest.php
@@ -64,7 +64,7 @@ class DeleteTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Tag/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Tag/DeleteTest.php
@@ -64,7 +64,7 @@ class DeleteTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 


### PR DESCRIPTION
## Issue
jka-1437 講師/マネージャー タグ削除機能へのPolicyパターンを用いた認可機能の実装

## 仕様確認
マネージャー/講師　タグ削除機能の認可処理をpolicyクラスで共通化

## 実装内容
①マッピング
②TagPolicy作成
③Manager/Instructor：Conrtoller修正
④Manager/Instructor：DeleteTest修正

## テスト
### postman及び既存のPHPUnitで実施

#### postman【問題無し】
![スクリーンショット (149)](https://github.com/user-attachments/assets/4253345e-96df-409f-a41c-1551ae993d80)

#### PHPUnit【問題無し】
![スクリーンショット (148)](https://github.com/user-attachments/assets/b8a30cae-1db4-4e0a-86a6-71cb14c83821)

