### PR TITLE
JKA-1482 講師/マネージャー 受講状況削除APIへのPolicyパターンを用いた認可機能の実装（街）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -157,7 +157,7 @@ class AttendanceController extends Controller
             Attendance::PERIOD_WEEK => $nowDate->copy()->subWeek(),
             Attendance::PERIOD_MONTH => $nowDate->copy()->subMonth(),
             Attendance::PERIOD_YEAR => $nowDate->copy()->subYear(),
-            default => throw new Exception('Invalid period. [' . $request->period . ']'),
+            default => throw new Exception('Invalid period. ['.$request->period.']'),
         };
 
         $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
@@ -199,7 +199,7 @@ class AttendanceController extends Controller
         $period = $request->period;
 
         // 指定期間内に完了したレッスンの個数を取得
-        $completedLessonsCount = $attendances->flatMap(fn(Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
+        $completedLessonsCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
             if ($period === LessonAttendance::PERIOD_TODAY) {
                 $updatedAtRequestPeriod = $lessonAttendance->updated_at->isToday();
             } elseif ($period === LessonAttendance::PERIOD_MONTH) {
@@ -212,7 +212,7 @@ class AttendanceController extends Controller
         }))->count();
 
         // 指定期間内に完了したチャプターの個数を取得
-        $completedChaptersCount = $attendances->flatMap(fn(Attendance $attendance) => $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
+        $completedChaptersCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
             ->filter(function (LessonAttendance $lessonAttendance) use ($period) {
                 // チャプターに含まれているレッスンが全て完了されているかつ、最新のレッスンの完了済みステータスの更新日時が指定期間のもので絞り込む
                 $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
@@ -231,7 +231,7 @@ class AttendanceController extends Controller
 
                 return $updatedAtRequestPeriod && $totalLessonsCount === $completedLessonsCount;
             })
-            ->map(fn(LessonAttendance $lessonAttendance) =>
+            ->map(fn (LessonAttendance $lessonAttendance) =>
             // chapter_idとattendance_idをキーにもつ新しい配列を作成
             [
                 'chapter_id' => $lessonAttendance->lesson->chapter_id,

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -48,7 +48,8 @@ class AttendanceController extends Controller
 
         if (Attendance::where('course_id', $request->course_id)
             ->where('student_id', $request->student_id)
-            ->exists()) {
+            ->exists()
+        ) {
             // 受講状況が存在する場合はエラーを返す
             throw new AuthorizationException('Attendance record already exists.');
         }
@@ -117,14 +118,11 @@ class AttendanceController extends Controller
 
         try {
             $attendanceId = $request->route('attendance_id');
-            $attendance = Attendance::with('lessonAttendances')->findOrFail($attendanceId);
+            $attendance = Attendance::with('course.instructor')->findOrFail($attendanceId);
 
-            if (Auth::guard('instructor')->user()->id !== $attendance->course->instructor_id) {
-                throw new AuthorizationException(
-                    'Forbidden, invalid instructor_id.'
-                );
-            }
+            $this->authorize('delete', $attendance);
 
+            // 受講状況に紐づくレッスン受講状況を削除
             $attendance->delete();
 
             DB::commit();
@@ -134,7 +132,7 @@ class AttendanceController extends Controller
             ]);
         } catch (Exception $e) {
             DB::rollBack();
-            Log::error($e);
+            Log::error($e->getMessage());
             throw $e;
         }
     }
@@ -159,7 +157,7 @@ class AttendanceController extends Controller
             Attendance::PERIOD_WEEK => $nowDate->copy()->subWeek(),
             Attendance::PERIOD_MONTH => $nowDate->copy()->subMonth(),
             Attendance::PERIOD_YEAR => $nowDate->copy()->subYear(),
-            default => throw new Exception('Invalid period. ['.$request->period.']'),
+            default => throw new Exception('Invalid period. [' . $request->period . ']'),
         };
 
         $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
