### PR TITLE
LessonControllerのstoreメソッドのPolicyパターンを用いた認可機能の実装 (たつのり)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -43,7 +43,7 @@ class LessonController extends Controller
     public function store(StoreRequest $request, StoreLessonService $service): JsonResponse
     {
         $course = Course::findOrFail($request->course_id);
-        
+
         // Policyパターンによる認可チェック
         $this->authorize('create', [Lesson::class, $course]);
 

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -43,9 +43,9 @@ class LessonController extends Controller
     public function store(StoreRequest $request, StoreLessonService $service): JsonResponse
     {
         $course = Course::findOrFail($request->course_id);
-        if ($course->instructor_id !== $request->user()->id) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        
+        // Policyパターンによる認可チェック
+        $this->authorize('create', [Lesson::class, $course]);
 
         DB::beginTransaction();
         try {

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -44,20 +44,10 @@ class LessonController extends Controller
      */
     public function store(StoreRequest $request, StoreLessonService $service): JsonResponse
     {
-        $managerId = Auth::guard('instructor')->user()->id;
-
-        // 配下の講師情報を取得
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrFail($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
         $course = Course::findOrFail($request->course_id);
 
-        if (! in_array($course->instructor_id, $instructorIds, true)) {
-            // 自分、または配下の講師の講座でなければエラー応答
-            throw new AuthorizationException('Forbidden, not allowed to this lesson.');
-        }
+        // Policyパターンによる認可チェック
+        $this->authorize('create', [Lesson::class, $course]);
 
         DB::beginTransaction();
         try {

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -15,7 +15,6 @@ use App\Http\Requests\Manager\Lesson\UpdateStatusRequest;
 use App\Http\Requests\Manager\Lesson\UpdateTitleRequest;
 use App\Model\Chapter;
 use App\Model\Course;
-use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Lesson\BulkDeleteLessonsService;
@@ -30,7 +29,6 @@ use App\Services\Lesson\UpdateLessonTitleService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 

--- a/app/Policies/LessonPolicy.php
+++ b/app/Policies/LessonPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Model\Instructor;
+use App\Model\Course; 
 use App\Model\Lesson;
 use Illuminate\Support\Collection;
 
@@ -82,4 +83,18 @@ class LessonPolicy
             fn (Lesson $lesson) => $lesson->chapter->course->instructor_id === $instructor->id
         );
     }
+
+    public function create(Instructor $instructor, Course $course): bool
+{
+    if ($instructor->isManager()) {
+        // マネージャーは自分または配下講師のコースにレッスン作成可能
+        $instructorIds = $instructor->managings->pluck('id')->toArray();
+        $instructorIds[] = $instructor->id;
+
+        return in_array($course->instructor_id, $instructorIds, true);
+    }
+
+    // 通常講師は自分のコースのみ作成可能
+    return $course->instructor_id === $instructor->id;
+}
 }

--- a/app/Policies/LessonPolicy.php
+++ b/app/Policies/LessonPolicy.php
@@ -2,13 +2,30 @@
 
 namespace App\Policies;
 
+use App\Model\Course;
 use App\Model\Instructor;
-use App\Model\Course; 
 use App\Model\Lesson;
 use Illuminate\Support\Collection;
 
 class LessonPolicy
 {
+    /**
+     * レッスンの閲覧に関する認可処理
+     */
+    public function create(Instructor $instructor, Course $course): bool
+    {
+        if ($instructor->isManager()) {
+            // マネージャーは自分または配下講師のコースにレッスン作成可能
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($course->instructor_id, $instructorIds, true);
+        }
+
+        // 通常講師は自分のコースのみ作成可能
+        return $course->instructor_id === $instructor->id;
+    }
+
     /**
      * レッスンの更新処理に関する認可処理
      */
@@ -83,18 +100,4 @@ class LessonPolicy
             fn (Lesson $lesson) => $lesson->chapter->course->instructor_id === $instructor->id
         );
     }
-
-    public function create(Instructor $instructor, Course $course): bool
-{
-    if ($instructor->isManager()) {
-        // マネージャーは自分または配下講師のコースにレッスン作成可能
-        $instructorIds = $instructor->managings->pluck('id')->toArray();
-        $instructorIds[] = $instructor->id;
-
-        return in_array($course->instructor_id, $instructorIds, true);
-    }
-
-    // 通常講師は自分のコースのみ作成可能
-    return $course->instructor_id === $instructor->id;
-}
 }

--- a/tests/Feature/Api/Instructor/Lesson/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/StoreTest.php
@@ -21,11 +21,11 @@ class StoreTest extends TestCase
     public function test_レッスン登録_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->postJson('/api/v1/instructor/course/1/chapter/1/lesson', [
+        $response = $this->postJson('/api/v1/instructor/course/2/chapter/4/lesson', [
             'title' => 'title',
         ]);
 
@@ -36,11 +36,8 @@ class StoreTest extends TestCase
             'lesson_id',
         ]);
         $this->assertDatabaseHas('lessons', [
-            'chapter_id' => 1,
+            'chapter_id' => 4,
             'title' => 'title',
-        ]);
-        $this->assertDatabaseHas('lesson_attendances', [
-            'lesson_id' => $response['lesson_id'],
         ]);
     }
 
@@ -58,7 +55,7 @@ class StoreTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Lesson/StoreTest.php
+++ b/tests/Feature/Api/Manager/Lesson/StoreTest.php
@@ -82,7 +82,7 @@ class StoreTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, not allowed to this lesson.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 


### PR DESCRIPTION
## issue
JKA-1505 LessonControllerのstoreメソッドのPolicyパターンを用いた認可機能の実装

## 概要
- LessonPolicy に `create` メソッドを追加し、レッスン作成時の認可ロジックを実装
- LessonController（Instructor / Manager）の `store` メソッドにおける認可処理を、LessonPolicy に委譲

## 動作確認
### 【Manager】
#### 1. 自身が担当するコース・チャプター(Course_id: 1 /Chapter_id: 1)にLesson作成できることを確認

<img width="600" height="605" alt="マネージャー自身のレッスン" src="https://github.com/user-attachments/assets/b4113ef5-1635-4397-b5f3-a06989467e6c" />

#### 2. 自身の配下の講師が担当するコース・チャプター(Course_id: 2 /Chapter_id: 4)にLesson作成できることを確認

<img width="600" height="605" alt="スクリーンショット 2025-07-28 011700" src="https://github.com/user-attachments/assets/e4077680-3b45-4305-88f7-f487e2f0b857" />

#### 3. 権限外のコース・チャプター(Course_id: 4 /Chapter_id: 1)にLesson作成できないことを確認

<img width="1259" height="567" alt="マネージャー権限外" src="https://github.com/user-attachments/assets/13025c65-de8f-43b2-9bc2-93183bff3514" />

### 【instructor】
#### 1. 自身が担当するコース・チャプター(Course_id: 2 /Chapter_id: 2)にLesson作成できることを確認

<img width="605" height="602" alt="インストラクター自身のレッスン" src="https://github.com/user-attachments/assets/4a61efa2-fd83-4cdc-945e-60d417fb5e6e" />

#### 2. 権限外のコース・チャプター(Course_id: 1 /Chapter_id: 1)にLesson作成できないことを確認

<img width="1254" height="567" alt="インストラクター権限外レッスン" src="https://github.com/user-attachments/assets/033ce99f-be79-440b-a8a0-f95d31532ccd" />

### 確認してほしいこと
- Policyパターン実装において不備はないか。

