### PR TITLE
JKA-1495 TagControllerのdeleteメソッドをサービスクラス作成などで共通化（いのっち）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -115,9 +115,14 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(DeleteRequest $request, DeleteTagService $deleteTagService): JsonResponse
+    public function delete(DeleteRequest $request, Tag $tag, DeleteTagService $service): JsonResponse
     {
-        $deleteTagService(['tag_id' => $request->tag_id]);
+        $tag = Tag::findOrFail($request->tag_id);
+
+        // 認可処理
+        $this->authorize('delete', $tag);
+
+        $service($tag);
 
         return response()->json(['result' => true]);
     }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -115,14 +115,14 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(DeleteRequest $request, Tag $tag, DeleteTagService $service): JsonResponse
+    public function delete(DeleteRequest $request, DeleteTagService $service): JsonResponse
     {
         $tag = Tag::findOrFail($request->tag_id);
 
         // 認可処理
         $this->authorize('delete', $tag);
 
-        $service($tag);
+        $service(tag: $tag);
 
         return response()->json(['result' => true]);
     }

--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -12,6 +12,7 @@ use App\Http\Resources\Base\Instructor\TagResource;
 use App\Http\Resources\Instructor\TagIndexResource;
 use App\Model\Instructor;
 use App\Model\Tag;
