### PR TITLE
JKA-1464 レッスン並び替え機能のデータ整合性を向上(街)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -286,7 +286,7 @@ class LessonController extends Controller
         try {
             $courseId = $request->input('course_id');
             $chapterId = $request->input('chapter_id');
-            $inputLessons = $request->input('lessons');
+            $inputLessons = $request->input('lessons'); // example: [5, 4, 3, 2, 1]
 
             // レッスン一括取得
             $lessons = Lesson::with('chapter.course')->whereIn('id', array_column($inputLessons, 'lesson_id'))->get();

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -284,27 +284,13 @@ class LessonController extends Controller
         DB::beginTransaction();
 
         try {
-            $courseId = $request->input('course_id');
-            $chapterId = $request->input('chapter_id');
-            $inputLessons = $request->input('lessons'); // example: [5, 4, 3, 2, 1]
+            $inputLessons = $request->input('lessons');
 
             // レッスン一括取得
             $lessons = Lesson::with('chapter.course')->whereIn('id', $inputLessons)->get();
 
             // Policy による認可チェック
             $this->authorize('bulkUpdate', [Lesson::class, $lessons]);
-
-            // 認可
-            $lessons->each(function (Lesson $lesson) use ($courseId, $chapterId) {
-                // 指定した講座IDが1レッスンの講座IDと一致しない場合は許可しない
-                if ((int) $courseId !== $lesson->chapter->course_id) {
-                    throw new AuthorizationException('Forbidden, invalid course.');
-                }
-                // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
-                if ((int) $chapterId !== $lesson->chapter_id) {
-                    throw new AuthorizationException('Forbidden, invalid chapter.');
-                }
-            });
 
             $sortLessonsService($lessons, $inputLessons);
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -289,7 +289,7 @@ class LessonController extends Controller
             $inputLessons = $request->input('lessons'); // example: [5, 4, 3, 2, 1]
 
             // レッスン一括取得
-            $lessons = Lesson::with('chapter.course')->whereIn('id', array_column($inputLessons, 'lesson_id'))->get();
+            $lessons = Lesson::with('chapter.course')->whereIn('id', $inputLessons)->get();
 
             // Policy による認可チェック
             $this->authorize('bulkUpdate', [Lesson::class, $lessons]);

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -173,27 +173,13 @@ class LessonController extends Controller
         DB::beginTransaction();
 
         try {
-            $courseId = $request->input('course_id');
-            $chapterId = $request->input('chapter_id');
-            $inputLessons = $request->input('lessons'); // example: [5, 4, 3, 2, 1]
+            $inputLessons = $request->input('lessons');
 
             // レッスンを一括取得
             $lessons = Lesson::with('chapter.course')->whereIn('id', $inputLessons)->get();
 
             // Policy による認可チェック
             $this->authorize('bulkUpdate', [Lesson::class, $lessons]);
-
-            /// 認可
-            $lessons->each(function (Lesson $lesson) use ($courseId, $chapterId) {
-                // 指定した講座IDが1レッスンの講座IDと一致しない場合は許可しない
-                if ((int) $courseId !== $lesson->chapter->course->id) {
-                    throw new AuthorizationException('Forbidden, not allowed to delete this lesson. Invalid course_id.');
-                }
-                // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
-                if ((int) $chapterId !== $lesson->chapter->id) {
-                    throw new AuthorizationException('Forbidden, not allowed to delete this lesson. Invalid chapter_id.');
-                }
-            });
 
             $sortLessonsService($lessons, $inputLessons);
 

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -175,12 +175,10 @@ class LessonController extends Controller
         try {
             $courseId = $request->input('course_id');
             $chapterId = $request->input('chapter_id');
-            $inputLessons = $request->input('lessons');
+            $inputLessons = $request->input('lessons'); // example: [5, 4, 3, 2, 1]
 
             // レッスンを一括取得
-            $lessons = Lesson::with('chapter.course')
-                ->whereIn('id', array_column($inputLessons, 'lesson_id'))
-                ->get();
+            $lessons = Lesson::with('chapter.course')->whereIn('id', $inputLessons)->get();
 
             // Policy による認可チェック
             $this->authorize('bulkUpdate', [Lesson::class, $lessons]);

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -5,7 +5,6 @@ namespace App\Http\Requests\Instructor\Lesson;
 use App\Model\Lesson;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Collection;
 
 class SortRequest extends FormRequest
 {
@@ -50,17 +49,17 @@ class SortRequest extends FormRequest
                     })
                     ->get();
 
-                // 入力されたレッスンのみ取り出し 
+                // 入力されたレッスンのみ取り出し
                 $inputLessonsCollection = $allLessons->whereIn('id', $inputLessons);
 
                 // (1) lesson が chapter_id に属しているか
-                $invalidChapter = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+                $invalidChapter = $inputLessonsCollection->reject(fn ($lesson) => $lesson->chapter_id === $chapterId);
                 if ($invalidChapter->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
                 }
 
                 // (2) lesson が course_id に属しているか
-                $invalidCourse = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+                $invalidCourse = $inputLessonsCollection->reject(fn ($lesson) => $lesson->chapter->course_id === $courseId);
                 if ($invalidCourse->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
                 }
@@ -79,7 +78,7 @@ class SortRequest extends FormRequest
                 if (count($inputLessons) !== count(array_unique($inputLessons))) {
                     $validator->errors()->add('lessons', 'duplicate lessons found.');
                 }
-            }
+            },
         ];
     }
 

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -43,27 +43,30 @@ class SortRequest extends FormRequest
                 $chapterId = (int) $this->input('chapter_id');
                 $inputLessons = $this->input('lessons', []);
 
