### PR TITLE
 講師Notification Type 変更のAPIをマネジャー側の形式に統一

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -301,7 +301,7 @@ class NotificationController extends Controller
         $notifications = Notification::where('instructor_id', $instructorId)->get(['id', 'instructor_id', 'status']);
 
         // 講師と一致しないお知らせが含まれている場合はエラー
-        $this->authorize('putStatusAll', [Notification::class, $notifications]);
+        $this->authorize('bulkUpdate', [Notification::class, $notifications]);
 
         $service($status, $notifications);
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -203,7 +203,7 @@ class NotificationController extends Controller
     /**
      * 該当講師お知らせ一覧タイプ　一括変更
      */
-    public function updateTypeAll(NotificationUpdateTypeRequest $request): JsonResponse
+    public function updateTypeAll(UpdateTypeRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 
@@ -301,7 +301,7 @@ class NotificationController extends Controller
         $notifications = Notification::where('instructor_id', $instructorId)->get(['id', 'instructor_id', 'status']);
 
         // 講師と一致しないお知らせが含まれている場合はエラー
-        $this->authorize('bulkUpdate', [Notification::class, $notifications]);
+        $this->authorize('putStatusAll', [Notification::class, $notifications]);
 
         $service($status, $notifications);
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -13,8 +13,8 @@ use App\Http\Requests\Instructor\Notification\PutStatusAllRequest;
 use App\Http\Requests\Instructor\Notification\PutStatusRequest;
 use App\Http\Requests\Instructor\Notification\ShowRequest;
 use App\Http\Requests\Instructor\Notification\StoreRequest;
+use App\Http\Requests\Instructor\Notification\UpdateTypeAllRequest;
 use App\Http\Requests\Instructor\Notification\UpdateTypeRequest;
-use App\Http\Requests\Manager\Notification\UpdateTypeRequest as NotificationUpdateTypeRequest;
 use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Instructor\NotificationIndexResource;
 use App\Model\Course;
@@ -203,7 +203,7 @@ class NotificationController extends Controller
     /**
      * 該当講師お知らせ一覧タイプ　一括変更
      */
-    public function updateTypeAll(UpdateTypeRequest $request): JsonResponse
+    public function updateTypeAll(UpdateTypeAllRequest $request): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
 

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeAllRequest.php
@@ -16,14 +16,6 @@ class UpdateTypeAllRequest extends FormRequest
         return true;
     }
 
