### PR TITLE
NotificationControllerのupdateTypeメソッドのPolicyパターンを用いた認可機能部分の修正（もりお）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -176,16 +176,9 @@ class NotificationController extends Controller
     public function updateType(UpdateTypeRequest $request, UpdateTypeService $service): JsonResponse
     {
         $notifications = Notification::whereIn('id', $request->notifications)->get();
-        $instructorId = Auth::guard('instructor')->user()->id;
 
         // policyによる認可チェック
         $this->authorize('bulkUpdate', [Notification::class, $notifications]);
-
-        if (
-            $notifications->contains(fn (Notification $notification) => $notification->instructor_id !== $instructorId)
-        ) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
 
         DB::beginTransaction();
         try {

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -201,7 +201,7 @@ class NotificationController extends Controller
      * お知らせ種別一括更新API
      */
     public function updateType(UpdateTypeRequest $request, UpdateTypeService $service): JsonResponse
-    {    
+    {
         // 選択されたお知らせを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -201,16 +201,7 @@ class NotificationController extends Controller
      * お知らせ種別一括更新API
      */
     public function updateType(UpdateTypeRequest $request, UpdateTypeService $service): JsonResponse
-    {
-        // 認証しているマネージャーIDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // マネージャーが管理する講師IDリストを取得
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
+    {    
         // 選択されたお知らせを取得
         $notifications = Notification::whereIn('id', $request->notifications)->get();
 


### PR DESCRIPTION
# issue
- Closes  #1031

# 概要
- NotificationController の UpdateType メソッドに関しまして、Policyパターンを用いた認可機能部分を修正いたしました。

# 変更内容
- Controller 内の手動での instructor_id チェックを削除いたしました。
- Policy の bulkUpdate メソッドを利用し、認可を実施いたしました。
- Instructor、Manager 両方での認可テストを Postman にて実施し、確認済みです。

# 動作確認
- Instructor は自分の通知のみ更新可能（他人の通知は403エラー）
- Manager 自分の通知と配下である Instructor の通知も更新可能
- 存在しない通知ID指定時は422エラー

# 確認して欲しいこと
- コードのより良い記載方法等、ご指摘いただけますと幸いに存じます。
何とぞよろしくお願いいたします。