### PR TITLE
NotificationControllerのupdateTypeAllメソッドのPolicyパターンを用いた認可機能部分の修正(ちゃこ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -212,6 +212,11 @@ class NotificationController extends Controller
     public function updateTypeAll(UpdateTypeAllRequest $request, UpdateTypeAllService $service): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
+
+        $notifications = Notification::whereIn('instructor_id', [$instructorId])->get();
+
+        $this->authorize('bulkUpdate', [Notification::class, $notifications]);
+
         $service(
             instructorIds: [$instructorId],
             notificationType: $request->notification_type


### PR DESCRIPTION
## JIRA
- [jka-1507] お知らせ種別一括更新APIに認可機能を追加（Instructor側）

## 概要
- /api/v1/instructor/notification/type/all に対して bulkUpdate ポリシーを適用し、講師／管理者の権限に応じた一括更新制御を追加
Manager → 自分 + 配下インストラクターの通知が対象
Instructor → 自分の通知のみ対象
- マネージャー側は変更する箇所がないと判断したため、今回変更はしておりません。
- 動作確認済みです（マネージャー側、インストラクター側両方）


## 動作確認手順
1. Instructorユーザでログイン
ユーザ名：山本花子
email：[test_instructor2@example.com](mailto:test_instructor2@example.com)
password：password

2. 自分の通知が変更できるか確認

PUT http://localhost:8080/api/v1/instructor/notification/type/all

<img width="908" height="765" alt="スクリーンショット 2025-07-26 16 40 41" src="https://github.com/user-attachments/assets/e3c0d29d-fefa-438f-8cde-3c8e32a5e7e8" />


該当のスクランブル：
http://localhost:8080/docs/api#/operations/instructor.notification.updateTypeAll

## 考慮してほしいこと
- 

## 確認してほしいこと
- マネージャー側は変更する箇所がないと判断しましたが、問題なかったか