-                // 取得
-                $lessons = Lesson::with('chapter.course')
-                    ->whereIn('id', $inputLessons)
+                $allLessons = Lesson::with('chapter.course')
+                    ->where(function ($query) use ($chapterId, $inputLessons) {
+                        $query->whereIn('id', $inputLessons)
+                            ->orWhere('chapter_id', $chapterId);
+                    })
                     ->get();
 
+                // 入力されたレッスンのみ取り出し 
+                $inputLessonsCollection = $allLessons->whereIn('id', $inputLessons);
+
                 // (1) lesson が chapter_id に属しているか
-                $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+                $invalidChapter = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
                 if ($invalidChapter->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
                 }
 
                 // (2) lesson が course_id に属しているか
-                $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+                $invalidCourse = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
                 if ($invalidCourse->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
                 }
 
                 // (3) chapter_id に属する lesson がすべて含まれているか
-                $validLessonIds = $lessons
-                    // $chapterIdと紐づくレッスンのみを残す
-                    ->filter(fn($lesson) => $lesson->chapter_id === $chapterId)
+                $validLessonIds = $allLessons->where('chapter_id', $chapterId)
                     ->pluck('id')
                     ->toArray();
 

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -36,8 +36,8 @@ class SortRequest extends FormRequest
     public function withValidator($validator)
     {
         $validator->after(function (Validator $validator) {
-            $courseId = (int)$this->input('course_id');
-            $chapterId = (int)$this->input('chapter_id');
+            $courseId = (int) $this->input('course_id');
+            $chapterId = (int) $this->input('chapter_id');
             $inputLessons = $this->input('lessons', []);
 
             // 取得
@@ -46,13 +46,13 @@ class SortRequest extends FormRequest
                 ->get();
 
             // ① lesson が chapter_id に属しているか
-            $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+            $invalidChapter = $lessons->reject(fn ($lesson) => $lesson->chapter_id === $chapterId);
             if ($invalidChapter->isNotEmpty()) {
                 $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
             }
 
             // ② lesson が course_id に属しているか
-            $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+            $invalidCourse = $lessons->reject(fn ($lesson) => $lesson->chapter->course_id === $courseId);
             if ($invalidCourse->isNotEmpty()) {
                 $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
             }

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -36,18 +36,33 @@ class SortRequest extends FormRequest
     public function withValidator($validator)
     {
         $validator->after(function (Validator $validator) {
-            $chapterId = $this->input('chapter_id');
-            $inputLessonIds = $this->input('lessons', []);
+            $courseId = (int)$this->input('course_id');
+            $chapterId = (int)$this->input('chapter_id');
+            $inputLessons = $this->input('lessons', []);
 
-            // 指定された chapter_id に属し、論理削除されていないレッスンを取得
+            // 取得
+            $lessons = Lesson::with('chapter.course')
+                ->whereIn('id', $inputLessons)
+                ->get();
+
+            // ① lesson が chapter_id に属しているか
+            $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+            if ($invalidChapter->isNotEmpty()) {
+                $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
+            }
+
+            // ② lesson が course_id に属しているか
+            $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+            if ($invalidCourse->isNotEmpty()) {
+                $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
+            }
+
+            // ③ chapter_id に属する lesson がすべて含まれているか（既存の検証）
             $validLessonIds = Lesson::where('chapter_id', $chapterId)
-                ->whereNull('deleted_at')
                 ->pluck('id')
                 ->toArray();
 
-            // 対象のレッスンIDがすべて含まれているかチェック
-            $diff = array_diff($validLessonIds, $inputLessonIds);
-
+            $diff = array_diff($validLessonIds, $inputLessons);
             if (! empty($diff)) {
                 $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
             }

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -43,12 +43,10 @@ class SortRequest extends FormRequest
                 $chapterId = (int) $this->input('chapter_id');
                 $inputLessons = $this->input('lessons', []);
 
-                // chapter_id に紐づくレッスンを全て取得
-                $allLessonIds = Lesson::with('chapter.course')
-                    ->where('chapter_id', $chapterId)->get();
-
-                // inputLessonsのレッスンを取得
-                $lessons = $allLessonIds->whereIn('id', $inputLessons);
+                // 取得
+                $lessons = Lesson::with('chapter.course')
+                    ->whereIn('id', $inputLessons)
+                    ->get();
 
                 // (1) lesson が chapter_id に属しているか
                 $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
@@ -63,9 +61,13 @@ class SortRequest extends FormRequest
                 }
 
                 // (3) chapter_id に属する lesson がすべて含まれているか
-                $allLessonIds = $allLessonIds->pluck('id')->toArray();
+                $validLessonIds = $lessons
+                    // $chapterIdと紐づくレッスンのみを残す
+                    ->filter(fn($lesson) => $lesson->chapter_id === $chapterId)
+                    ->pluck('id')
+                    ->toArray();
 
-                $diff = array_diff($allLessonIds, $inputLessons);
+                $diff = array_diff($validLessonIds, $inputLessons);
                 if (! empty($diff)) {
                     $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
                 }

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\Instructor\Lesson;
 
-use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Contracts\Validation\Validator;
 use App\Model\Lesson;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
 
 class SortRequest extends FormRequest
 {
@@ -48,7 +48,7 @@ class SortRequest extends FormRequest
             // 対象のレッスンIDがすべて含まれているかチェック
             $diff = array_diff($validLessonIds, $inputLessonIds);
 
-            if (!empty($diff)) {
+            if (! empty($diff)) {
                 $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
             }
         });

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests\Instructor\Lesson;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use App\Model\Lesson;
 
 class SortRequest extends FormRequest
 {
@@ -28,8 +30,28 @@ class SortRequest extends FormRequest
             'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lessons' => ['required', 'array'],
             'lessons.*.lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
-            'lessons.*.order' => ['required', 'integer'],
         ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function (Validator $validator) {
+            $chapterId = $this->input('chapter_id');
+            $inputLessonIds = collect($this->input('lessons'))->pluck('lesson_id')->toArray();
+
+            // 指定された chapter_id に属し、論理削除されていないレッスンを取得
+            $validLessonIds = Lesson::where('chapter_id', $chapterId)
+                ->whereNull('deleted_at')
+                ->pluck('id')
+                ->toArray();
+
+            // 対象のレッスンIDがすべて含まれているかチェック
+            $diff = array_diff($validLessonIds, $inputLessonIds);
+
+            if (!empty($diff)) {
+                $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
+            }
+        });
     }
 
     #[\Override]

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Instructor\Lesson;
 use App\Model\Lesson;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Collection;
 
 class SortRequest extends FormRequest
 {
@@ -19,7 +20,7 @@ class SortRequest extends FormRequest
     }
 
     /**
-     * Get the validation rules that apply to the request.
+     * 最初のバリデーション
      *
      * @return array
      */
@@ -33,40 +34,48 @@ class SortRequest extends FormRequest
         ];
     }
 
-    public function withValidator($validator)
+    // 追加のバリデーション
+    public function after(): array
     {
-        $validator->after(function (Validator $validator) {
-            $courseId = (int) $this->input('course_id');
-            $chapterId = (int) $this->input('chapter_id');
-            $inputLessons = $this->input('lessons', []);
+        return [
+            function (Validator $validator) {
+                $courseId = (int) $this->input('course_id');
+                $chapterId = (int) $this->input('chapter_id');
+                $inputLessons = $this->input('lessons', []);
 
-            // 取得
-            $lessons = Lesson::with('chapter.course')
-                ->whereIn('id', $inputLessons)
-                ->get();
+                // chapter_id に紐づくレッスンを全て取得
+                $allLessonIds = Lesson::with('chapter.course')
+                    ->where('chapter_id', $chapterId)->get();
 
-            // ① lesson が chapter_id に属しているか
-            $invalidChapter = $lessons->reject(fn ($lesson) => $lesson->chapter_id === $chapterId);
-            if ($invalidChapter->isNotEmpty()) {
-                $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
+                // inputLessonsのレッスンを取得
+                $lessons = $allLessonIds->whereIn('id', $inputLessons);
+
+                // (1) lesson が chapter_id に属しているか
+                $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+                if ($invalidChapter->isNotEmpty()) {
+                    $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
+                }
+
+                // (2) lesson が course_id に属しているか
+                $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+                if ($invalidCourse->isNotEmpty()) {
+                    $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
+                }
+
+                // (3) chapter_id に属する lesson がすべて含まれているか
+                $allLessonIds = $allLessonIds->pluck('id')->toArray();
+
+                $diff = array_diff($allLessonIds, $inputLessons);
+                if (! empty($diff)) {
+                    $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
+                }
+
+                // (4) 重複しているlessonsがあるか
+                if (count($inputLessons) !== count(array_unique($inputLessons))) {
+                    $validator->errors()->add('lessons', 'duplicate lessons found.');
+                }
             }
-
-            // ② lesson が course_id に属しているか
-            $invalidCourse = $lessons->reject(fn ($lesson) => $lesson->chapter->course_id === $courseId);
-            if ($invalidCourse->isNotEmpty()) {
-                $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
-            }
-
-            // ③ chapter_id に属する lesson がすべて含まれているか（既存の検証）
-            $validLessonIds = Lesson::where('chapter_id', $chapterId)
-                ->pluck('id')
-                ->toArray();
-
-            $diff = array_diff($validLessonIds, $inputLessons);
-            if (! empty($diff)) {
-                $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
-            }
-        });
+        ];
     }
 
     #[\Override]

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -29,7 +29,8 @@ class SortRequest extends FormRequest
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lessons' => ['required', 'array'],
-            'lessons.*.lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+            // order値を検証する。
+            'lessons.*.order' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
         ];
     }
 

--- a/app/Http/Requests/Instructor/Lesson/SortRequest.php
+++ b/app/Http/Requests/Instructor/Lesson/SortRequest.php
@@ -29,8 +29,7 @@ class SortRequest extends FormRequest
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lessons' => ['required', 'array'],
-            // order値を検証する。
-            'lessons.*.order' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+            'lessons.*' => ['required', 'integer'],
         ];
     }
 
