### PR TITLE
JKA-1459 NotificationControllerのputメソッドをサービスクラス作成などで共通化（街）

### DIFF
--- a/app/Dto/Notification/PutDto.php
+++ b/app/Dto/Notification/PutDto.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Dto\Notification;
+
+class PutDto
+{
+    public function __construct(
+        private readonly int $notificationId,
+        private readonly string $type,
+        private readonly string $startDate,
+        private readonly string $endDate,
+        private readonly string $title,
+        private readonly string $content,
+        private readonly string $status
+    ) {}
+}

--- a/app/Dto/Notification/PutDto.php
+++ b/app/Dto/Notification/PutDto.php
@@ -5,12 +5,11 @@ namespace App\Dto\Notification;
 class PutDto
 {
     public function __construct(
-        private readonly int $notificationId,
-        private readonly string $type,
-        private readonly string $startDate,
-        private readonly string $endDate,
-        private readonly string $title,
-        private readonly string $content,
-        private readonly string $status
+        public readonly string $type,
+        public readonly string $start_date,
+        public readonly string $end_date,
+        public readonly string $title,
+        public readonly string $content,
+        public readonly string $status
     ) {}
 }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Services\Notification\PutNotificationService;
+use App\Dto\Notification\PutDto;
 
 
 /**
@@ -111,13 +112,19 @@ class NotificationController extends Controller
 
         DB::beginTransaction();
         try {
-            $service(
+            $data = new PutDto(
+                notificationId: $request->notification_id,
                 type: $request->type,
-                start_date: $request->start_date,
-                end_date: $request->end_date,
+                startDate: $request->start_date,
+                endDate: $request->end_date,
                 title: $request->title,
                 content: $request->content,
-                status: $request->status,
+                status: $request->status
+            );
+
+            $service(
+                $notification,
+                $data
             );
 
             DB::commit();

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -25,6 +25,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use App\Services\Notification\PutNotificationService;
+
 
 /**
  * @tags Instructor-Notification
@@ -99,7 +101,7 @@ class NotificationController extends Controller
     /**
      * お知らせ更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, PutNotificationService $service): JsonResponse
     {
         $notification = Notification::findOrFail($request->notification_id);
 
@@ -108,15 +110,15 @@ class NotificationController extends Controller
 
         DB::beginTransaction();
         try {
-            $notification->fill([
-                'type' => $request->type,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'title' => $request->title,
-                'content' => $request->content,
-                'status' => $request->status,
-            ])
-                ->save();
+            $service(
+                type: $request->type,
+                start_date: $request->start_date,
+                end_date: $request->end_date,
+                title: $request->title,
+                content: $request->content,
+                status: $request->status,
+            );
+
             DB::commit();
 
             return response()->json([
@@ -172,7 +174,7 @@ class NotificationController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
 
         if (
-            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
+            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
@@ -229,7 +231,7 @@ class NotificationController extends Controller
 
         // 講師と一致しないお知らせが含まれている場合はエラー
         if (
-            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructor->id)
+            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructor->id)
         ) {
             // 講師と一致しないお知らせが含まれている場合はエラー
             throw new AuthorizationException('Invalid instructor_id.');
@@ -274,7 +276,7 @@ class NotificationController extends Controller
 
         // 選択されたお知らせの中に、講師と一致しないお知らせが、１つでも含まれている場合はエラー
         if (
-            $chosenNotifications->contains(fn ($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
+            $chosenNotifications->contains(fn($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -113,10 +113,9 @@ class NotificationController extends Controller
         DB::beginTransaction();
         try {
             $data = new PutDto(
-                notificationId: $request->notification_id,
                 type: $request->type,
-                startDate: $request->start_date,
-                endDate: $request->end_date,
+                start_date: $request->start_date,
+                end_date: $request->end_date,
                 title: $request->title,
                 content: $request->content,
                 status: $request->status

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
+use App\Dto\Notification\PutDto;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Notification\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Notification\DeleteRequest;
@@ -19,6 +20,7 @@ use App\Model\Course;
 use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
 use App\Services\Notification\DeleteService;
+use App\Services\Notification\PutNotificationService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Collection;
@@ -26,9 +28,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use App\Services\Notification\PutNotificationService;
-use App\Dto\Notification\PutDto;
-
 
 /**
  * @tags Instructor-Notification
@@ -179,7 +178,7 @@ class NotificationController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
 
         if (
-            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructorId)
+            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
@@ -236,7 +235,7 @@ class NotificationController extends Controller
 
         // 講師と一致しないお知らせが含まれている場合はエラー
         if (
-            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructor->id)
+            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructor->id)
         ) {
             // 講師と一致しないお知らせが含まれている場合はエラー
             throw new AuthorizationException('Invalid instructor_id.');
@@ -281,7 +280,7 @@ class NotificationController extends Controller
 
         // 選択されたお知らせの中に、講師と一致しないお知らせが、１つでも含まれている場合はエラー
         if (
-            $chosenNotifications->contains(fn($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
+            $chosenNotifications->contains(fn ($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -365,14 +365,14 @@ class LessonController extends Controller
         $courseId = $request->input('course_id');
 
         // レッスン情報を取得
-        $lesson = Lesson::with('chapter.course', 'lessonAttendances')->whereIn('id', $lessonIds)->get();
+        $lessons = Lesson::with('chapter.course', 'lessonAttendances')->whereIn('id', $lessonIds)->get();
         DB::beginTransaction();
 
         try {
             // 自身もしくは配下の講師の講座・チャプターに紐づくレッスンでない場合は許可しない
-            $this->authorize('bulkDelete', [Lesson::class, $lesson]);
+            $this->authorize('bulkDelete', [Lesson::class, $lessons]);
 
-            $lesson->each(function (Lesson $lesson) use ($chapterId, $courseId) {
+            $lessons->each(function (Lesson $lesson) use ($chapterId, $courseId) {
                 // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
                 if ((int) $courseId !== $lesson->chapter->course->id) {
                     throw new AuthorizationException('Invalid course_id.');
@@ -389,7 +389,7 @@ class LessonController extends Controller
 
             // サービスクラスで対象レッスンの削除処理を実行
             $service(
-                lessonIds: $lesson->pluck('id')->toArray(),
+                lessonIds: $lessons->pluck('id')->toArray(),
                 chapterId: $chapterId
             );
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -27,7 +27,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use App\Services\Notification\PutNotificationService;
+use App\Dto\Notification\PutDto;
 
 /**
  * @tags Manager-Notification
@@ -194,7 +194,7 @@ class NotificationController extends Controller
             DB::commit();
 
             return response()->json([
-                'result' true,
+                'result' => true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -232,13 +232,13 @@ class NotificationController extends Controller
         try {
             $notifications->each(function (Notification $notification) use ($notificationType) {
                 $notification->fill([
-                    'type' $notificationType,
+                    'type' => $notificationType,
                 ])->save();
             });
             DB::commit();
 
             return response()->json([
-                'result' true,
+                'result' => true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -262,11 +262,11 @@ class NotificationController extends Controller
 
         try {
             $notifications->update([
-                'type' $request->notification_type,
+                'type' => $request->notification_type,
             ]);
 
             return response()->json([
-                'result' true,
+                'result' => true,
             ]);
         } catch (Exception $e) {
             Log::error($e);
@@ -310,7 +310,7 @@ class NotificationController extends Controller
             DB::commit();
 
             return response()->json([
-                'result' true,
+                'result' => true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -106,19 +106,19 @@ class NotificationController extends Controller
         DB::beginTransaction();
         try {
             Notification::create([
-                'course_id' $request->course_id,
-                'instructor_id' Auth::guard('instructor')->user()->id,
-                'title' $request->title,
-                'type' $request->type,
-                'start_date' $request->start_date,
-                'end_date' $request->end_date,
-                'status' $request->status,
-                'content' $request->content,
+                'course_id' => $request->course_id,
+                'instructor_id' => Auth::guard('instructor')->user()->id,
+                'title' => $request->title,
+                'type' => $request->type,
+                'start_date' => $request->start_date,
+                'end_date' => $request->end_date,
+                'status' => $request->status,
+                'content' => $request->content,
             ]);
             DB::commit();
 
             return response()->json([
-                'result' true,
+                'result' => true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -157,7 +157,7 @@ class NotificationController extends Controller
             DB::commit();
 
             return response()->json([
-                'result' true,
+                'result' => true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -140,14 +140,18 @@ class NotificationController extends Controller
 
         DB::beginTransaction();
         try {
-            $service(
-                $notification,
+            $data = new PutDto(
                 type: $request->type,
                 start_date: $request->start_date,
                 end_date: $request->end_date,
                 title: $request->title,
                 content: $request->content,
-                status: $request->status,
+                status: $request->status
+            );
+
+            $service(
+                $notification,
+                $data
             );
 
             DB::commit();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -141,6 +141,7 @@ class NotificationController extends Controller
         DB::beginTransaction();
         try {
             $service(
+                $notification,
                 type: $request->type,
                 start_date: $request->start_date,
                 end_date: $request->end_date,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -17,12 +17,14 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
+use App\Services\Notification\PutNotificationService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use App\Services\Notification\PutNotificationService;
 
 /**
  * @tags Manager-Notification
@@ -101,19 +103,19 @@ class NotificationController extends Controller
         DB::beginTransaction();
         try {
             Notification::create([
-                'course_id' => $request->course_id,
-                'instructor_id' => Auth::guard('instructor')->user()->id,
-                'title' => $request->title,
-                'type' => $request->type,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'status' => $request->status,
-                'content' => $request->content,
+                'course_id' $request->course_id,
+                'instructor_id' Auth::guard('instructor')->user()->id,
+                'title' $request->title,
+                'type' $request->type,
+                'start_date' $request->start_date,
+                'end_date' $request->end_date,
+                'status' $request->status,
+                'content' $request->content,
             ]);
             DB::commit();
 
             return response()->json([
-                'result' => true,
+                'result' true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -125,29 +127,29 @@ class NotificationController extends Controller
     /**
      * お知らせ更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, PutNotificationService $service): JsonResponse
     {
         // 指定されたお知らせIDでお知らせを取得
-        $notification = Notification::with('course')->findOrFail($request->notification_id);
+        $notification = Notification::findOrFail($request->notification_id);
 
         // policyによる認可チェック
         $this->authorize('update', $notification);
 
         DB::beginTransaction();
         try {
-            $notification->fill([
-                'type' => $request->type,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'title' => $request->title,
-                'content' => $request->content,
-                'status' => $request->status,
-            ])
-                ->save();
+            $service(
+                type: $request->type,
+                start_date: $request->start_date,
+                end_date: $request->end_date,
+                title: $request->title,
+                content: $request->content,
+                status: $request->status,
+            );
+
             DB::commit();
 
             return response()->json([
-                'result' => true,
+                'result' true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -186,7 +188,7 @@ class NotificationController extends Controller
             DB::commit();
 
             return response()->json([
-                'result' => true,
+                'result' true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -224,13 +226,13 @@ class NotificationController extends Controller
         try {
             $notifications->each(function (Notification $notification) use ($notificationType) {
                 $notification->fill([
-                    'type' => $notificationType,
+                    'type' $notificationType,
                 ])->save();
             });
             DB::commit();
 
             return response()->json([
-                'result' => true,
+                'result' true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();
@@ -254,11 +256,11 @@ class NotificationController extends Controller
 
         try {
             $notifications->update([
-                'type' => $request->notification_type,
+                'type' $request->notification_type,
             ]);
 
             return response()->json([
-                'result' => true,
+                'result' true,
             ]);
         } catch (Exception $e) {
             Log::error($e);
@@ -302,7 +304,7 @@ class NotificationController extends Controller
             DB::commit();
 
             return response()->json([
-                'result' => true,
+                'result' true,
             ]);
         } catch (Exception $e) {
             DB::rollBack();

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Manager;
 
+use App\Dto\Notification\PutDto;
 use App\Enums\Notification\StatusEnum;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Notification\BulkDeleteRequest;
@@ -19,15 +20,14 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
 use App\Model\ViewedOnceNotification;
-use App\Services\Notification\PutNotificationService;
 use App\Services\Notification\DeleteService;
+use App\Services\Notification\PutNotificationService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use App\Dto\Notification\PutDto;
 
 /**
  * @tags Manager-Notification

--- a/app/Services/Notification/PutNotificationService.php
+++ b/app/Services/Notification/PutNotificationService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Notification;
 
+use App\Dto\Notification\PutDto;
 use App\Model\Notification;
 
 class PutNotificationService
@@ -9,23 +10,15 @@ class PutNotificationService
     /**
      * お知らせの内容を更新
      */
