### PR TITLE
[JKA-1462] NotificationControllerのupdateTypeAllメソッドをサービスクラス作成で共通化

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -207,7 +207,7 @@ class NotificationController extends Controller
     public function updateTypeAll(UpdateTypeAllRequest $request, UpdateTypeAllService $notificationService): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $notificationService->updateNotificationType([$instructorId], $request->notification_type);//[$instructorId]→サービスクラスを共通に使いたいため、配列の形にする
+        $notificationService->updateNotificationType([$instructorId], $request->notification_type); //[$instructorId]→サービスクラスを共通に使いたいため、配列の形にする
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -207,7 +207,7 @@ class NotificationController extends Controller
     public function updateTypeAll(UpdateTypeAllRequest $request, UpdateTypeAllService $notificationService): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-        $notificationService->updateNotificationType([$instructorId], $request->notification_type);//[$instructorId]→サービスクラスを共通に使いたいため、配列の形にする
+        $notificationService->updateNotificationType([$instructorId], $request->notification_type);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -23,6 +23,7 @@ use App\Services\Notification\BulkDeleteService;
 use App\Services\Notification\DeleteService;
 use App\Services\Notification\PutNotificationService;
 use App\Services\Notification\PutStatusAllService;
+use App\Services\Notification\UpdateTypeAllService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -203,14 +204,10 @@ class NotificationController extends Controller
     /**
      * 該当講師お知らせ一覧タイプ　一括変更
      */
-    public function updateTypeAll(UpdateTypeAllRequest $request): JsonResponse
+    public function updateTypeAll(UpdateTypeAllRequest $request, UpdateTypeAllService $notificationService): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
-
-        Notification::where('instructor_id', $instructorId)
-            ->update([
-                'type' => $request->notification_type,
-            ]);
+        $notificationService->updateNotificationType([$instructorId], $request->notification_type);//[$instructorId]→サービスクラスを共通に使いたいため、配列の形にする
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -23,6 +23,7 @@ use App\Services\Notification\BulkDeleteService;
 use App\Services\Notification\DeleteService;
 use App\Services\Notification\PutNotificationService;
 use App\Services\Notification\PutStatusAllService;
+use App\Services\Notification\UpdateTypeAllService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -238,11 +239,9 @@ class NotificationController extends Controller
         }
     }
 
-    public function updateTypeAll(UpdateTypeAllRequest $request)
+    public function updateTypeAll(UpdateTypeAllRequest $request, UpdateTypeAllService $notificationService): JsonResponse
     {
-        $instructor = Auth::guard('instructor')->user();
-
-        $manager = Instructor::with('managings')->find($instructor->id);
+        $manager = Auth::guard('instructor')->user();
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
@@ -250,18 +249,11 @@ class NotificationController extends Controller
 
         $this->authorize('bulkUpdate', [Notification::class, $notifications]);
 
-        try {
-            Notification::whereIn('instructor_id', $instructorIds)->update([
-                'type' => $request->notification_type,
-            ]);
+        $notificationService->updateNotificationType($instructorIds, $request->notification_type);
 
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            Log::error($e);
-            throw $e;
-        }
+        return response()->json([
+            'result' => true,
+        ]);
     }
 
     /**

--- a/app/Services/Notification/UpdateTypeAllService.php
+++ b/app/Services/Notification/UpdateTypeAllService.php
@@ -7,7 +7,10 @@ use App\Model\Notification;
 class UpdateTypeAllService
 {
     /**
-     * 指定されたinstructorId配列に属する通知タイプを一括更新
+     * お知らせのタイプを一括更新するサービス
+     *
+     * @param  array<int>  $instructorIds
+     * @param  'always' | 'once'  $notificationType
      */
     public function updateNotificationType(array $instructorIds, string $notificationType): void
     {

--- a/app/Services/Notification/UpdateTypeAllService.php
+++ b/app/Services/Notification/UpdateTypeAllService.php
@@ -3,23 +3,16 @@
 namespace App\Services\Notification;
 
 use App\Model\Notification;
-use Illuminate\Support\Facades\Log;
 
 class UpdateTypeAllService
 {
     /**
      * 指定されたinstructorId配列に属する通知タイプを一括更新
      */
-    public function updateNotificationType(array $instructorIds, string $notificationType): bool
+    public function updateNotificationType(array $instructorIds, string $notificationType): void
     {
-        try {
-            Notification::whereIn('instructor_id', $instructorIds)->update([
-                'type' => $notificationType,
-            ]);
-            return true;
-        } catch (\Exception $e) {
-            Log::error('Notification update failed: ' . $e->getMessage());
-            throw $e;
-        }
+        Notification::whereIn('instructor_id', $instructorIds)->update([
+            'type' => $notificationType,
+        ]);
     }
 }

--- a/app/Services/Notification/UpdateTypeAllService.php
+++ b/app/Services/Notification/UpdateTypeAllService.php
@@ -16,9 +16,10 @@ class UpdateTypeAllService
             Notification::whereIn('instructor_id', $instructorIds)->update([
                 'type' => $notificationType,
             ]);
+
             return true;
         } catch (\Exception $e) {
-            Log::error('Notification update failed: ' . $e->getMessage());
+            Log::error('Notification update failed: '.$e->getMessage());
             throw $e;
         }
     }

--- a/app/Services/Notification/UpdateTypeAllService.php
+++ b/app/Services/Notification/UpdateTypeAllService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services\Notification;
+
+use App\Model\Notification;
+use Illuminate\Support\Facades\Log;
+
+class UpdateTypeAllService
+{
+    /**
+     * 指定されたinstructorId配列に属する通知タイプを一括更新
+     */
+    public function updateNotificationType(array $instructorIds, string $notificationType): bool
+    {
+        try {
+            Notification::whereIn('instructor_id', $instructorIds)->update([
+                'type' => $notificationType,
+            ]);
+            return true;
+        } catch (\Exception $e) {
+            Log::error('Notification update failed: ' . $e->getMessage());
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
- [$instructorId]→サービスクラスを共通に使いたいため、配列の形にして引数として渡す。そのためmaneger側と異なる。

ご確認お願いします。