### PR TITLE
講師Notification Type 変更のAPIをマネジャー側の形式に統一

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -301,7 +301,7 @@ class NotificationController extends Controller
         $notifications = Notification::where('instructor_id', $instructorId)->get(['id', 'instructor_id', 'status']);
 
         // 講師と一致しないお知らせが含まれている場合はエラー
-        $this->authorize('putStatusAll', [Notification::class, $notifications]);
+        $this->authorize('bulkUpdate', [Notification::class, $notifications]);
 
         $service($status, $notifications);
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -203,7 +203,7 @@ class NotificationController extends Controller
     /**
      * 該当講師お知らせ一覧タイプ　一括変更
      */
-    public function updateTypeAll(NotificationUpdateTypeRequest $request): JsonResponse
+    public function updateTypeAll(UpdateTypeRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -301,7 +301,7 @@ class NotificationController extends Controller
         $notifications = Notification::where('instructor_id', $instructorId)->get(['id', 'instructor_id', 'status']);
 
         // 講師と一致しないお知らせが含まれている場合はエラー
-        $this->authorize('bulkUpdate', [Notification::class, $notifications]);
+        $this->authorize('putStatusAll', [Notification::class, $notifications]);
 
         $service($status, $notifications);
 

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
@@ -21,9 +21,11 @@ class UpdateTypeRequest extends FormRequest
     #[\Override]
     protected function prepareForValidation()
     {
-        $this->merge([
-            'notification_type' => $this->route('notification_type'),
-        ]);
+        if ($this->route('notification_type') !== null) {
+            $this->merge([
+                'notification_type' => $this->route('notification_type'),
+            ]);
+        }
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,7 +151,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
-                Route::prefix('type/{notification_type}')->group(function () {
+                Route::prefix('type')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
                     Route::put('all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
                 });


### PR DESCRIPTION
## 変更点
- 講師側updateTypeAllのRequestファイルの変更（Manager側の方になっていたため）。
- 講師側updateTypeのRequestファイルを変更
- apiの変更

※動作ok