@@ -38,7 +37,7 @@ class SortRequest extends FormRequest
     {
         $validator->after(function (Validator $validator) {
             $chapterId = $this->input('chapter_id');
-            $inputLessonIds = collect($this->input('lessons'))->pluck('lesson_id')->toArray();
+            $inputLessonIds = $this->input('lessons', []);
 
             // 指定された chapter_id に属し、論理削除されていないレッスンを取得
             $validLessonIds = Lesson::where('chapter_id', $chapterId)

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -29,7 +29,7 @@ class SortRequest extends FormRequest
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lessons' => ['required', 'array'],
-            'lessons.*.lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+            'lessons.*' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
         ];
     }
 

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -36,8 +36,8 @@ class SortRequest extends FormRequest
     public function withValidator($validator)
     {
         $validator->after(function (Validator $validator) {
-            $courseId = (int)$this->input('course_id');
-            $chapterId = (int)$this->input('chapter_id');
+            $courseId = (int) $this->input('course_id');
+            $chapterId = (int) $this->input('chapter_id');
             $inputLessons = $this->input('lessons', []);
 
             // 取得
@@ -46,13 +46,13 @@ class SortRequest extends FormRequest
                 ->get();
 
             // ① lesson が chapter_id に属しているか
-            $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+            $invalidChapter = $lessons->reject(fn ($lesson) => $lesson->chapter_id === $chapterId);
             if ($invalidChapter->isNotEmpty()) {
                 $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
             }
 
             // ② lesson が course_id に属しているか
-            $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+            $invalidCourse = $lessons->reject(fn ($lesson) => $lesson->chapter->course_id === $courseId);
             if ($invalidCourse->isNotEmpty()) {
                 $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
             }

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -49,17 +49,17 @@ class SortRequest extends FormRequest
                     })
                     ->get();
 
-                // 入力されたレッスンのみ取り出し 
+                // 入力されたレッスンのみ取り出し
                 $inputLessonsCollection = $allLessons->whereIn('id', $inputLessons);
 
                 // (1) lesson が chapter_id に属しているか
-                $invalidChapter = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+                $invalidChapter = $inputLessonsCollection->reject(fn ($lesson) => $lesson->chapter_id === $chapterId);
                 if ($invalidChapter->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
                 }
 
                 // (2) lesson が course_id に属しているか
-                $invalidCourse = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+                $invalidCourse = $inputLessonsCollection->reject(fn ($lesson) => $lesson->chapter->course_id === $courseId);
                 if ($invalidCourse->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
                 }
@@ -78,7 +78,7 @@ class SortRequest extends FormRequest
                 if (count($inputLessons) !== count(array_unique($inputLessons))) {
                     $validator->errors()->add('lessons', 'duplicate lessons found.');
                 }
-            }
+            },
         ];
     }
 

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -42,25 +42,30 @@ class SortRequest extends FormRequest
                 $chapterId = (int) $this->input('chapter_id');
                 $inputLessons = $this->input('lessons', []);
 
