### PR TITLE
【jka-776子課題】jka-1484 notificationController：readメソッド修正 (芦野)

### DIFF
--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -66,7 +66,7 @@ class NotificationController extends Controller
         $courseIds = $attendances->pluck('course_id')->toArray();
         $currentDateTime = CarbonImmutable::now();
 
-        return Notification::with('students', 'course')
+        return Notification::with(['students', 'course'])
             ->whereIn('course_id', $courseIds)
             ->where('start_date', '<=', $currentDateTime)
             ->where('end_date', '>=', $currentDateTime)

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -66,7 +66,7 @@ class NotificationController extends Controller
         $courseIds = $attendances->pluck('course_id')->toArray();
         $currentDateTime = CarbonImmutable::now();
 
-        return Notification::with('students')
+        return Notification::with('students', 'course')
             ->whereIn('course_id', $courseIds)
             ->where('start_date', '<=', $currentDateTime)
             ->where('end_date', '>=', $currentDateTime)


### PR DESCRIPTION
## Issue
- jka-1484：NotificationController：readメソッド 修正  
※jka-776 子課題：React 受講生側 お知らせ表示機能

---

## 修正内容
下記内容を修正
#### 修正前
```
return Notification::with('students')
```
#### 修正後
```
return Notification::with('students', 'course')
```

## テスト
postmanでテスト実施
#### 修正前
・500エラー

#### 修正後
・200　OK
・レスポンス
{
    "data": [
        {
            "notification_id": 1,
            "course_id": 1,
            "course_title": "PHP入門講座",
            "title": "レッスン「変数とは？」閲覧について",
            "content": "10月1日〜10日の間、レッスン「変数とは？」がメンテナンスにつき閲覧できなくなります。",
            "type": "always"
        }
    ]