### PR TITLE
NotificationControllerのstoreメソッドのPolicyパターンを用いた認可機能の実装（もりお）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -78,7 +78,7 @@ class NotificationController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // Policyを使った認可チェック
-        $this->authorize('create', [$course], 'Forbidden, invalid instructor_id.');
+        $this->authorize('create', [$course]);
 
         // 講師IDは認可済みなので、ログインユーザーから取得
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -78,7 +78,7 @@ class NotificationController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // Policyを使った認可チェック
-        $this->authorize('create', $course);
+        $this->authorize('create', [$course], 'Forbidden, invalid instructor_id.');
 
         // 講師IDは認可済みなので、ログインユーザーから取得
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -74,13 +74,14 @@ class NotificationController extends Controller
      */
     public function store(StoreRequest $request, StoreNotificationService $service): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // 講座がこの講師のものか確認
+        // 講座取得
         $course = Course::findOrFail($request->course_id);
-        if ($course->instructor_id !== $instructorId) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+
+        // Policyを使った認可チェック
+        $this->authorize('create', $course);
+
+        // 講師IDは認可済みなので、ログインユーザーから取得
+        $instructorId = Auth::guard('instructor')->user()->id;
 
         DB::beginTransaction();
         try {

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -78,7 +78,9 @@ class NotificationController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // Policyを使った認可チェック
-        $this->authorize('create', [$course]);
+        if (Gate::denies('create', $course)) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
 
         // 講師IDは認可済みなので、ログインユーザーから取得
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -32,6 +32,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @tags Instructor-Notification

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -23,7 +23,6 @@ use App\Services\Notification\BulkDeleteService;
 use App\Services\Notification\DeleteService;
 use App\Services\Notification\PutNotificationService;
 use App\Services\Notification\PutStatusAllService;
-use App\Services\Notification\PutStatusService;
 use App\Services\Notification\StoreNotificationService;
 use App\Services\Notification\UpdateTypeAllService;
 use App\Services\Notification\UpdateTypeService;
@@ -255,14 +254,13 @@ class NotificationController extends Controller
     /**
      * お知らせステータス更新API
      */
-    public function putStatus(PutStatusRequest $request, PutStatusService $service): JsonResponse
+    public function putStatus(PutStatusRequest $request): JsonResponse
     {
         // ログインしている講師のIDを取得
         $instructorId = Auth::guard('instructor')->user()->id;
 
         // 選択されたお知らせidを取得
         $notificationIds = $request->input('notifications', []);
-        $status = $request->status;
 
         // 選択されたお知らせを取得
         $chosenNotifications = Notification::whereIn('id', $notificationIds)->pluck('instructor_id');
@@ -278,15 +276,11 @@ class NotificationController extends Controller
         DB::beginTransaction();
 
         try {
-            $notifications = Notification::where('instructor_id', $instructorId)
+            Notification::where('instructor_id', $instructorId)
                 ->whereIn('id', $notificationIds)
-                ->get(['id', 'instructor_id', 'status']);
+                ->update(['status' => $request->status]);
 
-            $service(
-                notifications: $notifications,
-                status: $status
-            );
-
+            // コミット
             DB::commit();
 
             return response()->json([

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -24,7 +24,6 @@ use App\Services\Notification\BulkDeleteService;
 use App\Services\Notification\DeleteService;
 use App\Services\Notification\PutNotificationService;
 use App\Services\Notification\PutStatusAllService;
-use App\Services\Notification\PutStatusService;
 use App\Services\Notification\StoreNotificationService;
 use App\Services\Notification\UpdateTypeAllService;
 use App\Services\Notification\UpdateTypeService;
@@ -95,19 +94,14 @@ class NotificationController extends Controller
      */
     public function store(StoreRequest $request, StoreNotificationService $service): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-
-        // 配下のインストラクター情報を取得
-        $manager = Instructor::with('managings')->find($instructorId);
-        assert($manager instanceof Instructor);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
+        // コース取得
         $course = Course::findOrFail($request->course_id);
-        assert($course instanceof Course);
-        if (! in_array($course->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+
+        // Policyによる認可チェック
+        $this->authorize('create', $course);
+
+        // ログインしているInstructor(Manager)のID
+        $instructorId = Auth::guard('instructor')->user()->id;
 
         DB::beginTransaction();
         try {
@@ -284,10 +278,9 @@ class NotificationController extends Controller
     /**
      * お知らせ一括公開・非公開API
      */
-    public function putStatus(PutStatusRequest $request, PutStatusService $service): JsonResponse
+    public function putStatus(PutStatusRequest $request): JsonResponse
     {
         $notificationIds = $request->input('notifications', []);
-        $status = $request->input('status');
 
         $notifications = Notification::whereIn('id', $notificationIds)->get(['id', 'instructor_id', 'status']);
 
@@ -296,10 +289,8 @@ class NotificationController extends Controller
         DB::beginTransaction();
 
         try {
-            $service(
-                notifications: $notifications,
-                status: $status
-            );
+            Notification::whereIn('id', $notificationIds)
+                ->update(['status' => $request->status]);
 
             DB::commit();
 

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -98,7 +98,7 @@ class NotificationController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // Policyによる認可チェック
-        $this->authorize('create', [$course], 'Forbidden, invalid instructor_id.');
+        $this->authorize('create', [$course]);
 
         // ログインしているInstructor(Manager)のID
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -98,7 +98,9 @@ class NotificationController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // Policyによる認可チェック
-        $this->authorize('create', [$course]);
+        if (Gate::denies('create', $course)) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
 
         // ログインしているInstructor(Manager)のID
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -33,6 +33,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @tags Manager-Notification

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -98,7 +98,7 @@ class NotificationController extends Controller
         $course = Course::findOrFail($request->course_id);
 
         // Policyによる認可チェック
-        $this->authorize('create', $course);
+        $this->authorize('create', [$course], 'Forbidden, invalid instructor_id.');
 
         // ログインしているInstructor(Manager)のID
         $instructorId = Auth::guard('instructor')->user()->id;

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -94,25 +94,20 @@ class NotificationPolicy
     /**
      * お知らせ作成処理に関する認可処理
      *
-     * @param  Instructor|Manager $user   ユーザー（Instructor または Manager）
-     * @param  Course              $course 対象の講座
+     * @param  Instructor $user   ユーザー（Instructor）
+     * @param  Course     $course 対象の講座
      */
-    public function create($user, Course $course): bool
+    public function create(Instructor $user, Course $course): bool
     {
-        // Instructor 側
-        if ($user instanceof Instructor) {
-            return $course->instructor_id === $user->id;
-        }
-
-        // Manager 側
-        if ($user instanceof Instructor && $user->isManager()) {
-            // 自分と配下のInstructorを取得
+        // マネージャーかどうか判定
+        if ($user->isManager()) {
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
 
             return in_array($course->instructor_id, $instructorIds, true);
         }
 
-        return false;
+        // 講師の場合は自分の講座のみ
+        return $course->instructor_id === $user->id;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -94,7 +94,9 @@ class NotificationPolicy
      *
      * @param  Instructor  $user   認可を確認するユーザー（Instructor）
      * @param  Course      $course 対象の講座
-     * @return bool  認可された場合 true、されなければ false を返す
+     * @return bool  認可された場合 true を返す
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException 認可されない場合は 403 エラーを投げる
      */
     public function create(Instructor $user, Course $course): bool
     {
@@ -102,11 +104,16 @@ class NotificationPolicy
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
 
-            // instructor_idが配下かを判定
-            return in_array($course->instructor_id, $instructorIds, true);
+            if (! in_array($course->instructor_id, $instructorIds, true)) {
+                abort(403, 'Forbidden, invalid instructor_id.');
+            }
+            return true;
         }
 
-        // 講師は自分の講座のみ
-        return $course->instructor_id === $user->id;
+        if ($course->instructor_id !== $user->id) {
+            abort(403, 'Forbidden, invalid instructor_id.');
+        }
+
+        return true;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -98,7 +98,6 @@ class NotificationPolicy
      */
     public function create(Instructor $user, Course $course): bool
     {
-        // マネージャーの場合は配下の講師の講座も作成可能
         if ($user->isManager()) {
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
@@ -106,7 +105,6 @@ class NotificationPolicy
             return in_array($course->instructor_id, $instructorIds, true);
         }
 
-        // 講師の場合は自分の講座のみ作成可能
         return $course->instructor_id === $user->id;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -94,26 +94,19 @@ class NotificationPolicy
      *
      * @param  Instructor  $user   認可を確認するユーザー（Instructor）
      * @param  Course      $course 対象の講座
-     * @return bool  認可された場合 true を返す
-     *
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException 認可されない場合は 403 エラーを投げる
+     * @return bool  認可された場合 true、されなければ false を返す
      */
     public function create(Instructor $user, Course $course): bool
     {
+        // マネージャーの場合は配下の講師の講座も作成可能
         if ($user->isManager()) {
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
 
-            if (! in_array($course->instructor_id, $instructorIds, true)) {
-                abort(403, 'Forbidden, invalid instructor_id.');
-            }
-            return true;
+            return in_array($course->instructor_id, $instructorIds, true);
         }
 
-        if ($course->instructor_id !== $user->id) {
-            abort(403, 'Forbidden, invalid instructor_id.');
-        }
-
-        return true;
+        // 講師の場合は自分の講座のみ作成可能
+        return $course->instructor_id === $user->id;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -99,12 +99,14 @@ class NotificationPolicy
     public function create(Instructor $user, Course $course): bool
     {
         if ($user->isManager()) {
+            // 管理者の場合、配下の講師の講座も可能
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
 
             return in_array($course->instructor_id, $instructorIds, true);
         }
 
+        // 講師の場合、自分のコースだけを許可
         return $course->instructor_id === $user->id;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -90,10 +90,13 @@ class NotificationPolicy
     }
 
     /**
-     * お知らせ作成処理に関する認可処理
+     * お知らせ作成処理に関する認可処理     
      *
-     * @param  Instructor  $user  ユーザー（Instructor）
-     * @param  Course  $course  対象の講座
+     * @param  Instructor  $user   認可を確認するユーザー（Instructor）
+     * @param  Course      $course 対象の講座
+     * @return bool 認可された場合 true を返す
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException 403 条件未満の場合
      */
     public function create(Instructor $user, Course $course): bool
     {
@@ -102,10 +105,17 @@ class NotificationPolicy
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
 
-            return in_array($course->instructor_id, $instructorIds, true);
+            if (! in_array($course->instructor_id, $instructorIds, true)) {
+                abort(403, 'Forbidden, invalid instructor_id.');
+            }
+
+            return true;
         }
 
-        // 講師の場合は自分の講座のみ
-        return $course->instructor_id === $user->id;
+        if ($course->instructor_id !== $user->id) {
+            abort(403, 'Forbidden, invalid instructor_id.');
+        }
+
+        return true;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -87,4 +87,28 @@ class NotificationPolicy
             fn (Notification $notification) => $notification->instructor_id === $instructor->id
         );
     }
+
+    /**
+     * お知らせ作成処理に関する認可処理
+     *
+     * @param  \App\Models\User   $user    ユーザー（Instructor または Manager）
+     * @param  \App\Models\Course $course  対象の講座
+     * @return bool
+     */
+    public function create(User $user, Course $course): bool
+    {
+        // Instructor 側
+        if ($user instanceof Instructor) {
+            return $course->instructor_id === $user->id;
+        }
+
+        // Manager 側
+        if ($user instanceof Manager) {
+            $instructorIds = $user->managings->pluck('id')->toArray();
+            $instructorIds[] = $user->id;
+            return in_array($course->instructor_id, $instructorIds, true);
+        }
+
+        return false;
+    }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -14,7 +14,7 @@ class NotificationPolicy
     /**
      * お知らせの更新処理に関する認可処理
      */
-    public function update(Instructor $instructor, Notification $notification)
+    public function update(Instructor $instructor, Notification $notification): bool
     {
         // マネージャーの場合は配下の講師レッスンも更新可能
         if ($instructor->isManager()) {
@@ -31,7 +31,7 @@ class NotificationPolicy
     /**
      * お知らせの削除に関する認可処理
      */
-    public function delete(Instructor $instructor, Notification $notification): bool
+    public function delete(Instructor $instructor, Notification $notification)
     {
         // マネージャーの場合は配下の講師のお知らせも削除可能
         if ($instructor->isManager()) {
@@ -94,11 +94,10 @@ class NotificationPolicy
     /**
      * お知らせ作成処理に関する認可処理
      *
-     * @param  mixed  $user   ユーザー（Instructor または Manager）
-     * @param  mixed  $course 対象の講座
-     * @return bool
+     * @param  Instructor|Manager $user   ユーザー（Instructor または Manager）
+     * @param  Course              $course 対象の講座
      */
-    public function create($user, $course): bool
+    public function create($user, Course $course): bool
     {
         // Instructor 側
         if ($user instanceof Instructor) {
@@ -106,9 +105,11 @@ class NotificationPolicy
         }
 
         // Manager 側
-        if ($user instanceof Manager) {
+        if ($user instanceof Instructor && $user->isManager()) {
+            // 自分と配下のInstructorを取得
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
+
             return in_array($course->instructor_id, $instructorIds, true);
         }
 

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -3,6 +3,9 @@
 namespace App\Policies;
 
 use App\Model\Instructor;
+use App\Model\Manager;
+use App\Model\User;
+use App\Model\Course;
 use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -91,11 +94,11 @@ class NotificationPolicy
     /**
      * お知らせ作成処理に関する認可処理
      *
-     * @param  \App\Models\User   $user    ユーザー（Instructor または Manager）
-     * @param  \App\Models\Course $course  対象の講座
+     * @param  mixed  $user   ユーザー（Instructor または Manager）
+     * @param  mixed  $course 対象の講座
      * @return bool
      */
-    public function create(User $user, Course $course): bool
+    public function create($user, $course): bool
     {
         // Instructor 側
         if ($user instanceof Instructor) {

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -90,32 +90,23 @@ class NotificationPolicy
     }
 
     /**
-     * お知らせ作成処理に関する認可処理     
+     * お知らせ作成処理に関する認可処理
      *
      * @param  Instructor  $user   認可を確認するユーザー（Instructor）
      * @param  Course      $course 対象の講座
-     * @return bool 認可された場合 true を返す
-     *
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException 403 条件未満の場合
+     * @return bool  認可された場合 true、されなければ false を返す
      */
     public function create(Instructor $user, Course $course): bool
     {
-        // マネージャーかどうか判定
         if ($user->isManager()) {
             $instructorIds = $user->managings->pluck('id')->toArray();
             $instructorIds[] = $user->id;
 
-            if (! in_array($course->instructor_id, $instructorIds, true)) {
-                abort(403, 'Forbidden, invalid instructor_id.');
-            }
-
-            return true;
+            // instructor_idが配下かを判定
+            return in_array($course->instructor_id, $instructorIds, true);
         }
 
-        if ($course->instructor_id !== $user->id) {
-            abort(403, 'Forbidden, invalid instructor_id.');
-        }
-
-        return true;
+        // 講師は自分の講座のみ
+        return $course->instructor_id === $user->id;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -2,10 +2,8 @@
 
 namespace App\Policies;
 
-use App\Model\Instructor;
-use App\Model\Manager;
-use App\Model\User;
 use App\Model\Course;
+use App\Model\Instructor;
 use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -94,8 +92,8 @@ class NotificationPolicy
     /**
      * お知らせ作成処理に関する認可処理
      *
-     * @param  Instructor $user   ユーザー（Instructor）
-     * @param  Course     $course 対象の講座
+     * @param  Instructor  $user  ユーザー（Instructor）
+     * @param  Course  $course  対象の講座
      */
     public function create(Instructor $user, Course $course): bool
     {


### PR DESCRIPTION
# issue
- Closes  #1036

# 概要
- NotificationControllerのstoreメソッドのPolicyパターンを用いた認可機能の実装を行いました。

# 変更内容
- Instructor 側および Manager 側の NotificationController の store メソッドに記載されていた認可チェックの記載コードを削除しました。
- $this->authorize('create', $course) を追加しました。
- NotificationPolicy に create メソッドを追加し、Instructorおよび Manager の認可判定を集約しました。

# 動作確認
- Postman にて、Instructor、Manager それぞれの権限チェックが下記の通り正しく動作することを確認しました。

①
http://localhost:8080/login/instructor
メソッド：POST
Instructor 2
を設定

http://localhost:8080/api/v1/instructor/notification/type （PUT）にて Instructor 側のテスト

- notification: [2] を実行 → 200
- notification: [1] を実行 → 403
- notification: [1,3] を実行 → 403

②
http://localhost:8080/login/instructor
メソッド：POST
Instructor 1
を設定

http://localhost:8080/api/v1/manager/notification/type （PUT）にて Manager 側のテスト

- notification: [1] を実行 → 200
- notification: [1,2] を実行 → 200
- notification: [1,4] を実行 → 200
- notification: [3] を実行 → 403

# 確認していただきたいこと
- コードの記載方法、テスト方法に誤りがないか等、ご確認いただけましたらと存じます。
何とぞよろしくお願いいたします。