-                // 取得
-                $lessons = Lesson::with('chapter.course')
-                    ->whereIn('id', $inputLessons)
+                $allLessons = Lesson::with('chapter.course')
+                    ->where(function ($query) use ($chapterId, $inputLessons) {
+                        $query->whereIn('id', $inputLessons)
+                            ->orWhere('chapter_id', $chapterId);
+                    })
                     ->get();
 
+                // 入力されたレッスンのみ取り出し 
+                $inputLessonsCollection = $allLessons->whereIn('id', $inputLessons);
+
                 // (1) lesson が chapter_id に属しているか
-                $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+                $invalidChapter = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
                 if ($invalidChapter->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
                 }
 
                 // (2) lesson が course_id に属しているか
-                $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+                $invalidCourse = $inputLessonsCollection->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
                 if ($invalidCourse->isNotEmpty()) {
                     $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
                 }
 
                 // (3) chapter_id に属する lesson がすべて含まれているか
-                $validLessonIds = Lesson::where('chapter_id', $chapterId)
+                $validLessonIds = $allLessons->where('chapter_id', $chapterId)
                     ->pluck('id')
                     ->toArray();
 

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -36,18 +36,33 @@ class SortRequest extends FormRequest
     public function withValidator($validator)
     {
         $validator->after(function (Validator $validator) {
-            $chapterId = $this->input('chapter_id');
-            $inputLessonIds = $this->input('lessons', []);
+            $courseId = (int)$this->input('course_id');
+            $chapterId = (int)$this->input('chapter_id');
+            $inputLessons = $this->input('lessons', []);
 
-            // 指定された chapter_id に属し、論理削除されていないレッスンを取得
+            // 取得
+            $lessons = Lesson::with('chapter.course')
+                ->whereIn('id', $inputLessons)
+                ->get();
+
+            // ① lesson が chapter_id に属しているか
+            $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+            if ($invalidChapter->isNotEmpty()) {
+                $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
+            }
+
+            // ② lesson が course_id に属しているか
+            $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+            if ($invalidCourse->isNotEmpty()) {
+                $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
+            }
+
+            // ③ chapter_id に属する lesson がすべて含まれているか（既存の検証）
             $validLessonIds = Lesson::where('chapter_id', $chapterId)
-                ->whereNull('deleted_at')
                 ->pluck('id')
                 ->toArray();
 
-            // 対象のレッスンIDがすべて含まれているかチェック
-            $diff = array_diff($validLessonIds, $inputLessonIds);
-
+            $diff = array_diff($validLessonIds, $inputLessons);
             if (! empty($diff)) {
                 $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
             }

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests\Manager\Lesson;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use App\Model\Lesson;
 
 class SortRequest extends FormRequest
 {
@@ -28,8 +30,28 @@ class SortRequest extends FormRequest
             'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lessons' => ['required', 'array'],
             'lessons.*.lesson_id' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
-            'lessons.*.order' => ['required', 'integer'],
         ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function (Validator $validator) {
+            $chapterId = $this->input('chapter_id');
+            $inputLessonIds = collect($this->input('lessons'))->pluck('lesson_id')->toArray();
+
+            // 指定された chapter_id に属し、論理削除されていないレッスンを取得
+            $validLessonIds = Lesson::where('chapter_id', $chapterId)
+                ->whereNull('deleted_at')
+                ->pluck('id')
+                ->toArray();
+
+            // 対象のレッスンIDがすべて含まれているかチェック
+            $diff = array_diff($validLessonIds, $inputLessonIds);
+
+            if (!empty($diff)) {
+                $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
+            }
+        });
     }
 
     #[\Override]

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\Manager\Lesson;
 
-use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Contracts\Validation\Validator;
 use App\Model\Lesson;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
 
 class SortRequest extends FormRequest
 {
@@ -48,7 +48,7 @@ class SortRequest extends FormRequest
             // 対象のレッスンIDがすべて含まれているかチェック
             $diff = array_diff($validLessonIds, $inputLessonIds);
 
-            if (!empty($diff)) {
+            if (! empty($diff)) {
                 $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
             }
         });

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -29,7 +29,7 @@ class SortRequest extends FormRequest
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
             'chapter_id' => ['required', 'integer', 'exists:chapters,id,deleted_at,NULL'],
             'lessons' => ['required', 'array'],
-            'lessons.*' => ['required', 'integer', 'exists:lessons,id,deleted_at,NULL'],
+            'lessons.*' => ['required', 'integer'],
         ];
     }
 
