### PR TITLE
ChapterControllerのstoreメソッドのPolicyパターンを用いた認可機能の実装(ちゃこ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -73,10 +73,7 @@ class ChapterController extends Controller
             /** @var Course $course */
             $course = Course::with('chapters')->findOrFail($request->input('course_id'));
 
-            if ($course->instructor_id !== $user->id) {
-                // 講座の作成者が現在の講師と一致しない場合はエラーを返す
-                throw new AuthorizationException('Invalid instructor_id for this course.');
-            }
+            $this->authorize('create', [Chapter::class, $course]);
 
             $chapter = $createChapterService(
                 course: $course,

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -75,17 +75,13 @@ class ChapterController extends Controller
         $managerId = Auth::guard('instructor')->user()->id;
 
         /** @var Instructor $manager */
+        // 認可ポリシー内で managings を使用するため、ここで読み込んでおく
         $manager = Instructor::with('managings')->find($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
 
         /** @var Course $course */
         $course = Course::FindOrFail($request->course_id);
 
-        if (! in_array($course->instructor_id, $instructorIds, true)) {
-            // 自分、または配下の講師の講座でなければエラー応答
-            throw new AuthorizationException('Forbidden, not allowed to create new chapter.');
-        }
+        $this->authorize('create', [\App\Model\Chapter::class, $course]);
 
         try {
             $chapter = $createChapterService(

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -71,17 +71,10 @@ class ChapterController extends Controller
      */
     public function store(StoreRequest $request, CreateChapterService $createChapterService): JsonResponse
     {
-        // ログイン中の講師IDを取得
-        $managerId = Auth::guard('instructor')->user()->id;
-
-        /** @var Instructor $manager */
-        // 認可ポリシー内で managings を使用するため、ここで読み込んでおく
-        $manager = Instructor::with('managings')->find($managerId);
-
         /** @var Course $course */
         $course = Course::FindOrFail($request->course_id);
 
-        $this->authorize('create', [\App\Model\Chapter::class, $course]);
+        $this->authorize('create', [Chapter::class, $course]);
 
         try {
             $chapter = $createChapterService(

--- a/app/Policies/ChapterPolicy.php
+++ b/app/Policies/ChapterPolicy.php
@@ -3,11 +3,27 @@
 namespace App\Policies;
 
 use App\Model\Chapter;
+use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Support\Collection;
 
 class ChapterPolicy
 {
+    /**
+     * チャプターの作成処理に関する認可処理
+     */
+    public function create(Instructor $instructor, Course $course): bool
+    {
+        if ($instructor->isManager()) {
+            $managerIds = $instructor->managings->pluck('id')->toArray();
+            $managerIds[] = $instructor->id;
+
+            return in_array($course->instructor_id, $managerIds, true);
+        }
+
+        return $instructor->id === $course->instructor_id;
+    }
+
     /**
      * チャプターの更新処理に関する認可処理
      */

--- a/tests/Feature/Api/Instructor/Chapter/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/StoreTest.php
@@ -55,7 +55,7 @@ class StoreTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Invalid instructor_id for this course.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Chapter/StoreTest.php
+++ b/tests/Feature/Api/Manager/Chapter/StoreTest.php
@@ -55,7 +55,7 @@ class StoreTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, not allowed to create new chapter.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 


### PR DESCRIPTION
## JIRA
- [jka-1504] ChapterControllerのstoreメソッドにポリシー認可処理を追加

## 概要
- ChapterController@store に対して、ChapterPolicy@create を使った認可処理を導入
- マネージャー／インストラクター両方のコントローラで共通の認可ロジックを使用
- 既存の if 文による認可判定を削除し、Policy に集約
- Instructor::with('managings') による eager load を用いて、Policy 内で managings を使用できるように調整
- 動作確認済：
正常系：自身または配下の講師のコースIDでチャプター作成 → result: trueレスポンス
バリデーションエラー：存在しないコースID → 422 Unprocessable Entity
認可チェック：他人のコースIDまたは配下以外の講師のコースIDでチャプター作成 → 403 Forbidden

## 動作確認手順
1. Managerユーザでログイン
ユーザ名：山田太郎
email：[test_instructor@example.com](mailto:test_instructor@example.com)
password：password


2. 自身または配下の講師のコースIDでチャプター作成ができるかを確認

POST  http://localhost:8080/api/v1/manager/course/1/chapter  （自身のコースID）
POST  http://localhost:8080/api/v1/manager/course/2/chapter （配下の講師のコースID）


<img width="901" height="765" alt="マネージャー本人のコースid" src="https://github.com/user-attachments/assets/e2eff5e4-3b65-4eb2-98fd-5d5dfc821e0d" />


<img width="903" height="767" alt="配下のコースid" src="https://github.com/user-attachments/assets/ef9ce0bd-48cb-4474-9ed6-981a421a2b7f" />



4. 配下に属さない講師のコースIDでチャプター作成ができるかを確認 → 更新不可（403）を確認


<img width="913" height="775" alt="配下でない講師のコースid" src="https://github.com/user-attachments/assets/a453a932-3c0b-436b-83aa-274524e9347f" />



5. Instructorユーザでログイン
ユーザ名：山本花子
email：[test_instructor2@example.com](mailto:test_instructor2@example.com)
password：password


6. 自身のコースIDでチャプター作成ができるかを確認

POST  http://localhost:8080/api/v1/instructor/course/2/chapter

<img width="913" height="774" alt="インストラクター自身のコースid" src="https://github.com/user-attachments/assets/5be1d866-36f6-4980-aec2-c703f8f65d64" />


7. 自身ではない講師のコースIDでチャプター作成ができるかを確認 → 更新不可（403）を確認


<img width="913" height="775" alt="配下でない講師のコースid" src="https://github.com/user-attachments/assets/a7f8e0d6-6f0d-494d-bee6-9414edf99b63" />


該当のスクランブル：
http://localhost:8080/docs/api#/operations/manager.chapter.store  (マネージャー側)
http://localhost:8080/docs/api#/operations/instructor.chapter.store  (インストラクター側)

## 考慮してほしいこと
- app/Http/Controllers/Api/Manager/ChapterController.phpにて、$manager 変数自体はコントローラ内で使用していませんが、managings を eager load させるために必要だと判断し、また他のコードとの統一性を考慮し、残しております。
ご指摘ございましたら、ご教示賜れますと幸いです。

## 確認してほしいこと
- 既存機能との整合性が取れているか（他メソッドとのコードスタイル含む）
- コードの構造が参考PRの内容に沿ったものになっているか
参考PR：https://github.com/yukihiroLaravel/juko_laravel/pull/1009/files