-    #[\Override]
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'notification_type' => $this->route('notification_type'),
-        ]);
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
@@ -27,7 +27,8 @@ class UpdateTypeRequest extends FormRequest
     {
         return [
             'notification_type' => ['required', Rule::enum(TypeEnum::class)],
-            'notifications.*' => ['integer', 'exists:notifications,id,deleted_at,NULL'],
+            'notifications' => ['required', 'array', 'min:1'],
+            'notifications.*' => ['integer', 'exists:notifications,id'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
@@ -21,9 +21,11 @@ class UpdateTypeRequest extends FormRequest
     #[\Override]
     protected function prepareForValidation()
     {
-        $this->merge([
-            'notification_type' => $this->route('notification_type'),
-        ]);
+        if ($this->route('notification_type') !== null) {
+            $this->merge([
+                'notification_type' => $this->route('notification_type'),
+            ]);
+        }
     }
 
     /**

--- a/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
+++ b/app/Http/Requests/Instructor/Notification/UpdateTypeRequest.php
@@ -18,16 +18,6 @@ class UpdateTypeRequest extends FormRequest
         return true;
     }
 
-    #[\Override]
-    protected function prepareForValidation()
-    {
-        if ($this->route('notification_type') !== null) {
-            $this->merge([
-                'notification_type' => $this->route('notification_type'),
-            ]);
-        }
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *

--- a/app/Http/Requests/Manager/Notification/UpdateTypeRequest.php
+++ b/app/Http/Requests/Manager/Notification/UpdateTypeRequest.php
@@ -18,14 +18,6 @@ class UpdateTypeRequest extends FormRequest
         return true;
     }
 
-    #[\Override]
-    protected function prepareForValidation()
-    {
-        $this->merge([
-            'notification_type' => $this->route('notification_type'),
-        ]);
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *
@@ -35,7 +27,8 @@ class UpdateTypeRequest extends FormRequest
     {
         return [
             'notification_type' => ['required',  Rule::enum(TypeEnum::class)],
-            'notifications.*' => ['integer', 'exists:notifications,id,deleted_at,NULL'],
+            'notifications' => ['required', 'array', 'min:1'],
+            'notifications.*' => ['integer', 'exists:notifications,id'],
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,7 +151,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-お知らせ
             Route::prefix('notification')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'index']);
-                Route::prefix('type/{notification_type}')->group(function () {
+                Route::prefix('type')->group(function () {
                     Route::put('/', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateType']);
                     Route::put('all', [App\Http\Controllers\Api\Instructor\NotificationController::class, 'updateTypeAll']);
                 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -267,7 +267,10 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 // マネージャー-お知らせ
                 Route::prefix('notification')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\NotificationController::class, 'index']);
-                    Route::put('type/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateTypeAll']);
+                    Route::prefix('type')->group(function () {
+                        Route::put('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
+                        Route::put('all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateTypeAll']);
+                    });
                     Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::put('status/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'putStatusAll']);
                     Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);

--- a/tests/Feature/Api/Instructor/Notification/UpdateTypeTest.php
+++ b/tests/Feature/Api/Instructor/Notification/UpdateTypeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateTypeTest extends TestCase
+{
+    // データベース初期化
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $notificationType = 'once';
+        $response = $this->putJson('/api/v1/instructor/notification/type', [
+            'notification_type' => $notificationType,
+            'notifications' => [2],
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('notifications', [
+            'id' => 2,
+            'type' => 'once',
+        ]);
+    }
+
+    public function test_権限なし_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $notificationType = 'once';
+        $response = $this->putJson('/api/v1/instructor/notification/type', [
+            'notification_type' => $notificationType,
+            'notifications' => [1],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Invalid instructor_id.',
+        ]);
+    }
+
+    public function test_バリデーションエラー_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $notificationType = 'action';
+        $response = $this->putJson('/api/v1/instructor/notification/type', [
+            'notification_type' => $notificationType,
+            'notifications' => [],
+        ]);
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'notification_type' => 'The selected notification type is invalid.',
+            'notifications' => 'The notifications field is required.',
+        ]);
+    }
+}

--- a/tests/Feature/Api/Manager/Notification/UpdateTypeAllTest.php
+++ b/tests/Feature/Api/Manager/Notification/UpdateTypeAllTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api\Instructor\Notification;
+namespace Tests\Feature\Api\Manager\Notification;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -27,7 +27,7 @@ class UpdateTypeAllTest extends TestCase
 
         // act
         $notificationType = 'once';
-        $response = $this->putJson('/api/v1/instructor/notification/type/all', [
+        $response = $this->putJson('/api/v1/manager/notification/type/all', [
             'notification_type' => $notificationType,
         ]);
 
@@ -47,7 +47,7 @@ class UpdateTypeAllTest extends TestCase
 
         // act
         $notificationType = 'action';
-        $response = $this->putJson('/api/v1/instructor/notification/type/all', [
+        $response = $this->putJson('/api/v1/manager/notification/type/all', [
             'notification_type' => $notificationType,
         ]);
 
@@ -55,6 +55,25 @@ class UpdateTypeAllTest extends TestCase
         $response->assertStatus(422);
         $response->assertJson([
             'message' => 'The selected notification type is invalid.',
+        ]);
+    }
+
+    public function test_お知らせ登録_権限エラー(): void
+    {
+        // arrange
+        $unauthorizedInstructor = Instructor::find(2);
+        $this->actingAs($unauthorizedInstructor, 'instructor');
+
+        // act
+        $notificationType = 'once';
+        $response = $this->putJson('/api/v1/manager/notification/type/all', [
+            'notification_type' => $notificationType,
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
         ]);
     }
 }

--- a/tests/Feature/Api/Manager/Notification/UpdateTypeTest.php
+++ b/tests/Feature/Api/Manager/Notification/UpdateTypeTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Feature\Api\Instructor\Notification;
+namespace Tests\Feature\Api\Manager\Notification;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class UpdateTypeAllTest extends TestCase
+class UpdateTypeTest extends TestCase
 {
     // データベース初期化
     use RefreshDatabase;
@@ -27,15 +27,36 @@ class UpdateTypeAllTest extends TestCase
 
         // act
         $notificationType = 'once';
-        $response = $this->putJson('/api/v1/instructor/notification/type/all', [
+        $response = $this->putJson('/api/v1/manager/notification/type', [
             'notification_type' => $notificationType,
+            'notifications' => [1],
         ]);
 
         // assert
         $response->assertStatus(200);
         $this->assertDatabaseHas('notifications', [
-            'id' => 1,
+            'id' => 2,
             'type' => 'once',
+        ]);
+    }
+
+    public function test_権限なし_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $notificationType = 'once';
+        $response = $this->putJson('/api/v1/manager/notification/type', [
+            'notification_type' => $notificationType,
+            'notifications' => [3],
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Invalid instructor_id.',
         ]);
     }
 
@@ -47,14 +68,16 @@ class UpdateTypeAllTest extends TestCase
 
         // act
         $notificationType = 'action';
-        $response = $this->putJson('/api/v1/instructor/notification/type/all', [
+        $response = $this->putJson('/api/v1/manager/notification/type', [
             'notification_type' => $notificationType,
+            'notifications' => [],
         ]);
 
         // assert
         $response->assertStatus(422);
-        $response->assertJson([
-            'message' => 'The selected notification type is invalid.',
+        $response->assertJsonValidationErrors([
+            'notification_type' => 'The selected notification type is invalid.',
+            'notifications' => 'The notifications field is required.',
         ]);
     }
 }


### PR DESCRIPTION
## 変更点
- 講師側updateTypeAllのRequestファイルの変更（Manager側の方になっていたため）。
- 講師側updateTypeのRequestファイルを変更
- apiの変更

※動作ok