### PR TITLE
JKA-1494 TagControllerのputメソッドをサービスクラス作成などで共通化（智美）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -16,6 +16,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use App\Services\Tag\UpdateTagService;
 
 /**
  * @tags Instructor-Tag
@@ -95,21 +96,15 @@ class TagController extends Controller
     /**
      * タグ更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, int $tag_id, UpdateTagService $service): JsonResponse
     {
-        $tag = Tag::findOrFail($request->tag_id);
-
-        // 配下のインストラクターまたは本人が作成したタグのみ更新可能
-        $this->authorize('update', $tag);
-
-        // タグの更新
-        $tag->update([
+        ($service)([
+            'tag_id' => $tag_id,
             'content' => $request->content,
+            'user' => $request->user(),
         ]);
 
-        return response()->json([
-            'result' => true,
-        ]);
+        return response()->json(['result' => true]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -12,11 +12,11 @@ use App\Http\Resources\Base\Instructor\TagResource;
 use App\Http\Resources\Instructor\TagIndexResource;
 use App\Model\Instructor;
 use App\Model\Tag;
+use App\Services\Tag\UpdateTagService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use App\Services\Tag\UpdateTagService;
 
 /**
  * @tags Instructor-Tag
@@ -103,10 +103,10 @@ class TagController extends Controller
         // 認可処理
         $this->authorize('update', $tag);
 
-        ($service)([
-            'tag_id' => $tag->id,
-            'content' => $request->content,
-        ]);
+        ($service)(
+            tag: $tag,
+            content: $request->content
+        );
 
         return response()->json(['result' => true]);
     }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -98,13 +98,13 @@ class TagController extends Controller
      */
     public function put(PutRequest $request, UpdateTagService $service): JsonResponse
     {
-        $tag = Tag::finorFail($request->tag_id;)
+        $tag = Tag::findOrFail($request->tag_id);
 
         // 認可処理
         $this->authorize('update', $tag);
 
         ($service)([
-            'tag_id' => $tag_id,
+            'tag_id' => $tag->id,
             'content' => $request->content,
         ]);
 

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -96,12 +96,16 @@ class TagController extends Controller
     /**
      * タグ更新API
      */
-    public function put(PutRequest $request, int $tag_id, UpdateTagService $service): JsonResponse
+    public function put(PutRequest $request, UpdateTagService $service): JsonResponse
     {
+        $tag = Tag::finorFail($request->tag_id;)
+
+        // 認可処理
+        $this->authorize('update', $tag);
+
         ($service)([
             'tag_id' => $tag_id,
             'content' => $request->content,
-            'user' => $request->user(),
         ]);
 
         return response()->json(['result' => true]);

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -16,6 +16,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use App\Services\Tag\UpdateTagService;
 
 /**
  * @tags Manager-Tag
@@ -69,22 +70,15 @@ class TagController extends Controller
     /**
      * タグ更新API
      */
-    public function put(PutRequest $request): JsonResponse
+    public function put(PutRequest $request, int $tag_id, UpdateTagService $service): JsonResponse
     {
-        // タグの取得
-        $tag = Tag::findOrFail($request->tag_id);
-
-        // 配下のインストラクターまたは本人が作成したタグのみ更新可能
-        $this->authorize('update', $tag);
-
-        // タグの更新
-        $tag->update([
+        ($service)([
+            'tag_id' => $tag_id,
             'content' => $request->content,
+            'user' => $request->user(),
         ]);
 
-        return response()->json([
-            'result' => true,
-        ]);
+        return response()->json(['result' => true]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -12,11 +12,11 @@ use App\Http\Resources\Manager\TagIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Tag;
+use App\Services\Tag\UpdateTagService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use App\Services\Tag\UpdateTagService;
 
 /**
  * @tags Manager-Tag
@@ -77,10 +77,10 @@ class TagController extends Controller
         // 認可処理
         $this->authorize('update', $tag);
 
-        ($service)([
-            'tag_id' => $tag->id,
-            'content' => $request->content,
-        ]);
+        ($service)(
+            tag: $tag,
+            content: $request->content
+        );
 
         return response()->json(['result' => true]);
     }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -70,12 +70,16 @@ class TagController extends Controller
     /**
      * タグ更新API
      */
-    public function put(PutRequest $request, int $tag_id, UpdateTagService $service): JsonResponse
+    public function put(PutRequest $request, UpdateTagService $service): JsonResponse
     {
+        $tag = Tag::finorFail($request->tag_id;)
+
+        // 認可処理
+        $this->authorize('update', $tag);
+
         ($service)([
             'tag_id' => $tag_id,
             'content' => $request->content,
-            'user' => $request->user(),
         ]);
 
         return response()->json(['result' => true]);

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -72,13 +72,13 @@ class TagController extends Controller
      */
     public function put(PutRequest $request, UpdateTagService $service): JsonResponse
     {
-        $tag = Tag::finorFail($request->tag_id;)
+        $tag = Tag::findOrFail($request->tag_id);
 
         // 認可処理
         $this->authorize('update', $tag);
 
         ($service)([
-            'tag_id' => $tag_id,
+            'tag_id' => $tag->id,
             'content' => $request->content,
         ]);
 

--- a/app/Services/Tag/UpdateTagService.php
+++ b/app/Services/Tag/UpdateTagService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Tag;
+
+use App\Model\Tag;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class UpdateTagService
+{
+    /**
+     * タグを更新する
+     *
+     * @param array{
+     *     tag_id: int,
+     *     content: string,
+     *     user: \App\Models\User
+     * } $params
+     * @return bool
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function __invoke(array $params): bool
+    {
+        $tag = Tag::findOrFail($params['tag_id']);
+
+        if (Gate::forUser($params['user'])->denies('update', $tag)) {
+            throw new AuthorizationException('This action is unauthorized.');
+        }
+
+        return $tag->update([
+            'content' => $params['content'],
+        ]);
+    }
+}

--- a/app/Services/Tag/UpdateTagService.php
+++ b/app/Services/Tag/UpdateTagService.php
@@ -3,8 +3,6 @@
 namespace App\Services\Tag;
 
 use App\Model\Tag;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Auth\Access\AuthorizationException;
 
 class UpdateTagService
 {
@@ -14,7 +12,6 @@ class UpdateTagService
      * @param array{
      *     tag_id: int,
      *     content: string,
-     *     user: \App\Models\User
      * } $params
      * @return bool
      *
@@ -24,10 +21,6 @@ class UpdateTagService
     public function __invoke(array $params): bool
     {
         $tag = Tag::findOrFail($params['tag_id']);
-
-        if (Gate::forUser($params['user'])->denies('update', $tag)) {
-            throw new AuthorizationException('This action is unauthorized.');
-        }
 
         return $tag->update([
             'content' => $params['content'],

--- a/app/Services/Tag/UpdateTagService.php
+++ b/app/Services/Tag/UpdateTagService.php
@@ -8,22 +8,11 @@ class UpdateTagService
 {
     /**
      * タグを更新する
-     *
-     * @param array{
-     *     tag_id: int,
-     *     content: string,
-     * } $params
-     * @return bool
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function __invoke(array $params): bool
+    public function __invoke(Tag $tag, string $content): void
     {
-        $tag = Tag::findOrFail($params['tag_id']);
-
-        return $tag->update([
-            'content' => $params['content'],
+        $tag->update([
+            'content' => $content,
         ]);
     }
 }


### PR DESCRIPTION
## Jira
- JKA-1494

## 概要
- TagControllerのputメソッドをサービスクラス作成などで共通化

## 動作確認手順
- 山田太郎でログイン
email：[test_instructor@example.com](mailto:test_instructor@example.com)
password：password

- Manager・Instructorともに更新されることを確認
- Instructor
<img width="1187" height="606" alt="スクリーンショット 2025-07-25 033601" src="https://github.com/user-attachments/assets/e410987e-0e43-4475-b362-6e2bdd5160d8" />

- Manager
<img width="1202" height="629" alt="スクリーンショット 2025-07-25 032847" src="https://github.com/user-attachments/assets/a5104c0c-bd7b-41d7-b6a9-e83e7450f5ba" />

## 確認してほしいこと
動作確認はしていますが、再度ご確認をお願いいたします。
また、不足している部分などありましたら、ご教授いただきたいです。
よろしくお願いいたします。