@@ -37,7 +37,7 @@ class SortRequest extends FormRequest
     {
         $validator->after(function (Validator $validator) {
             $chapterId = $this->input('chapter_id');
-            $inputLessonIds = collect($this->input('lessons'))->pluck('lesson_id')->toArray();
+            $inputLessonIds = $this->input('lessons', []);
 
             // 指定された chapter_id に属し、論理削除されていないレッスンを取得
             $validLessonIds = Lesson::where('chapter_id', $chapterId)

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -42,12 +42,10 @@ class SortRequest extends FormRequest
                 $chapterId = (int) $this->input('chapter_id');
                 $inputLessons = $this->input('lessons', []);
 
-                // chapter_id に紐づくレッスンを全て取得
-                $allLessonIds = Lesson::with('chapter.course')
-                    ->where('chapter_id', $chapterId)->get();
-
-                // inputLessonsのレッスンを取得
-                $lessons = $allLessonIds->whereIn('id', $inputLessons);
+                // 取得
+                $lessons = Lesson::with('chapter.course')
+                    ->whereIn('id', $inputLessons)
+                    ->get();
 
                 // (1) lesson が chapter_id に属しているか
                 $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
@@ -62,9 +60,11 @@ class SortRequest extends FormRequest
                 }
 
                 // (3) chapter_id に属する lesson がすべて含まれているか
-                $allLessonIds = $allLessonIds->pluck('id')->toArray();
+                $validLessonIds = Lesson::where('chapter_id', $chapterId)
+                    ->pluck('id')
+                    ->toArray();
 
-                $diff = array_diff($allLessonIds, $inputLessons);
+                $diff = array_diff($validLessonIds, $inputLessons);
                 if (! empty($diff)) {
                     $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
                 }

--- a/app/Http/Requests/Manager/Lesson/SortRequest.php
+++ b/app/Http/Requests/Manager/Lesson/SortRequest.php
@@ -19,7 +19,7 @@ class SortRequest extends FormRequest
     }
 
     /**
-     * Get the validation rules that apply to the request.
+     * 最初のバリデーション
      *
      * @return array
      */
@@ -33,40 +33,48 @@ class SortRequest extends FormRequest
         ];
     }
 