@@ -201,7 +199,7 @@ class AttendanceController extends Controller
         $period = $request->period;
 
         // 指定期間内に完了したレッスンの個数を取得
-        $completedLessonsCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
+        $completedLessonsCount = $attendances->flatMap(fn(Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
             if ($period === LessonAttendance::PERIOD_TODAY) {
                 $updatedAtRequestPeriod = $lessonAttendance->updated_at->isToday();
             } elseif ($period === LessonAttendance::PERIOD_MONTH) {
@@ -214,7 +212,7 @@ class AttendanceController extends Controller
         }))->count();
 
         // 指定期間内に完了したチャプターの個数を取得
-        $completedChaptersCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
+        $completedChaptersCount = $attendances->flatMap(fn(Attendance $attendance) => $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
             ->filter(function (LessonAttendance $lessonAttendance) use ($period) {
                 // チャプターに含まれているレッスンが全て完了されているかつ、最新のレッスンの完了済みステータスの更新日時が指定期間のもので絞り込む
                 $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
@@ -233,12 +231,12 @@ class AttendanceController extends Controller
 
                 return $updatedAtRequestPeriod && $totalLessonsCount === $completedLessonsCount;
             })
-            ->map(fn (LessonAttendance $lessonAttendance) =>
-                // chapter_idとattendance_idをキーにもつ新しい配列を作成
-                [
-                    'chapter_id' => $lessonAttendance->lesson->chapter_id,
-                    'attendance_id' => $lessonAttendance->attendance_id,
-                ])
+            ->map(fn(LessonAttendance $lessonAttendance) =>
+            // chapter_idとattendance_idをキーにもつ新しい配列を作成
+            [
+                'chapter_id' => $lessonAttendance->lesson->chapter_id,
+                'attendance_id' => $lessonAttendance->attendance_id,
+            ])
             ->unique()
             ->count();
 

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -190,7 +190,7 @@ class AttendanceController extends Controller
             Attendance::PERIOD_WEEK => $nowDate->copy()->subWeek(),
             Attendance::PERIOD_MONTH => $nowDate->copy()->subMonth(),
             Attendance::PERIOD_YEAR => $nowDate->copy()->subYear(),
-            default => throw new Exception('Invalid period. [' . $request->period . ']'),
+            default => throw new Exception('Invalid period. ['.$request->period.']'),
         };
 
         $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
@@ -240,7 +240,7 @@ class AttendanceController extends Controller
         $period = $request->period;
 
         // 完了したレッスンの数を取得
-        $completedLessonsCount = $attendances->flatMap(fn(Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
+        $completedLessonsCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
             $updatedAtRequestPeriod = match ($period) {
                 LessonAttendance::PERIOD_TODAY => $lessonAttendance->updated_at->isToday(),
                 LessonAttendance::PERIOD_MONTH => $lessonAttendance->updated_at->isCurrentMonth(),
@@ -251,7 +251,7 @@ class AttendanceController extends Controller
         }))->count();
 
         // 完了したチャプターの数を取得
