### PR TITLE
JKA-1436 講師/マネージャー タグ更新機能へのPolicyパターンを用いた認可機能の実装（街）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -51,7 +51,7 @@ class TagController extends Controller
 
         $query = Tag::where('instructor_id', $instructorId)
             ->when($tagId, function (Builder $query, string $tagId) {
-                $query->whereHas('courses', fn(Builder $query) => $query->where('tags.id', $tagId));
+                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
             })
             ->with('courses')
             ->get();

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -51,7 +51,7 @@ class TagController extends Controller
 
         $query = Tag::where('instructor_id', $instructorId)
             ->when($tagId, function (Builder $query, string $tagId) {
-                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
+                $query->whereHas('courses', fn(Builder $query) => $query->where('tags.id', $tagId));
             })
             ->with('courses')
             ->get();
@@ -97,12 +97,9 @@ class TagController extends Controller
      */
     public function put(PutRequest $request): JsonResponse
     {
-        $user = Instructor::find(Auth::guard('instructor')->user()->id);
         $tag = Tag::findOrFail($request->tag_id);
 
-        if ($user->id !== $tag->instructor_id) {
-            throw new AuthorizationException('Forbidden, invalid instructor.');
-        }
+        $this->authorize('update', $tag);
 
         $tag->update([
             'content' => $request->content,

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -51,7 +51,7 @@ class TagController extends Controller
 
         $query = Tag::where('instructor_id', $instructorId)
             ->when($tagId, function (Builder $query, string $tagId) {
-                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
+                $query->whereHas('courses', fn(Builder $query) => $query->where('tags.id', $tagId));
             })
             ->with('courses')
             ->get();
@@ -99,8 +99,10 @@ class TagController extends Controller
     {
         $tag = Tag::findOrFail($request->tag_id);
 
+        // 配下のインストラクターまたは本人が作成したタグのみ更新可能
         $this->authorize('update', $tag);
 
+        // タグの更新
         $tag->update([
             'content' => $request->content,
         ]);

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -51,7 +51,7 @@ class TagController extends Controller
 
         $query = Tag::whereIn('instructor_id', $instructorIds)
             ->when($tagId, function (Builder $query, string $tagId) {
-                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
+                $query->whereHas('courses', fn(Builder $query) => $query->where('tags.id', $tagId));
             })
             ->with(['courses.instructor', 'courses.tags'])
             ->get();
@@ -71,21 +71,11 @@ class TagController extends Controller
      */
     public function put(PutRequest $request): JsonResponse
     {
-        // マネージャーが管理する講師IDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id; // 自身のIDも追加
-
         // タグの取得
         $tag = Tag::findOrFail($request->tag_id);
 
         // 配下のインストラクターまたは本人が作成したタグのみ更新可能
-        if (! in_array($tag->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        $this->authorize('update', $tag);
 
         // タグの更新
         $tag->update([

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -51,7 +51,7 @@ class TagController extends Controller
 
         $query = Tag::whereIn('instructor_id', $instructorIds)
             ->when($tagId, function (Builder $query, string $tagId) {
-                $query->whereHas('courses', fn(Builder $query) => $query->where('tags.id', $tagId));
+                $query->whereHas('courses', fn (Builder $query) => $query->where('tags.id', $tagId));
             })
             ->with(['courses.instructor', 'courses.tags'])
             ->get();

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -8,8 +8,24 @@ use App\Model\Tag;
 class TagPolicy
 {
     /**
+     * タグの削除機能に関する認可処理
+     */
+    public function delete(Instructor $instructor, Tag $tag)
+    {
+        // マネージャーの場合は配下の講師タグも削除可能
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
 
-     * Create a new policy instance.
+            return in_array($tag->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師の場合は自分のタグのみ削除可能
+        return $tag->instructor_id === $instructor->id;
+    }
+
+    /**
+     * タグの更新機能に関する認可処理
      */
     public function update(Instructor $instructor, Tag $tag): bool
     {

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -21,6 +21,6 @@ class TagPolicy
         }
 
         // マネージャー権限のない講師
-        return $instructor->id === $tag->instructor_id;
+        return $tag->instructor_id === $instructor->id;
     }
 }

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Instructor;
+use App\Model\Tag;
+
+class TagPolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function update(Instructor $instructor, Tag $tag): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($tag->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $instructor->id === $tag->instructor_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,10 +6,12 @@ use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Notification;
+use App\Model\Tag;
 use App\Policies\ChapterPolicy;
 use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
 use App\Policies\NotificationPolicy;
+use App\Policies\TagPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -24,6 +26,7 @@ class AuthServiceProvider extends ServiceProvider
         Chapter::class => ChapterPolicy::class,
         Lesson::class => LessonPolicy::class,
         Notification::class => NotificationPolicy::class,
+        Tag::class => TagPolicy::class,
     ];
 
     /**

--- a/tests/Feature/Api/Instructor/Tag/PutTest.php
+++ b/tests/Feature/Api/Instructor/Tag/PutTest.php
@@ -51,7 +51,7 @@ class PutTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Tag/PutTest.php
+++ b/tests/Feature/Api/Manager/Tag/PutTest.php
@@ -52,6 +52,9 @@ class PutTest extends TestCase
 
         // assert
         $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
     }
 
     public function test_バリデーションエラー(): void

--- a/tests/Feature/Api/Manager/Tag/PutTest.php
+++ b/tests/Feature/Api/Manager/Tag/PutTest.php
@@ -39,6 +39,24 @@ class PutTest extends TestCase
         ]);
     }
 
+    public function test_権限がないマネージャーで認証_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->putJson('/api/v1/manager/tag/1', [
+            'content' => 'test',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
     public function test_権限エラー(): void
     {
         // arrange


### PR DESCRIPTION
## issue
JKA-1436 講師/マネージャー タグ更新機能へのPolicyパターンを用いた認可機能の実装

## 実装内容
講師/マネージャーのタグ更新メソッドput()内の、認可をpolicyで書き換えた。
①マッピング
②TagPolicy作成
③Manager/Instructor：Conrtoller修正
④Manager/Instructor：PutTest修正

## postmanによる確認
<img width="653" alt="image" src="https://github.com/user-attachments/assets/008bb50f-8ed6-4a2f-8a03-622c9c1e8de3" />

## PHPUnitによる確認
![image](https://github.com/user-attachments/assets/ac061685-e6d7-4080-b75d-b2cf74e6ebee)