-    public function withValidator($validator)
+    // 追加のバリデーション
+    public function after(): array
     {
-        $validator->after(function (Validator $validator) {
-            $courseId = (int) $this->input('course_id');
-            $chapterId = (int) $this->input('chapter_id');
-            $inputLessons = $this->input('lessons', []);
+        return [
+            function (Validator $validator) {
+                $courseId = (int) $this->input('course_id');
+                $chapterId = (int) $this->input('chapter_id');
+                $inputLessons = $this->input('lessons', []);
 
-            // 取得
-            $lessons = Lesson::with('chapter.course')
-                ->whereIn('id', $inputLessons)
-                ->get();
+                // chapter_id に紐づくレッスンを全て取得
+                $allLessonIds = Lesson::with('chapter.course')
+                    ->where('chapter_id', $chapterId)->get();
 
-            // ① lesson が chapter_id に属しているか
-            $invalidChapter = $lessons->reject(fn ($lesson) => $lesson->chapter_id === $chapterId);
-            if ($invalidChapter->isNotEmpty()) {
-                $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
+                // inputLessonsのレッスンを取得
+                $lessons = $allLessonIds->whereIn('id', $inputLessons);
+
+                // (1) lesson が chapter_id に属しているか
+                $invalidChapter = $lessons->reject(fn($lesson) => $lesson->chapter_id === $chapterId);
+                if ($invalidChapter->isNotEmpty()) {
+                    $validator->errors()->add('lessons', 'invalid lessons found for the specified chapter.');
+                }
+
+                // (2) lesson が course_id に属しているか
+                $invalidCourse = $lessons->reject(fn($lesson) => $lesson->chapter->course_id === $courseId);
+                if ($invalidCourse->isNotEmpty()) {
+                    $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
+                }
+
+                // (3) chapter_id に属する lesson がすべて含まれているか
+                $allLessonIds = $allLessonIds->pluck('id')->toArray();
+
+                $diff = array_diff($allLessonIds, $inputLessons);
+                if (! empty($diff)) {
+                    $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
+                }
+
+                // (4) 重複しているlessonsがあるか
+                if (count($inputLessons) !== count(array_unique($inputLessons))) {
+                    $validator->errors()->add('lessons', 'duplicate lessons found.');
+                }
             }
-
-            // ② lesson が course_id に属しているか
-            $invalidCourse = $lessons->reject(fn ($lesson) => $lesson->chapter->course_id === $courseId);
-            if ($invalidCourse->isNotEmpty()) {
-                $validator->errors()->add('lessons', 'invalid lessons found for the specified course.');
-            }
-
-            // ③ chapter_id に属する lesson がすべて含まれているか（既存の検証）
-            $validLessonIds = Lesson::where('chapter_id', $chapterId)
-                ->pluck('id')
-                ->toArray();
-
-            $diff = array_diff($validLessonIds, $inputLessons);
-            if (! empty($diff)) {
-                $validator->errors()->add('lessons', 'all valid lessons not found for the specified chapter.');
-            }
-        });
+        ];
     }
 
     #[\Override]

--- a/app/Services/Lesson/SortLessonsService.php
+++ b/app/Services/Lesson/SortLessonsService.php
@@ -22,8 +22,8 @@ class SortLessonsService
 
             $lesson = $model;
 
-            // インデックスを取得
-            $index = $inputLessonCollection->search(fn (array $input) => $input['lesson_id'] === $lesson->id);
+            // lessons配列内における要素の順序を取得
+            $index = $inputLessonCollection->search(fn(array $input) => $input['lesson_id'] === $lesson->id);
 
             if ($index !== false) {
                 $lesson->update([

--- a/app/Services/Lesson/SortLessonsService.php
+++ b/app/Services/Lesson/SortLessonsService.php
@@ -2,9 +2,9 @@
 
 namespace App\Services\Lesson;
 
-use Illuminate\Database\Eloquent\Model;
 use App\Model\Lesson;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 
 class SortLessonsService
 {
@@ -16,16 +16,14 @@ class SortLessonsService
         $inputLessonCollection = collect($inputLessons);
 
         $lessons->each(function (Model $model) use ($inputLessonCollection) {
-            if (!$model instanceof Lesson) {
+            if (! $model instanceof Lesson) {
                 return;
             }
 
             $lesson = $model;
 
             // インデックスを取得
-            $index = $inputLessonCollection->search(function (array $input) use ($lesson) {
-                return $input['lesson_id'] === $lesson->id;
-            });
+            $index = $inputLessonCollection->search(fn (array $input) => $input['lesson_id'] === $lesson->id);
 
             if ($index !== false) {
                 $lesson->update([

--- a/app/Services/Lesson/SortLessonsService.php
+++ b/app/Services/Lesson/SortLessonsService.php
@@ -9,21 +9,19 @@ use Illuminate\Database\Eloquent\Model;
 class SortLessonsService
 {
     /**
-     * レッスン並び替えサービス order値は、配列要素のインデックス値にする。１から始まる値にする。
+     * レッスン並び替えサービス order値は、配列要素のインデックスにする。１から始まる値にする。
      */
     public function __invoke(Collection $lessons, array $inputLessons): void
     {
-        $inputLessonCollection = collect($inputLessons);
-
-        $lessons->each(function (Model $model) use ($inputLessonCollection) {
+        $lessons->each(function (Model $model) use ($inputLessons) {
             if (! $model instanceof Lesson) {
                 return;
             }
 
             $lesson = $model;
 
-            // lessons配列内における要素の順序を取得
-            $index = $inputLessonCollection->search(fn(array $input) => $input['lesson_id'] === $lesson->id);
+            // lessons配列内における要素のインデックスを取得
+            $index = array_search($lesson->id, $inputLessons, true);
 
             if ($index !== false) {
                 $lesson->update([

--- a/app/Services/Lesson/SortLessonsService.php
+++ b/app/Services/Lesson/SortLessonsService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Lesson;
 
+use Illuminate\Database\Eloquent\Model;
 use App\Model\Lesson;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -14,9 +15,15 @@ class SortLessonsService
     {
         $inputLessonCollection = collect($inputLessons);
 
-        $lessons->each(function (Lesson $lesson) use ($inputLessonCollection) {
+        $lessons->each(function (Model $model) use ($inputLessonCollection) {
+            if (!$model instanceof Lesson) {
+                return;
+            }
+
+            $lesson = $model;
+
             // インデックスを取得
-            $index = $inputLessonCollection->search(function ($input) use ($lesson) {
+            $index = $inputLessonCollection->search(function (array $input) use ($lesson) {
                 return $input['lesson_id'] === $lesson->id;
             });
 

--- a/app/Services/Lesson/SortLessonsService.php
+++ b/app/Services/Lesson/SortLessonsService.php
@@ -8,21 +8,21 @@ use Illuminate\Database\Eloquent\Collection;
 class SortLessonsService
 {
     /**
-     * @param  Collection<int, Lesson>  $lessons
-     * @param array<int, array{
-     *    lesson_id: int,
-     *    order: int
-     * }> $inputLessons
+     * レッスン並び替えサービス order値は、配列要素のインデックス値にする。１から始まる値にする。
      */
     public function __invoke(Collection $lessons, array $inputLessons): void
     {
         $inputLessonCollection = collect($inputLessons);
 
         $lessons->each(function (Lesson $lesson) use ($inputLessonCollection) {
-            $input = $inputLessonCollection->firstWhere('lesson_id', $lesson->id);
-            if ($input) {
+            // インデックスを取得
+            $index = $inputLessonCollection->search(function ($input) use ($lesson) {
+                return $input['lesson_id'] === $lesson->id;
+            });
+
+            if ($index !== false) {
                 $lesson->update([
-                    'order' => $input['order'],
+                    'order' => $index + 1,
                 ]);
             }
         });

--- a/app/Services/Lesson/SortLessonsService.php
+++ b/app/Services/Lesson/SortLessonsService.php
@@ -4,13 +4,13 @@ namespace App\Services\Lesson;
 
 use App\Model\Lesson;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 
 class SortLessonsService
 {
     /**
      * レッスン並び替えサービス order値は、配列要素のインデックスにする。１から始まる値にする。
-     * @param \Illuminate\Database\Eloquent\Collection<int, \App\Model\Lesson> $lessons
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection<int, \App\Model\Lesson>  $lessons
      */
     public function __invoke(Collection $lessons, array $inputLessons): void
     {

--- a/app/Services/Lesson/SortLessonsService.php
+++ b/app/Services/Lesson/SortLessonsService.php
@@ -10,16 +10,11 @@ class SortLessonsService
 {
     /**
      * レッスン並び替えサービス order値は、配列要素のインデックスにする。１から始まる値にする。
+     * @param \Illuminate\Database\Eloquent\Collection<int, \App\Model\Lesson> $lessons
      */
     public function __invoke(Collection $lessons, array $inputLessons): void
     {
-        $lessons->each(function (Model $model) use ($inputLessons) {
-            if (! $model instanceof Lesson) {
-                return;
-            }
-
-            $lesson = $model;
-
+        $lessons->each(function (Lesson $lesson) use ($inputLessons) {
             // lessons配列内における要素のインデックスを取得
             $index = array_search($lesson->id, $inputLessons, true);
 

--- a/tests/Feature/Api/Instructor/Lesson/SortTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/SortTest.php
@@ -88,4 +88,50 @@ class SortTest extends TestCase
             'lessons',
         ]);
     }
+
+    public function test_レッスン_i_dが不足している_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                5,
+                4,
+                3,
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'lessons' => 'all valid lessons not found for the specified chapter.',
+        ]);
+    }
+
+    public function test_余計なレッスン_i_dが含まれている_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                5,
+                4,
+                1,
+                3,
+                2,
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'lessons' => 'invalid lessons found for the specified chapter.',
+        ]);
+    }
 }

--- a/tests/Feature/Api/Instructor/Lesson/SortTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/SortTest.php
@@ -111,7 +111,7 @@ class SortTest extends TestCase
         ]);
     }
 
-    public function test_余計なレッスン_i_dが含まれている_失敗(): void
+    public function test_余計なレッスンが含まれている_失敗(): void
     {
         // arrange
         $instructor = Instructor::find(1);
@@ -132,6 +132,30 @@ class SortTest extends TestCase
         $response->assertStatus(422);
         $response->assertJsonValidationErrors([
             'lessons' => 'invalid lessons found for the specified chapter.',
+        ]);
+    }
+
+    public function test_レッスンが重複している_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                5,
+                4,
+                3,
+                2,
+                5, // 重複
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'lessons' => 'duplicate lessons found.',
         ]);
     }
 }

--- a/tests/Feature/Api/Instructor/Lesson/SortTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/SortTest.php
@@ -27,10 +27,10 @@ class SortTest extends TestCase
         // act
         $response = $this->postJson('/api/v1/instructor/course/1/chapter/2/lesson/sort', [
             'lessons' => [
-                ['lesson_id' => 5, 'order' => 1],
-                ['lesson_id' => 4, 'order' => 2],
-                ['lesson_id' => 3, 'order' => 3],
-                ['lesson_id' => 2, 'order' => 4],
+                5,
+                4,
+                3,
+                2,
             ],
         ]);
 
@@ -57,10 +57,10 @@ class SortTest extends TestCase
         // act
         $response = $this->postJson('/api/v1/instructor/course/1/chapter/2/lesson/sort', [
             'lessons' => [
-                ['lesson_id' => 5, 'order' => 1],
-                ['lesson_id' => 4, 'order' => 2],
-                ['lesson_id' => 3, 'order' => 3],
-                ['lesson_id' => 2, 'order' => 4],
+                5,
+                4,
+                3,
+                2,
             ],
         ]);
 

--- a/tests/Feature/Api/Manager/Lesson/SortTest.php
+++ b/tests/Feature/Api/Manager/Lesson/SortTest.php
@@ -111,4 +111,50 @@ class SortTest extends TestCase
             'lessons',
         ]);
     }
+
+    public function test_レッスン_i_dが不足している_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                5,
+                4,
+                3,
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'lessons' => 'all valid lessons not found for the specified chapter.',
+        ]);
+    }
+
+    public function test_余計なレッスン_i_dが含まれている_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                5,
+                4,
+                1,
+                3,
+                2,
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'lessons' => 'invalid lessons found for the specified chapter.',
+        ]);
+    }
 }

--- a/tests/Feature/Api/Manager/Lesson/SortTest.php
+++ b/tests/Feature/Api/Manager/Lesson/SortTest.php
@@ -112,7 +112,7 @@ class SortTest extends TestCase
         ]);
     }
 
-    public function test_レッスン_i_dが不足している_失敗(): void
+    public function test_レッスンが不足している_失敗(): void
     {
         // arrange
         $instructor = Instructor::find(1);
@@ -134,7 +134,7 @@ class SortTest extends TestCase
         ]);
     }
 
-    public function test_余計なレッスン_i_dが含まれている_失敗(): void
+    public function test_余計なレッスンが含まれている_失敗(): void
     {
         // arrange
         $instructor = Instructor::find(1);
@@ -155,6 +155,30 @@ class SortTest extends TestCase
         $response->assertStatus(422);
         $response->assertJsonValidationErrors([
             'lessons' => 'invalid lessons found for the specified chapter.',
+        ]);
+    }
+
+    public function test_レッスンが重複している_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
+            'lessons' => [
+                5,
+                4,
+                3,
+                2,
+                5, // 重複
+            ],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'lessons' => 'duplicate lessons found.',
         ]);
     }
 }

--- a/tests/Feature/Api/Manager/Lesson/SortTest.php
+++ b/tests/Feature/Api/Manager/Lesson/SortTest.php
@@ -27,10 +27,10 @@ class SortTest extends TestCase
         // act
         $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
             'lessons' => [
-                ['lesson_id' => 5, 'order' => 1],
-                ['lesson_id' => 4, 'order' => 2],
-                ['lesson_id' => 3, 'order' => 3],
-                ['lesson_id' => 2, 'order' => 4],
+                5,
+                4,
+                3,
+                2,
             ],
         ]);
 
