### PR TITLE
NotificationControllerのputStatusAllメソッドのPolicyパターンを用いた認可機能部分の修正(智美)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -299,11 +299,9 @@ class NotificationController extends Controller
      */
     public function putStatusAll(PutStatusAllRequest $request, PutStatusAllService $service): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-
         $status = StatusEnum::from($request->status);
 
-        $notifications = Notification::where('instructor_id', $instructorId)->get(['id', 'instructor_id', 'status']);
+        $notifications = Notification::whereIn('id', $request->notification_ids)->get(['id', 'instructor_id', 'status']);
 
         // 講師と一致しないお知らせが含まれている場合はエラー
         $this->authorize('bulkUpdate', [Notification::class, $notifications]);

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -323,19 +323,10 @@ class NotificationController extends Controller
      */
     public function putStatusAll(PutStatusAllRequest $request, PutStatusAllService $service): JsonResponse
     {
-        // ログイン中のマネージャーIDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // 管理下の講師IDをすべて取得
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
         $status = StatusEnum::from($request->status);
 
         // 対象の通知をすべて取得（管理下の講師に紐づく）
-        $notifications = Notification::whereIn('instructor_id', $instructorIds)->get(['id', 'instructor_id', 'status']);
+        $notifications = Notification::whereIn('id', $request->notification_ids)->get(['id', 'instructor_id', 'status']);
 
         // 講師と一致しないお知らせが含まれている場合はエラー
         $this->authorize('bulkUpdate', [Notification::class, $notifications]);

--- a/app/Http/Requests/Instructor/Notification/PutStatusAllRequest.php
+++ b/app/Http/Requests/Instructor/Notification/PutStatusAllRequest.php
@@ -25,6 +25,8 @@ class PutStatusAllRequest extends FormRequest
     {
         return [
             'status' => ['required', Rule::enum(StatusEnum::class)],
+            'notification_ids' => ['required', 'array', 'min:1'],
+            'notification_ids.*' => ['integer', 'distinct'], // 各通知IDが数値で重複なし
         ];
     }
 }

--- a/app/Http/Requests/Manager/Notification/PutStatusAllRequest.php
+++ b/app/Http/Requests/Manager/Notification/PutStatusAllRequest.php
@@ -28,6 +28,8 @@ class PutStatusAllRequest extends FormRequest
     {
         return [
             'status' => ['required', Rule::enum(StatusEnum::class)],
+            'notification_ids' => ['required', 'array', 'min:1'],
+            'notification_ids.*' => ['integer', 'distinct'], // 各通知IDが数値で重複なし
         ];
     }
 }


### PR DESCRIPTION
## Jira
- 【JKA-1058】

## 概要
- NotificationControllerのputStatusAllメソッドのPolicyパターンを用いた認可機能部分の修正

## 動作確認手順
下記でログイン
- [test_instructor@example.com](mailto:test_instructor@example.com)
- password

POST：http://localhost:8080/api/v1/manager/notification/status/all
<img width="1366" height="677" alt="スクリーンショット 2025-07-29 141019" src="https://github.com/user-attachments/assets/e1b2c02a-096e-4936-8e02-442d04c7740a" />

POST：http://localhost:8080/api/v1/instructor/notification/status/all
<img width="1371" height="642" alt="スクリーンショット 2025-07-29 141133" src="https://github.com/user-attachments/assets/40084c93-3a5f-4c31-ac9f-3d1e923edfd6" />

## 確認してほしいこと
notification_idsに対してのバリデーションが定義されていなかった為、必要と思い実装したのですが、これで大丈夫でしょうか？
また、動作確認はしていますが、再度ご確認の程、よろしくお願いいたします。
