### PR TITLE
JKA-1460 NotificationControllerのdeleteメソッドをサービスクラス作成などで共通化（街）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -166,7 +166,7 @@ class NotificationController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
 
         if (
-            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructorId)
+            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
@@ -223,7 +223,7 @@ class NotificationController extends Controller
 
         // 講師と一致しないお知らせが含まれている場合はエラー
         if (
-            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructor->id)
+            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructor->id)
         ) {
             // 講師と一致しないお知らせが含まれている場合はエラー
             throw new AuthorizationException('Invalid instructor_id.');
@@ -268,7 +268,7 @@ class NotificationController extends Controller
 
         // 選択されたお知らせの中に、講師と一致しないお知らせが、１つでも含まれている場合はエラー
         if (
-            $chosenNotifications->contains(fn($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
+            $chosenNotifications->contains(fn ($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -135,16 +135,11 @@ class NotificationController extends Controller
      */
     public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {
-        // 認証している講師のIDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
         // 指定されたお知らせを取得
         $notification = Notification::findOrFail($request->notification_id);
 
-        // お知らせが、現在ログインしている講師のものでなければエラー
-        if ($instructorId !== $notification->instructor_id) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        // policyによる認可チェック
+        $this->authorize('delete', $notification);
 
         DB::beginTransaction();
         try {
@@ -171,7 +166,7 @@ class NotificationController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
 
         if (
-            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
+            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }
@@ -228,7 +223,7 @@ class NotificationController extends Controller
 
         // 講師と一致しないお知らせが含まれている場合はエラー
         if (
-            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructor->id)
+            $notifications->contains(fn(Notification $notification) => $notification->instructor_id !== $instructor->id)
         ) {
             // 講師と一致しないお知らせが含まれている場合はエラー
             throw new AuthorizationException('Invalid instructor_id.');
@@ -273,7 +268,7 @@ class NotificationController extends Controller
 
         // 選択されたお知らせの中に、講師と一致しないお知らせが、１つでも含まれている場合はエラー
         if (
-            $chosenNotifications->contains(fn ($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
+            $chosenNotifications->contains(fn($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
         ) {
             throw new AuthorizationException('Invalid instructor_id.');
         }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -164,21 +164,11 @@ class NotificationController extends Controller
      */
     public function delete(DeleteRequest $request, DeleteService $service): JsonResponse
     {
-        // 認証している講師のIDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // 配下の講師情報を取得
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
         // 指定されたお知らせを取得
         $notification = Notification::findOrFail($request->notification_id);
 
-        // アクセス権限のチェック
-        if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        // policyによる認可チェック
+        $this->authorize('delete', $notification);
 
         DB::beginTransaction();
         try {

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -23,4 +23,18 @@ class NotificationPolicy
         // マネージャー権限のない講師の場合は自分のレッスンのみ更新可能
         return $notification->instructor_id === $instructor->id;
     }
+
+    public function delete(Instructor $instructor, Notification $notification): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($notification->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $instructor->id === $notification->instructor_id;
+    }
 }

--- a/tests/Feature/Api/Instructor/Notification/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Notification/DeleteTest.php
@@ -51,7 +51,7 @@ class DeleteTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Notification/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Notification/DeleteTest.php
@@ -51,7 +51,7 @@ class DeleteTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 


### PR DESCRIPTION
## issue
JKA-1460 NotificationControllerのdeleteメソッドをサービスクラス作成などで共通化

## 実装内容
１）laravelapp/app/Policies/NotificationPolicy.phpに、delete()メソッドを追加。
　　instructorかmanagerか判定。ログインユーザのidが、お知らせのinstructor_idに一致するかを確認させる。

２）laravelapp/app/Http/Controllers/Api/Instructor/NotificationController.phpのログインユーザの認可をpolicyで書き換え。

３）laravelapp/app/Http/Controllers/Api/Manager/NotificationController.phpのログインユーザの認可をpolicyで書き換え。

※laravelapp/tests/Feature/Api/Instructor/Notification/DeleteTest.phpの、「test_権限がない講師_失敗」について、エラーmessageを'This action is unauthorized.'に変更。　
理由は、PHP UnitTestでエラーが出たため。　message変更しろと言われた。

## 動作確認
### postman
（１）インストラクター
リクエスト：自分所有のお知らせ削除
```
http://localhost:8080/api/v1/instructor/notification/2
{
  "notification_id": 2
}
```
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/14553682-70ca-4ae9-91fc-eb27ed460be4" />

（２）マネージャー
リクエスト１：自分所有のお知らせ削除
```
http://localhost:8080/api/v1/instructor/notification/1
{
  "notification_id": 1
}
```
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/41b83b38-ea53-43cf-9f1d-6ee36dcff486" />

リクエスト２：配下の講師お知らせ削除
```
http://localhost:8080/api/v1/instructor/notification/2
{
  "notification_id": 2
}
```
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/b8b57b1d-639a-431a-8328-3fee4b851429" />


### composer analyze
![image](https://github.com/user-attachments/assets/cb14fc4f-0c51-4033-94ed-ff6435439cc4)

### PHP UnitTest
![image](https://github.com/user-attachments/assets/d5652e50-41be-434f-9dfd-8998f1050287)

### composer rector
![image](https://github.com/user-attachments/assets/25c6cc6e-409a-4672-883c-ac9a1391106c)