+use App\Services\Tag\DeleteTagService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -115,23 +116,10 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(DeleteRequest $request): JsonResponse
+    public function delete(DeleteRequest $request, DeleteTagService $deleteTagService): JsonResponse
     {
-        // タグの取得
-        $tag = Tag::findOrFail($request->tag_id);
+        $deleteTagService(['tag_id' => $request->tag_id]);
 
-        // policyによる認可チェック
-        $this->authorize('delete', $tag);
-
-        // タグに紐づく講座が存在する場合は削除処理を中止
-        if ($tag->courses()->exists()) {
-            throw new AuthorizationException('Forbidden, this tag is linked to courses.');
-        }
-
-        $tag->delete();
-
-        return response()->json([
-            'result' => true,
-        ]);
+        return response()->json(['result' => true]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -12,6 +12,7 @@ use App\Http\Resources\Manager\TagIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Tag;
+use App\Services\Tag\DeleteTagService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -90,25 +91,11 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(DeleteRequest $request): JsonResponse
+    public function delete(DeleteRequest $request, DeleteTagService $deleteTagService): JsonResponse
     {
-        // タグの取得
-        $tag = Tag::findOrFail($request->tag_id);
+        $deleteTagService(['tag_id' => $request->tag_id]);
 
-        // policyによる認可チェック
-        $this->authorize('delete', $tag);
-
-        // タグに関連付けられた講座がある場合は削除不可
-        if ($tag->courses()->exists()) {
-            throw new AuthorizationException('Forbidden, this tag is linked to courses.');
-        }
-
-        // タグの削除
-        $tag->delete();
-
-        return response()->json([
-            'result' => true,
-        ]);
+        return response()->json(['result' => true]);
     }
 
     /**

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -89,9 +89,14 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(DeleteRequest $request, DeleteTagService $deleteTagService): JsonResponse
+    public function delete(DeleteRequest $request, Tag $tag, DeleteTagService $service): JsonResponse
     {
-        $deleteTagService(['tag_id' => $request->tag_id]);
+        $tag = Tag::findOrFail($request->tag_id);
+
+        // 認可処理
+        $this->authorize('delete', $tag);
+
+        $service($tag);
 
         return response()->json(['result' => true]);
     }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -89,14 +89,14 @@ class TagController extends Controller
     /**
      * タグ削除API
      */
-    public function delete(DeleteRequest $request, Tag $tag, DeleteTagService $service): JsonResponse
+    public function delete(DeleteRequest $request, DeleteTagService $service): JsonResponse
     {
         $tag = Tag::findOrFail($request->tag_id);
 
         // 認可処理
         $this->authorize('delete', $tag);
 
-        $service($tag);
+        $service(tag: $tag);
 
         return response()->json(['result' => true]);
     }

--- a/app/Services/Tag/DeleteTagService.php
+++ b/app/Services/Tag/DeleteTagService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services\Tag;
+
+use App\Model\Tag;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class DeleteTagService
+{
+    use AuthorizesRequests;
+
+    /**
+     * タグを削除する
+     *
+     * @param array{
+     *     tag_id: int,
+     * } $params
+     * @return void
+     *
+     * @throws ModelNotFoundException
+     * @throws AuthorizationException
+     */
+    public function __invoke(array $params): void
+    {
+        $tag = Tag::findOrFail($params['tag_id']);
+
+        // ポリシー認可
+        $this->authorize('delete', $tag);
+
+        // 紐づく講座がある場合は削除不可
+        if ($tag->courses()->exists()) {
+            throw new AuthorizationException('Forbidden, this tag is linked to courses.');
+        }
+
+        $tag->delete();
+    }
+}

--- a/app/Services/Tag/DeleteTagService.php
+++ b/app/Services/Tag/DeleteTagService.php
@@ -9,26 +9,16 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class DeleteTagService
 {
-    use AuthorizesRequests;
-
     /**
      * タグを削除する
      *
-     * @param array{
-     *     tag_id: int,
-     * } $params
+     * @param Tag $tag
      * @return void
-     *
-     * @throws ModelNotFoundException
+     * 
      * @throws AuthorizationException
      */
-    public function __invoke(array $params): void
+    public function __invoke(Tag $tag): void
     {
-        $tag = Tag::findOrFail($params['tag_id']);
-
-        // ポリシー認可
-        $this->authorize('delete', $tag);
-
         // 紐づく講座がある場合は削除不可
         if ($tag->courses()->exists()) {
             throw new AuthorizationException('Forbidden, this tag is linked to courses.');

--- a/app/Services/Tag/DeleteTagService.php
+++ b/app/Services/Tag/DeleteTagService.php
@@ -4,17 +4,13 @@ namespace App\Services\Tag;
 
 use App\Model\Tag;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class DeleteTagService
 {
     /**
      * タグを削除する
      *
-     * @param Tag $tag
-     * @return void
-     * 
+     *
      * @throws AuthorizationException
      */
     public function __invoke(Tag $tag): void

--- a/database/seeders/CourseTagSeeder.php
+++ b/database/seeders/CourseTagSeeder.php
@@ -40,11 +40,6 @@ class CourseTagSeeder extends Seeder
                 'created_at' => Carbon::now(),
             ],
             [
-                'course_id' => 6,
-                'tag_id' => 5,
-                'created_at' => Carbon::now(),
-            ],
-            [
                 'course_id' => 7,
                 'tag_id' => 3,
                 'created_at' => Carbon::now(),

--- a/tests/Feature/Api/Instructor/Tag/DeleteTest.php
+++ b/tests/Feature/Api/Instructor/Tag/DeleteTest.php
@@ -20,11 +20,11 @@ class DeleteTest extends TestCase
     public function test_タグ削除_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->deleteJson('/api/v1/instructor/tag/7');
+        $response = $this->deleteJson('/api/v1/instructor/tag/5');
 
         // assert
         $response->assertStatus(200);
@@ -32,18 +32,18 @@ class DeleteTest extends TestCase
             'result' => true,
         ]);
         $this->assertDatabaseMissing('tags', [
-            'id' => 7,
+            'id' => 5,
         ]);
     }
 
     public function test_タグに紐づく講座が存在_失敗(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->deleteJson('/api/v1/instructor/tag/1');
+        $response = $this->deleteJson('/api/v1/instructor/tag/2');
 
         // assert
         $response->assertStatus(403);
@@ -59,7 +59,7 @@ class DeleteTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->deleteJson('/api/v1/instructor/tag/1');
+        $response = $this->deleteJson('/api/v1/instructor/tag/6');
 
         // assert
         $response->assertStatus(403);


### PR DESCRIPTION
## Jira
- JKA-1495 

## 概要
- TagControllerのdeleteメソッドをサービスクラス作成で共通化

## 動作確認手順
- managerユーザでログイン
- email : test_instructor@example.com
- password : password
- 対象のタグが削除されるか確認

<img width="1512" height="982" alt="スクリーンショット 2025-07-28 0 47 42" src="https://github.com/user-attachments/assets/93266253-ef52-4a88-ab12-958b7d0cccac" />

- instructorユーザでログイン
- email : test_instructor2@example.com
- password : password
- 対象のタグが削除されるか確認
<img width="1512" height="982" alt="スクリーンショット 2025-07-28 1 41 51" src="https://github.com/user-attachments/assets/42ffded5-ea41-43f2-8856-339f4e22c000" />

## 考慮して欲しいこと
- 削除用のタグが１つだけしかなかったのでphp artisan migrate:fresh --seedを行い再利用しました！

## 確認して欲しいこと
- 動作確認はうまくいきましたがコードの書き方など足りないことなどありましたら教えてください！