-    public function __invoke(
-        Notification $notification,
-        string $type,
-        string $start_date,
-        string $end_date,
-        string $title,
-        string $content,
-        string $status
-    ): void {
+    public function __invoke(Notification $notification, PutDto $data): void
+    {
         $notification->fill([
-            'type' => $type,
-            'start_date' => $start_date,
-            'end_date' => $end_date,
-            'title' => $title,
-            'content' => $content,
-            'status' => $status,
-        ])
-            ->save();
+            'type' => $data->type,
+            'start_date' => $data->start_date,
+            'end_date' => $data->end_date,
+            'title' => $data->title,
+            'content' => $data->content,
+            'status' => $data->status,
+        ])->save();
     }
 }

--- a/app/Services/Notification/PutNotificationService.php
+++ b/app/Services/Notification/PutNotificationService.php
@@ -11,9 +11,9 @@ class PutNotificationService
      */
     public function __invoke(
         Notification $notification,
-        int $type,
-        int $start_date,
-        int $end_date,
+        string $type,
+        string $start_date,
+        string $end_date,
         string $title,
         string $content,
         string $status

--- a/app/Services/Notification/PutNotificationService.php
+++ b/app/Services/Notification/PutNotificationService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\Notification;
+
+use App\Model\Notification;
+
+class PutNotificationService
+{
+    /**
+     * お知らせの内容を更新
+     */
+    public function __invoke(
+        Notification $notification,
+        int $type,
+        int $start_date,
+        int $end_date,
+        string $title,
+        string $content,
+        string $status
+    ): void {
+        $notification->fill([
+            'type' => $type,
+            'start_date' => $start_date,
+            'end_date' => $end_date,
+            'title' => $title,
+            'content' => $content,
+            'status' => $status,
+        ])
+            ->save();
+    }
+}


### PR DESCRIPTION
## issue
JKA-1459 NotificationControllerのputメソッドをサービスクラス作成などで共通化

## 実装内容
１）Dtoクラスファイルaravelapp/app/Dto/Notification/PutDto.phpの作成

２）サービスファイルlaravelapp/app/Servicies/Notification/PutNotification.phpの作成

３）aravelapp/app/Http/Controllers/Api/Instructor/NotificationController.phpのput()の$notification->fill([])を、サービスで書き換え

４）aravelapp/app/Http/Controllers/Api/Mαnager/NotificationController.phpのput()の$notification->fill([])を、サービスで書き換え

## postomanによる動作確認
<img width="661" alt="image" src="https://github.com/user-attachments/assets/5e9c5433-cf31-4568-867d-e3c57581c5c1" />

## PHP UnitTestの結果
![image](https://github.com/user-attachments/assets/63c3c771-3c43-47e5-95b1-6ce94fcf691c)