-        $completedChaptersCount = $attendances->flatMap(fn(Attendance $attendance) =>
+        $completedChaptersCount = $attendances->flatMap(fn (Attendance $attendance) =>
         // 各出席情報に関連するレッスン出席情報をフィルタリング
         $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
             ->filter(function (LessonAttendance $lessonAttendance) use ($period) {
@@ -274,7 +274,7 @@ class AttendanceController extends Controller
                 // チャプター内の全レッスンが完了しているかつ、指定期間内に更新されているかをチェック
                 return $updatedAtRequestPeriod && ($totalLessonsCount === $completedLessonsCount);
             })
-            ->map(fn(LessonAttendance $lessonAttendance) =>
+            ->map(fn (LessonAttendance $lessonAttendance) =>
             // chapter_idとattendance_idをキーにもつ新しい配列を作成
             [
                 'chapter_id' => $lessonAttendance->lesson->chapter_id,

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -142,26 +142,14 @@ class AttendanceController extends Controller
     {
         DB::beginTransaction();
 
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
         try {
-            $attendanceId = $request->attendance_id;
+            $attendanceId = $request->route('attendance_id');
+            $attendance = Attendance::with('course.instructor')->findOrFail($attendanceId);
 
-            // ログインしている講師、またはそのマネージャーが管理する受講データのIDのリストを取得
-            $managedAttendances = Attendance::whereIn('course_id', $instructorIds)->pluck('id')->toArray();
+            $this->authorize('delete', $attendance);
 
-            if (! in_array((int) $attendanceId, $managedAttendances, true)) {
-                // ログインしている講師、またはそのマネージャーが管理する受講データでない場合はエラーを返す
-                throw new AuthorizationException('Forbidden.');
-            }
-
-            // 受講状況を削除
-            Attendance::findOrFail($attendanceId)->delete();
+            // 受講状況に紐づくレッスン受講状況を削除
+            $attendance->delete();
 
             DB::commit();
 
@@ -202,7 +190,7 @@ class AttendanceController extends Controller
             Attendance::PERIOD_WEEK => $nowDate->copy()->subWeek(),
             Attendance::PERIOD_MONTH => $nowDate->copy()->subMonth(),
             Attendance::PERIOD_YEAR => $nowDate->copy()->subYear(),
-            default => throw new Exception('Invalid period. ['.$request->period.']'),
+            default => throw new Exception('Invalid period. [' . $request->period . ']'),
         };
 
         $attendances = Attendance::with('student')->where('course_id', $request->course_id)->get();
@@ -252,7 +240,7 @@ class AttendanceController extends Controller
         $period = $request->period;
 
         // 完了したレッスンの数を取得
-        $completedLessonsCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
+        $completedLessonsCount = $attendances->flatMap(fn(Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
             $updatedAtRequestPeriod = match ($period) {
                 LessonAttendance::PERIOD_TODAY => $lessonAttendance->updated_at->isToday(),
                 LessonAttendance::PERIOD_MONTH => $lessonAttendance->updated_at->isCurrentMonth(),
@@ -263,9 +251,9 @@ class AttendanceController extends Controller
         }))->count();
 
         // 完了したチャプターの数を取得
-        $completedChaptersCount = $attendances->flatMap(fn (Attendance $attendance) =>
-            // 各出席情報に関連するレッスン出席情報をフィルタリング
-            $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
+        $completedChaptersCount = $attendances->flatMap(fn(Attendance $attendance) =>
+        // 各出席情報に関連するレッスン出席情報をフィルタリング
+        $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
             ->filter(function (LessonAttendance $lessonAttendance) use ($period) {
                 // チャプターに含まれているすべてのレッスンIDを取得
                 $allLessonsId = $lessonAttendance->lesson->chapter->lessons->pluck('id');
@@ -286,12 +274,12 @@ class AttendanceController extends Controller
                 // チャプター内の全レッスンが完了しているかつ、指定期間内に更新されているかをチェック
                 return $updatedAtRequestPeriod && ($totalLessonsCount === $completedLessonsCount);
             })
-            ->map(fn (LessonAttendance $lessonAttendance) =>
-                // chapter_idとattendance_idをキーにもつ新しい配列を作成
-                [
-                    'chapter_id' => $lessonAttendance->lesson->chapter_id,
-                    'attendance_id' => $lessonAttendance->attendance_id,
-                ])
+            ->map(fn(LessonAttendance $lessonAttendance) =>
+            // chapter_idとattendance_idをキーにもつ新しい配列を作成
+            [
+                'chapter_id' => $lessonAttendance->lesson->chapter_id,
+                'attendance_id' => $lessonAttendance->attendance_id,
+            ])
             ->unique() // 重複するチャプターと出席情報の組み合わせを削除
             ->count();
 

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Instructor;
+use App\Model\Attendance;
+
+class AttendancePolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function delete(Instructor $instructor, Attendance $attendance): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($attendance->course->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $instructor->id === $attendance->course->instructor_id;
+    }
+}

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -2,8 +2,8 @@
 
 namespace App\Policies;
 
-use App\Model\Instructor;
 use App\Model\Attendance;
+use App\Model\Instructor;
 
 class AttendancePolicy
 {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -12,6 +12,8 @@ use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
 use App\Policies\NotificationPolicy;
 use App\Policies\TagPolicy;
+use App\Policies\AttendancePolicy;
+use App\Model\Attendance;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -27,6 +29,7 @@ class AuthServiceProvider extends ServiceProvider
         Lesson::class => LessonPolicy::class,
         Notification::class => NotificationPolicy::class,
         Tag::class => TagPolicy::class,
+        Attendance::class => AttendancePolicy::class,
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,18 +2,18 @@
 
 namespace App\Providers;
 
+use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Notification;
 use App\Model\Tag;
+use App\Policies\AttendancePolicy;
 use App\Policies\ChapterPolicy;
 use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
 use App\Policies\NotificationPolicy;
 use App\Policies\TagPolicy;
-use App\Policies\AttendancePolicy;
-use App\Model\Attendance;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/tests/Feature/Api/Instructor/Attendance/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/DeleteTest.php
@@ -58,7 +58,7 @@ class DeleteTest extends TestCase
     public function test_バリデーションエラー(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act

--- a/tests/Feature/Api/Manager/Attendance/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Attendance/DeleteTest.php
@@ -21,11 +21,11 @@ class DeleteTest extends TestCase
     public function test_受講削除_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(2);
+        $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->deleteJson('/api/v1/instructor/attendance/3');
+        $response = $this->deleteJson('/api/v1/instructor/attendance/1');
 
         // assert
         $response->assertStatus(200);
@@ -35,7 +35,10 @@ class DeleteTest extends TestCase
 
         // 論理削除されているか確認
         $this->assertSoftDeleted('attendances', [
-            'id' => 3,
+            'id' => 1,
+        ]);
+        $this->assertSoftDeleted('lesson_attendances', [
+            'attendance_id' => 1,
         ]);
     }
 
@@ -46,7 +49,7 @@ class DeleteTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->deleteJson('/api/v1/instructor/attendance/2');
+        $response = $this->deleteJson('/api/v1/instructor/attendance/1');
 
         // assert
         $response->assertStatus(403);

--- a/tests/Feature/Api/Manager/Attendance/DeleteTest.php
+++ b/tests/Feature/Api/Manager/Attendance/DeleteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api\Instructor\Attendance;
+namespace Tests\Feature\Api\Manager\Attendance;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
## postmanによる動作確認
（１）インストラクター
・自分の受講状況削除
<img width="524" height="348" alt="image" src="https://github.com/user-attachments/assets/a7b66e58-8aee-46a7-8db2-c63b308abe4b" />

・マネージャー権限で削除を試みる
<img width="527" height="339" alt="image" src="https://github.com/user-attachments/assets/9a0bb950-2a7d-43b6-b3b0-c792a554a2e3" />

・自分(id=4)以外の受講状況(id=3)削除
<img width="523" height="314" alt="image" src="https://github.com/user-attachments/assets/67ab9f6b-2124-4f7b-ae6a-50c487f2f79a" />

（２）マネージャー

・自分の受講状況削除
<img width="539" height="335" alt="image" src="https://github.com/user-attachments/assets/27042c10-4d05-4da3-b3fe-5d543c59a0ae" />

・配下の講師id=2の受講状況削除
<img width="530" height="340" alt="image" src="https://github.com/user-attachments/assets/97ceea53-1cf1-41b0-9acf-b1aafd493e8d" />

## PHP UnitTest
<img width="798" height="618" alt="image" src="https://github.com/user-attachments/assets/3377d222-3dba-4f80-a555-e0515d0b3762" />
