### PR TITLE
ChapterControllerのshowメソッドのPolicyパターンを用いた認可機能の実装(ちゃこ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/ChapterController.php
+++ b/app/Http/Controllers/Api/Instructor/ChapterController.php
@@ -46,10 +46,7 @@ class ChapterController extends Controller
         // チャプターを取得
         $chapter = $queryService->getChapter($request->chapter_id);
 
-        if (Auth::guard('instructor')->user()->id !== $chapter->course->instructor_id) {
-            // ログインしている講師が作成していないチャプターの更新を許可しない
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        $this->authorize('view', $chapter);
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合は更新を許可しない

--- a/app/Http/Controllers/Api/Manager/ChapterController.php
+++ b/app/Http/Controllers/Api/Manager/ChapterController.php
@@ -43,24 +43,13 @@ class ChapterController extends Controller
      */
     public function show(ShowRequest $request): ChapterShowResource
     {
-        // ログイン中の講師IDを取得
-        $managerId = Auth::guard('instructor')->user()->id;
-
-        // 配下の講師情報を取得
-        $manager = Instructor::with('managings')->find($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
         $chapter = Chapter::with(['lessons', 'course'])->findOrFail($request->chapter_id);
+
+        $this->authorize('view', $chapter);
 
         if ((int) $request->course_id !== $chapter->course->id) {
             // 指定した講座IDがチャプターの講座IDと一致しない場合はエラー応答
             throw new AuthorizationException('Forbidden, invalid course_id.');
-        }
-
-        if (! in_array($chapter->course->instructor_id, $instructorIds, true)) {
-            // 自身もしくは配下の講師が作成した講座でない場合、権限エラーを返す
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
         }
 
         return new ChapterShowResource($chapter);

--- a/app/Policies/ChapterPolicy.php
+++ b/app/Policies/ChapterPolicy.php
@@ -9,6 +9,18 @@ use Illuminate\Support\Collection;
 
 class ChapterPolicy
 {
+    public function view(Instructor $instructor, Chapter $chapter): bool
+    {
+        if ($instructor->isManager()) {
+            $managerIds = $instructor->managings->pluck('id')->toArray();
+            $managerIds[] = $instructor->id;
+
+            return in_array($chapter->course->instructor_id, $managerIds, true);
+        }
+
+        return $instructor->id === $chapter->course->instructor_id;
+    }
+
     /**
      * チャプターの作成処理に関する認可処理
      */

--- a/app/Policies/ChapterPolicy.php
+++ b/app/Policies/ChapterPolicy.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Collection;
 
 class ChapterPolicy
 {
+    /**
+     * チャプターの閲覧に関する認可処理
+     */
     public function view(Instructor $instructor, Chapter $chapter): bool
     {
         if ($instructor->isManager()) {

--- a/tests/Feature/Api/Instructor/Chapter/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/ShowTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api\Manager\Chapter;
+namespace Tests\Feature\Api\Instructor\Chapter;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,11 +21,11 @@ class ShowTest extends TestCase
     public function test_チャプター取得_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->getJson('/api/v1/manager/course/1/chapter/1');
+        $response = $this->getJson('/api/v1/instructor/course/2/chapter/4');
 
         // assert
         $response->assertStatus(200);
@@ -34,11 +34,11 @@ class ShowTest extends TestCase
     public function test_講師が一致しない_失敗(): void
     {
         // arrange
-        $instructor = Instructor::find(4);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->getJson('/api/v1/manager/course/1/chapter/1');
+        $response = $this->getJson('/api/v1/instructor/course/1/chapter/1');
 
         // assert
         $response->assertStatus(403);
@@ -54,12 +54,12 @@ class ShowTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->getJson('/api/v1/manager/course/2/chapter/1');
+        $response = $this->getJson('/api/v1/instructor/course/2/chapter/1');
 
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid course_id.',
+            'message' => 'Invalid course_id.',
         ]);
     }
 
@@ -70,12 +70,13 @@ class ShowTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->getJson('/api/v1/manager/course/aaa/chapter/bbb');
+        $response = $this->getJson('/api/v1/instructor/course/aaa/chapter/bbb');
 
         // assert
         $response->assertStatus(422);
         $response->assertJsonValidationErrors([
             'course_id',
+            'chapter_id',
         ]);
     }
 }


### PR DESCRIPTION
## JIRA
- [jka-1510] ChapterController@show に Policy パターンを用いた認可機能を実装

## 概要
- Instructor / Manager 双方の ChapterController@show メソッドに対して、
ChapterPolicy@view を用いた認可処理を実装しました。
- 講師側、マネージャー側どちらも動作確認済みです（認可チェック済み）

## 動作確認手順
1.  Postman にて、マネージャーユーザーでログイン

以下のチャプターを取得

マネージャー自身のチャプター → 200 OK

<img width="882" height="771" alt="マネージャー自身のチャプター" src="https://github.com/user-attachments/assets/785926d9-f4ee-476d-a5f1-957c322b6395" />



配下講師のチャプター → 200 OK

<img width="881" height="775" alt="マネージャーの配下のチャプター" src="https://github.com/user-attachments/assets/78134dcc-f023-4250-81ea-55cd8f1743d6" />


配下でない講師のチャプター → 403 Forbidden


<img width="886" height="776" alt="配下でない講師のチャプター" src="https://github.com/user-attachments/assets/42df33a6-9307-4a91-9889-bdb5103c73eb" />



2. Instructorユーザーでログイン

自身のチャプターのみ閲覧可能であることを確認

<img width="886" height="772" alt="スクリーンショット 2025-07-29 22 52 54" src="https://github.com/user-attachments/assets/6cccae80-7b18-4a26-bf96-9683ccbe9d19" />


他講師のチャプターは403が返ることを確認

<img width="886" height="773" alt="スクリーンショット 2025-07-29 22 56 51" src="https://github.com/user-attachments/assets/86bfc931-8e37-47b9-a4e2-920072636157" />


該当のスクランブル：
http://localhost:8080/docs/api#/operations/instructor.chapter.show （インストラクター）
http://localhost:8080/docs/api#/operations/manager.chapter.show （マネージャー）


## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- ポリシーのロジックに不備がないか
- 既存コードと整合性あるか