### PR TITLE
AttendanceControllerのstoreメソッドのPolicyパターンを用いた認可機能の実装 (たつのり)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -30,17 +30,15 @@ use Illuminate\Support\Facades\Log;
  */
 class AttendanceController extends Controller
 {
+    /**
+     * 受講状況登録API
+     */
     public function store(StoreRequest $request): JsonResponse
 {
-    $attendance = new Attendance([
-        'course_id' => $request->course_id,
-        'student_id' => $request->student_id,
-    ]);
-
-    $attendance->setRelation('course', Course::findOrFail($request->course_id));
+     $course = Course::findOrFail($request->course_id);
 
     // Policyによる認可チェック
-    $this->authorize('create', $attendance);
+    $this->authorize('create', $course);
 
     if (Attendance::where('course_id', $request->course_id)
         ->where('student_id', $request->student_id)

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -34,49 +34,50 @@ class AttendanceController extends Controller
      * 受講状況登録API
      */
     public function store(StoreRequest $request): JsonResponse
-{
-     $course = Course::findOrFail($request->course_id);
+    {
+        $course = Course::findOrFail($request->course_id);
 
-    // Policyによる認可チェック
-    $this->authorize('create', $course);
+        // Policyによる認可チェック
+        $this->authorize('create', $course);
 
-    if (Attendance::where('course_id', $request->course_id)
-        ->where('student_id', $request->student_id)
-        ->exists()
-    ) {
-        throw new AuthorizationException(
-            'Attendance record already exists.'
-        );
-    }
-
-    DB::beginTransaction();
-    try {
-        $attendance = Attendance::create([
-            'course_id' => $request->course_id,
-            'student_id' => $request->student_id,
-        ]);
-
-        $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
-            $query->where('course_id', $request->course_id);
-        })->get();
-
-        foreach ($lessons as $lesson) {
-            LessonAttendance::create([
-                'attendance_id' => $attendance->id,
-                'lesson_id' => $lesson->id,
-                'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
-            ]);
+        if (Attendance::where('course_id', $request->course_id)
+            ->where('student_id', $request->student_id)
+            ->exists()
+        ) {
+            throw new AuthorizationException(
+                'Attendance record already exists.'
+            );
         }
 
-        DB::commit();
+        DB::beginTransaction();
+        try {
+            $attendance = Attendance::create([
+                'course_id' => $request->course_id,
+                'student_id' => $request->student_id,
+            ]);
 
-        return response()->json(['result' => true]);
-    } catch (Exception $e) {
-        DB::rollBack();
-        Log::error($e);
-        throw $e;
+            $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
+                $query->where('course_id', $request->course_id);
+            })->get();
+
+            foreach ($lessons as $lesson) {
+                LessonAttendance::create([
+                    'attendance_id' => $attendance->id,
+                    'lesson_id' => $lesson->id,
+                    'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+                ]);
+            }
+
+            DB::commit();
+
+            return response()->json(['result' => true]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
     }
-}
+
     /**
      * 受講状況取得API
      */

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -53,7 +53,10 @@ class AttendanceController extends Controller
 
     DB::beginTransaction();
     try {
-        $attendance->save();
+        $attendance = Attendance::create([
+            'course_id' => $request->course_id,
+            'student_id' => $request->student_id,
+        ]);
 
         $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
             $query->where('course_id', $request->course_id);

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -30,58 +30,52 @@ use Illuminate\Support\Facades\Log;
  */
 class AttendanceController extends Controller
 {
-    /**
-     * 受講状況登録API
-     */
     public function store(StoreRequest $request): JsonResponse
-    {
-        $instructorId = Auth::guard('instructor')->user()->id;
+{
+    $attendance = new Attendance([
+        'course_id' => $request->course_id,
+        'student_id' => $request->student_id,
+    ]);
 
-        $courseIds = Course::where('instructor_id', $instructorId)
-            ->pluck('id')
-            ->toArray();
+    $attendance->setRelation('course', Course::findOrFail($request->course_id));
 
-        if (! in_array($request->course_id, $courseIds, true)) {
-            // 講師の所有する講座でない場合はエラーを返す
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+    // Policyによる認可チェック
+    $this->authorize('create', $attendance);
 
-        if (Attendance::where('course_id', $request->course_id)
-            ->where('student_id', $request->student_id)
-            ->exists()
-        ) {
-            // 受講状況が存在する場合はエラーを返す
-            throw new AuthorizationException('Attendance record already exists.');
-        }
-
-        DB::beginTransaction();
-        try {
-            $attendance = Attendance::create([
-                'course_id' => $request->course_id,
-                'student_id' => $request->student_id,
-            ]);
-            $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
-                $query->where('course_id', $request->course_id);
-            })->get();
-            foreach ($lessons as $lesson) {
-                LessonAttendance::create([
-                    'attendance_id' => $attendance->id,
-                    'lesson_id' => $lesson->id,
-                    'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
-                ]);
-            }
-            DB::commit();
-
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
-        }
+    if (Attendance::where('course_id', $request->course_id)
+        ->where('student_id', $request->student_id)
+        ->exists()
+    ) {
+        throw new AuthorizationException(
+            'Attendance record already exists.'
+        );
     }
 
+    DB::beginTransaction();
+    try {
+        $attendance->save();
+
+        $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
+            $query->where('course_id', $request->course_id);
+        })->get();
+
+        foreach ($lessons as $lesson) {
+            LessonAttendance::create([
+                'attendance_id' => $attendance->id,
+                'lesson_id' => $lesson->id,
+                'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+            ]);
+        }
+
+        DB::commit();
+
+        return response()->json(['result' => true]);
+    } catch (Exception $e) {
+        DB::rollBack();
+        Log::error($e);
+        throw $e;
+    }
+}
     /**
      * 受講状況取得API
      */

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -38,7 +38,7 @@ class AttendanceController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // Policyによる認可チェック
-        $this->authorize('create', $course);
+        $this->authorize('create', [Attendance::class, $course]);
 
         if (Attendance::where('course_id', $request->course_id)
             ->where('student_id', $request->student_id)

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -34,51 +34,50 @@ class AttendanceController extends Controller
      * 受講状況登録API
      */
     public function store(StoreRequest $request): JsonResponse
-{
-    /** @var Attendance $attendance */
-    
-    $course = Course::findOrFail($request->course_id);
-    
-    // Policyによる認可チェック
-    $this->authorize('create', $course);
+    {
+        /** @var Attendance $attendance */
+        $course = Course::findOrFail($request->course_id);
 
-    if (Attendance::where('course_id', $request->course_id)
-        ->where('student_id', $request->student_id)
-        ->exists()
-    ) {
-        throw new AuthorizationException(
-            'Attendance record already exists.'
-        );
-    }
+        // Policyによる認可チェック
+        $this->authorize('create', $course);
 
-    DB::beginTransaction();
-    try {
-        $attendance = Attendance::create([
-            'course_id' => $request->course_id,
-            'student_id' => $request->student_id,
-        ]);
+        if (Attendance::where('course_id', $request->course_id)
+            ->where('student_id', $request->student_id)
+            ->exists()
+        ) {
+            throw new AuthorizationException(
+                'Attendance record already exists.'
+            );
+        }
 
-        $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
-            $query->where('course_id', $request->course_id);
-        })->get();
-
-        $lessons->each(function (Lesson $lesson) use ($attendance) {
-            LessonAttendance::create([
-                'attendance_id' => $attendance->id,
-                'lesson_id' => $lesson->id,
-                'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+        DB::beginTransaction();
+        try {
+            $attendance = Attendance::create([
+                'course_id' => $request->course_id,
+                'student_id' => $request->student_id,
             ]);
-        });
 
-        DB::commit();
+            $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
+                $query->where('course_id', $request->course_id);
+            })->get();
 
-        return response()->json(['result' => true]);
-    } catch (Exception $e) {
-        DB::rollBack();
-        Log::error($e);
-        throw $e;
+            $lessons->each(function (Lesson $lesson) use ($attendance) {
+                LessonAttendance::create([
+                    'attendance_id' => $attendance->id,
+                    'lesson_id' => $lesson->id,
+                    'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+                ]);
+            });
+
+            DB::commit();
+
+            return response()->json(['result' => true]);
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error($e);
+            throw $e;
+        }
     }
-}
 
     /**
      * 受講状況取得API

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -57,7 +57,10 @@ class AttendanceController extends Controller
 
     DB::beginTransaction();
     try {
-        $attendance->save();
+        $attendance = Attendance::create([
+            'course_id' => $request->course_id,
+            'student_id' => $request->student_id,
+        ]);
 
         $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
             $query->where('course_id', $request->course_id);

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -36,15 +36,11 @@ class AttendanceController extends Controller
     public function store(StoreRequest $request): JsonResponse
 {
     /** @var Attendance $attendance */
-    $attendance = new Attendance([
-        'course_id' => $request->course_id,
-        'student_id' => $request->student_id,
-    ]);
-
-    $attendance->setRelation('course', Course::findOrFail($request->course_id));
-
+    
+    $course = Course::findOrFail($request->course_id);
+    
     // Policyによる認可チェック
-    $this->authorize('create', $attendance);
+    $this->authorize('create', $course);
 
     if (Attendance::where('course_id', $request->course_id)
         ->where('student_id', $request->student_id)

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -34,69 +34,52 @@ class AttendanceController extends Controller
      * 受講状況登録API
      */
     public function store(StoreRequest $request): JsonResponse
-    {
-        $managerId = $request->user()->id;
+{
+    /** @var Attendance $attendance */
+    $attendance = new Attendance([
+        'course_id' => $request->course_id,
+        'student_id' => $request->student_id,
+    ]);
 
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrFail($managerId);
+    $attendance->setRelation('course', Course::findOrFail($request->course_id));
 
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
+    // Policyによる認可チェック
+    $this->authorize('create', $attendance);
 
-        $courseIds = Course::with('instructor')
-            ->whereIn('instructor_id', $instructorIds)
-            ->pluck('id')
-            ->toArray();
-
-        /** @var Course $course */
-        $course = Course::find($request->course_id);
-
-        if (! in_array($course->id, $courseIds, true)) {
-            // 自分もしくは配下の講師の講座でない場合はエラーを返す
-            throw new AuthorizationException('Forbidden.');
-        }
-
-        if (Attendance::where('course_id', $request->course_id)->where('student_id', $request->student_id)->exists()) {
-            // 受講状況が存在すれば、エラーを返す
-            throw new AuthorizationException(
-                'Attendance record already exists.'
-            );
-        }
-
-        DB::beginTransaction();
-        try {
-            // 受講状況を登録
-            /** @var Attendance $attendance */
-            $attendance = Attendance::create([
-                'course_id' => $request->course_id,
-                'student_id' => $request->student_id,
-            ]);
-
-            // 指定した講座のレッスンを取得
-            $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
-                $query->where('course_id', $request->course_id);
-            })->get();
-
-            // レッスン受講情報を登録
-            $lessons->each(function (Lesson $lesson) use ($attendance) {
-                LessonAttendance::create([
-                    'attendance_id' => $attendance->id,
-                    'lesson_id' => $lesson->id,
-                    'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
-                ]);
-            });
-
-            DB::commit();
-
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
-        }
+    if (Attendance::where('course_id', $request->course_id)
+        ->where('student_id', $request->student_id)
+        ->exists()
+    ) {
+        throw new AuthorizationException(
+            'Attendance record already exists.'
+        );
     }
+
+    DB::beginTransaction();
+    try {
+        $attendance->save();
+
+        $lessons = Lesson::whereHas('chapter', function ($query) use ($request) {
+            $query->where('course_id', $request->course_id);
+        })->get();
+
+        $lessons->each(function (Lesson $lesson) use ($attendance) {
+            LessonAttendance::create([
+                'attendance_id' => $attendance->id,
+                'lesson_id' => $lesson->id,
+                'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+            ]);
+        });
+
+        DB::commit();
+
+        return response()->json(['result' => true]);
+    } catch (Exception $e) {
+        DB::rollBack();
+        Log::error($e);
+        throw $e;
+    }
+}
 
     /**
      * 受講状況取得API

--- a/app/Http/Controllers/Api/Manager/AttendanceController.php
+++ b/app/Http/Controllers/Api/Manager/AttendanceController.php
@@ -35,11 +35,11 @@ class AttendanceController extends Controller
      */
     public function store(StoreRequest $request): JsonResponse
     {
-        /** @var Attendance $attendance */
+        /** @var Course $course */
         $course = Course::findOrFail($request->course_id);
 
         // Policyによる認可チェック
-        $this->authorize('create', $course);
+        $this->authorize('create', [Attendance::class, $course]);
 
         if (Attendance::where('course_id', $request->course_id)
             ->where('student_id', $request->student_id)

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Model\Attendance;
 use App\Model\Instructor;
+use App\Model\Course;
 
 class AttendancePolicy
 {
@@ -24,17 +25,17 @@ class AttendancePolicy
         return $instructor->id === $attendance->course->instructor_id;
     }
 
-    public function create(Instructor $instructor, Attendance $attendance): bool
+    public function create(Instructor $instructor, Course $course): bool
     {
         // マネージャー権限のある講師か判定
         if ($instructor->isManager()) {
             $instructorIds = $instructor->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;
 
-            return in_array($attendance->course->instructor_id, $instructorIds, true);
+            return in_array($course->instructor_id, $instructorIds, true);
         }
 
         // マネージャー権限のない講師
-        return $instructor->id === $attendance->course->instructor_id;
+        return $instructor->id === $course->instructor_id;
     }
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -23,4 +23,18 @@ class AttendancePolicy
         // マネージャー権限のない講師
         return $instructor->id === $attendance->course->instructor_id;
     }
+
+    public function create(Instructor $instructor, Attendance $attendance): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($attendance->course->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $instructor->id === $attendance->course->instructor_id;
+    }
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -9,7 +9,24 @@ use App\Model\Instructor;
 class AttendancePolicy
 {
     /**
-     * Create a new policy instance.
+     * 受講作成時のポリシー
+     */
+    public function create(Instructor $instructor, Course $course): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($course->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $instructor->id === $course->instructor_id;
+    }
+    
+    /**
+     * 受講状況削除時のポリシー
      */
     public function delete(Instructor $instructor, Attendance $attendance): bool
     {
@@ -25,17 +42,4 @@ class AttendancePolicy
         return $instructor->id === $attendance->course->instructor_id;
     }
 
-    public function create(Instructor $instructor, Course $course): bool
-    {
-        // マネージャー権限のある講師か判定
-        if ($instructor->isManager()) {
-            $instructorIds = $instructor->managings->pluck('id')->toArray();
-            $instructorIds[] = $instructor->id;
-
-            return in_array($course->instructor_id, $instructorIds, true);
-        }
-
-        // マネージャー権限のない講師
-        return $instructor->id === $course->instructor_id;
-    }
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -24,7 +24,7 @@ class AttendancePolicy
         // マネージャー権限のない講師
         return $instructor->id === $course->instructor_id;
     }
-    
+
     /**
      * 受講状況削除時のポリシー
      */
@@ -41,5 +41,4 @@ class AttendancePolicy
         // マネージャー権限のない講師
         return $instructor->id === $attendance->course->instructor_id;
     }
-
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -3,8 +3,8 @@
 namespace App\Policies;
 
 use App\Model\Attendance;
-use App\Model\Instructor;
 use App\Model\Course;
+use App\Model\Instructor;
 
 class AttendancePolicy
 {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -30,6 +30,7 @@ class AuthServiceProvider extends ServiceProvider
         Notification::class => NotificationPolicy::class,
         Tag::class => TagPolicy::class,
         Attendance::class => AttendancePolicy::class,
+        Course::class => AttendancePolicy::class,
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -30,7 +30,6 @@ class AuthServiceProvider extends ServiceProvider
         Notification::class => NotificationPolicy::class,
         Tag::class => TagPolicy::class,
         Attendance::class => AttendancePolicy::class,
-        Course::class => AttendancePolicy::class,
     ];
 
     /**

--- a/tests/Feature/Api/Manager/Attendance/StoreTest.php
+++ b/tests/Feature/Api/Manager/Attendance/StoreTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api\Instructor\Attendance;
+namespace Tests\Feature\Api\Manager\Attendance;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,13 +21,13 @@ class StoreTest extends TestCase
     public function test_受講登録_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(2);
+        $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/instructor/attendance', [
-            'course_id' => 2,
-            'student_id' => 1,
+        $response = $this->postJson('/api/v1/manager/attendance', [
+            'course_id' => 1,
+            'student_id' => 3,
         ]);
 
         // assert
@@ -37,15 +37,34 @@ class StoreTest extends TestCase
         ]);
     }
 
-    public function test_権限がない講師_失敗(): void
+    public function test_受講中の生徒_失敗(): void
     {
         // arrange
-        $instructor = Instructor::find(2);
+        $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/instructor/attendance', [
+        $response = $this->postJson('/api/v1/manager/attendance', [
             'course_id' => 1,
+            'student_id' => 1,
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Attendance record already exists.',
+        ]);
+    }
+
+    public function test_権限がない講師_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(4);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/manager/attendance', [
+            'course_id' => 2,
             'student_id' => 3,
         ]);
 
@@ -59,11 +78,11 @@ class StoreTest extends TestCase
     public function test_バリデーションエラー(): void
     {
         // arrange
-        $instructor = Instructor::find(2);
+        $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/instructor/attendance', []);
+        $response = $this->postJson('/api/v1/manager/attendance', []);
 
         // assert
         $response->assertStatus(422);


### PR DESCRIPTION
## issue
- JKA-1503 AttendanceControllerのstoreメソッドのPolicyパターンを用いた認可機能の実装

## 概要
- Policy の create メソッドを新規追加し、Manager/Instructor 権限の判定ロジックを統一。これにより、担当外のコースへの不正登録を Policy によって一元管理
- 既存の手動チェックを Policy に集約し、権限判定を一元化。
- 重複登録チェック（Attendance record already exists.）は既存仕様を維持。

## 動作確認
### 【Manager】
### 1. 自身が担当するコース(course_id:1)で正常登録を確認

<img width="601" height="588" alt="manager受講登録状況正常系" src="https://github.com/user-attachments/assets/e9d96fa6-026f-4114-bd2c-dce6707b1b9e" />

### 2. 再度自身の講座(course_id:1)登録で重複エラーを確認
<img width="1142" height="562" alt="manager　受講状況登録重複" src="https://github.com/user-attachments/assets/8f16d67d-becd-404d-b071-f6d332d9180e" />

### 3. 配下の講師(instructor_id:2) が担当するコース(course_id:2)で正常登録を確認
<img width="601" height="588" alt="manager配下講座受講条項登録正常" src="https://github.com/user-attachments/assets/c183a8a0-c77f-4701-8f5c-bd5bf8b2b063" />

### 4. 権限外のコース(course_id:4)登録でエラーを確認
<img width="1137" height="566" alt="manager権限外受講状況エラー" src="https://github.com/user-attachments/assets/b730d1a3-4fdc-48ed-889d-83c7a6e6c5df" />


###【Instructor】
### 1.自身が担当するコース(course_id:1)で正常登録を確認
<img width="601" height="588" alt="instoructor受講状況正常系" src="https://github.com/user-attachments/assets/087d8831-0405-47fb-a9ea-045a702291f2" />

### 2.  再度自身の講座(course_id:2)登録で重複エラーを確認
<img width="1259" height="567" alt="instoructor受講状況重複" src="https://github.com/user-attachments/assets/f89a6776-d1be-4206-a6d6-f734f81d29f8" />

### 3. 権限外のコース(course_id:1)登録でエラーを確認
<img width="1261" height="565" alt="instoructor受講状況権限外" src="https://github.com/user-attachments/assets/1eb3a238-22a6-4d49-997f-85bb1bea68b0" />

## 確認してほしいこと
- AttendanceController@store で Policy (create) を適用した方針に問題がないか
- Policy の create と delete メソッドが同一ロジックになっている点について、担当外コードを触らずに重複ロジックで対応したが、問題ないか。
- Postmanでの動作確認結果（7ケース：正常・権限外・重複）をもって
   想定通りの動作であると考えて良いか。