@@ -57,10 +57,10 @@ class SortTest extends TestCase
         // act
         $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
             'lessons' => [
-                ['lesson_id' => 5, 'order' => 1],
-                ['lesson_id' => 4, 'order' => 2],
-                ['lesson_id' => 3, 'order' => 3],
-                ['lesson_id' => 2, 'order' => 4],
+                5,
+                4,
+                3,
+                2,
             ],
         ]);
 
@@ -80,10 +80,10 @@ class SortTest extends TestCase
         // act
         $response = $this->postJson('/api/v1/manager/course/1/chapter/2/lesson/sort', [
             'lessons' => [
-                ['lesson_id' => 5, 'order' => 1],
-                ['lesson_id' => 4, 'order' => 2],
-                ['lesson_id' => 3, 'order' => 3],
-                ['lesson_id' => 2, 'order' => 4],
+                5,
+                4,
+                3,
+                2,
             ],
         ]);
 


### PR DESCRIPTION
## issue
JKA-1464 レッスン並び替え機能のデータ整合性を向上

## 実装内容
１）レッスン並び替えサービスlaravelapp/app/Services/Lesson/SortLessonsService.phpを変更。
　・データベースのorder値は、リクエストされたlesson_idの配列インデックス値で更新するように変更。1から連番を振るように変更。
　・下図each()のクロージャ内で、　function(Lesson $lesson)としたところ、composer analyzeでエラーが生じた。このため、アノテーションを記述
```
@param \Illuminate\Database\Eloquent\Collection<int, \App\Model\Lesson> $lessons
```

