### PR TITLE
NotificationControllerのstoreメソッドPolicyパターンを用いた認可機能の実装(ちゃこ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -74,19 +74,20 @@ class NotificationController extends Controller
      */
     public function store(StoreRequest $request, StoreNotificationService $service): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
+        $instructor = Auth::guard('instructor')->user();
 
-        // 講座がこの講師のものか確認
-        $course = Course::findOrFail($request->course_id);
-        if ($course->instructor_id !== $instructorId) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        $notification = new Notification([
+            'instructor_id' => $instructor->id,
+            'course_id' => $request->course_id,
+        ]);
+
+        $this->authorize('create', $notification);
 
         DB::beginTransaction();
         try {
             $service(
                 course_id: $request->course_id,
-                instructor_id: $instructorId,
+                instructor_id: $instructor->id,
                 title: $request->title,
                 type: $request->type,
                 start_date: $request->start_date,

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -94,25 +94,23 @@ class NotificationController extends Controller
      */
     public function store(StoreRequest $request, StoreNotificationService $service): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // 配下のインストラクター情報を取得
-        $manager = Instructor::with('managings')->find($instructorId);
-        assert($manager instanceof Instructor);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
+        $instructor = Auth::guard('instructor')->user();
 
         $course = Course::findOrFail($request->course_id);
         assert($course instanceof Course);
-        if (! in_array($course->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+
+        $notification = new Notification([
+            'instructor_id' => $instructor->id,
+            'course_id' => $request->course_id,
+        ]);
+
+        $this->authorize('create', $notification);
 
         DB::beginTransaction();
         try {
             $service(
                 course_id: $request->course_id,
-                instructor_id: $instructorId,
+                instructor_id: $instructor->id,
                 title: $request->title,
                 type: $request->type,
                 start_date: $request->start_date,

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -4,10 +4,32 @@ namespace App\Policies;
 
 use App\Model\Instructor;
 use App\Model\Notification;
+use App\Model\Course;
 use Illuminate\Database\Eloquent\Collection;
 
 class NotificationPolicy
 {
+    /**
+     * お知らせの作成処理に関する認可処理
+     */
+    public function create(Instructor $instructor, Notification $notification): bool
+    {
+        $course = Course::find($notification->course_id);
+
+        if (!$course) {
+            return false;
+        }
+
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($course->instructor_id, $instructorIds, true);
+        }
+
+        return $course->instructor_id === $instructor->id;
+    }
+
     /**
      * お知らせの更新処理に関する認可処理
      */


### PR DESCRIPTION
## JIRA
- [jka-1510] お知らせ登録時の認可処理のポリシーの実装

## 概要
- インストラクター／マネージャーのお知らせ登録APIに対して、認可処理をPolicyへ移行しました。

- NotificationPolicy::create() にて、コースの instructor_id による認可を実施。
- 動作確認済みです（マネージャー側、インストラクター側両方、DBへの反映も確認済み、認可チェック済み）


## 動作確認手順
1. Managerユーザでログイン
ユーザ名：山田太郎
email：[test_instructor@example.com](mailto:test_instructor@example.com)
password：password


2. 自身または配下の講師のコースIDでお知らせの登録ができるかを確認
POST http://localhost:8080/api/v1/manager/course/1/notification （自身のコースID）
POST http://localhost:8080/api/v1/manager/course/2/chapter （配下の講師のコースID）


<img width="913" height="772" alt="スクリーンショット 2025-07-29 14 23 05" src="https://github.com/user-attachments/assets/a79e2788-40e5-42ac-a957-d4a3a8eaf94b" />


<img width="905" height="778" alt="スクリーンショット 2025-07-29 14 23 17" src="https://github.com/user-attachments/assets/190db9ed-cd2a-43bd-ba67-fe45591a8cdf" />



3. 配下に属さない講師のコースIDでチャプター作成ができるかを確認 → 更新不可（403）を確認

<img width="913" height="772" alt="スクリーンショット 2025-07-29 14 20 34" src="https://github.com/user-attachments/assets/7afc11d4-053c-4549-a158-7d5688c1607c" />


4. Instructorユーザでログイン
ユーザ名：山本花子
email：[test_instructor2@example.com](mailto:test_instructor2@example.com)
password：password

5. 自身のコースIDでお知らせの登録ができるかを確認

POST http://localhost:8080/api/v1/instructor/course/2/notification


<img width="910" height="781" alt="スクリーンショット 2025-07-29 14 22 07" src="https://github.com/user-attachments/assets/6ac95053-3972-4070-b1c0-8cee5aa4d925" />


該当のスクランブル：
http://localhost:8080/docs/api#/operations/manager.notification.store (マネージャー側)
http://localhost:8080/docs/api#/operations/instructor.notification.store (インストラクター側)


## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 既存機能との整合性が取れているか（他メソッドとのコードスタイル含む）
コードの構造が参考PRの内容に沿ったものになっているか
参考PR：https://github.com/yukihiroLaravel/juko_laravel/pull/1009/files