２）リクエストファイル
/laravelapp/app/Http/Requests/Instructor/Lesson/SortRequest.php
/laravelapp/app/Http/Requests/Instructor/Lesson/SortRequest.php
を変更。
・"lessons"は、数値の配列になったので、lessons.*.lesson_id, lessons.*.orderは削除。lesson配列内の数値の確認lesson.*にした。
・リクエストされたレッスンは、対象チャプターのすべてのレッスン（論理削除されてないもの）を含むか確認するバリデーションwithValidator()を追加。

３）コントローラー
laravelapp/app/Http/Controllers/Api/Instructor/LessonController.php
laravelapp/app/Http/Controllers/Api/Manager/LessonController.phpを変更。
・order値は、配列のインデックスでつけるようにした。これによりリクエストデータは、下記のように、"lessons"は数値のみの配列になった。よってコントローラーもこの配列を取り扱うように変更。$inuptLessonsが単なる数値の配列になるので、従来あったarray_column()は削除した。

```
{
  "course_id": 1,
  "chapter_id": 2,
  "lessons": [
    5,
    4,
    3,
    2
  ]
}
```

## postomanによる動作確認
（１）instructor_id=1でログイン。
このユーザは、lessonsテーブルid=2,3,4,5を所有している。
これらlessonの並び替えを試みた。
（２）lessonsテーブルの初期状態は下記だった。
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/d5694e66-9234-4b3f-813a-0dfef4021dfe" />
（３）下図のようにリクエスト。
<img width="531" alt="image" src="https://github.com/user-attachments/assets/2b4f06a0-e7bd-4c1d-b887-9a472860a8c8" />

id=2,3,4,5のorder値は初め、それぞれ1,2,3,4,だった。しかしこれが4,3,2,1に変更された。
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/257be516-a36f-4e8a-a07e-cae3c99c8f85" />
（４）追加バリデーションの確認
前記lesson id=2,3,4,5は、チャプターid=2に属する。　リクエストするレッスンをid=2,3,4に減らしたところ、下図の結果。追加で記述したバリデーションのエラーメッセージが表示。テーブルも更新されず。
<img width="525" alt="image" src="https://github.com/user-attachments/assets/b2320d60-31b4-4db6-8dbb-3ef0a84dcdb3" />
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/4213528a-138f-49ae-9b8b-f9bac8a5df31" />

## PHP UnitTest
テストはpassした。
![image](https://github.com/user-attachments/assets/7dc9c554-b597-4bac-a51d-5a633effd674)

