### PR TITLE
NotificationControllerのshowメソッドのPolicyパターンを用いた認可機能の実装 (たつのり)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -63,9 +63,8 @@ class NotificationController extends Controller
         $notification = Notification::with(['course'])
             ->findOrFail($request->notification_id);
 
-        if ($notification->instructor_id !== Auth::guard('instructor')->user()->id) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        // Policyによる認可チェック
+        $this->authorize('view', $notification);
 
         return new NotificationResource($notification);
     }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -69,23 +69,12 @@ class NotificationController extends Controller
      */
     public function show(ShowRequest $request): NotificationResource
     {
-        // ユーザーID取得
-        $instructorId = $request->user()->id;
-
-        // 配下のインストラクター情報を取得
-        $manager = Instructor::with('managings')->find($instructorId);
-        assert($manager instanceof Instructor);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
+        
         // 指定されたお知らせIDでお知らせを取得
         $notification = Notification::with('instructor')->findOrFail($request->notification_id);
-        assert($notification instanceof Notification);
-
-        // アクセス権限のチェック
-        if (! in_array($notification->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        
+        // Policyによる認可チェック
+        $this->authorize('view', $notification);
 
         return new NotificationResource($notification);
     }

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -69,10 +69,10 @@ class NotificationController extends Controller
      */
     public function show(ShowRequest $request): NotificationResource
     {
-        
+
         // 指定されたお知らせIDでお知らせを取得
         $notification = Notification::with('instructor')->findOrFail($request->notification_id);
-        
+
         // Policyによる認可チェック
         $this->authorize('view', $notification);
 

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -9,6 +9,23 @@ use Illuminate\Database\Eloquent\Collection;
 class NotificationPolicy
 {
     /**
+     * お知らせの閲覧に関する認可処理
+     */
+    public function view(Instructor $instructor, Notification $notification): bool
+    {
+        // マネージャーの場合は配下の講師の通知も見られる
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($notification->instructor_id, $instructorIds, true);
+        }
+
+        // 講師権限のみの場合は、自分の通知だけが見られる
+        return $notification->instructor_id === $instructor->id;
+    }
+
+    /**
      * お知らせの更新処理に関する認可処理
      */
     public function update(Instructor $instructor, Notification $notification)
@@ -86,22 +103,5 @@ class NotificationPolicy
         return $notifications->every(
             fn (Notification $notification) => $notification->instructor_id === $instructor->id
         );
-    }
-
-    /**
-     * お知らせの閲覧に関する認可処理
-     */
-    public function view(Instructor $instructor, Notification $notification): bool
-    {
-        // マネージャーの場合は配下の講師の通知も見られる
-        if ($instructor->isManager()) {
-            $instructorIds = $instructor->managings->pluck('id')->toArray();
-            $instructorIds[] = $instructor->id;
-
-            return in_array($notification->instructor_id, $instructorIds, true);
-        }
-
-        // 講師権限のみの場合は、自分の通知だけが見られる
-        return $notification->instructor_id === $instructor->id;
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -87,4 +87,20 @@ class NotificationPolicy
             fn (Notification $notification) => $notification->instructor_id === $instructor->id
         );
     }
+    
+    /**
+     * お知らせの閲覧に関する認可処理
+     */
+    public function view(Instructor $instructor, Notification $notification): bool
+    {
+        // マネージャーの場合は配下の講師の通知も見られる
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+            return in_array($notification->instructor_id, $instructorIds, true);
+        }
+
+        // 講師権限のみの場合は、自分の通知だけが見られる
+        return $notification->instructor_id === $instructor->id;
+    }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -87,7 +87,7 @@ class NotificationPolicy
             fn (Notification $notification) => $notification->instructor_id === $instructor->id
         );
     }
-    
+
     /**
      * お知らせの閲覧に関する認可処理
      */
@@ -97,6 +97,7 @@ class NotificationPolicy
         if ($instructor->isManager()) {
             $instructorIds = $instructor->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;
+
             return in_array($notification->instructor_id, $instructorIds, true);
         }
 

--- a/tests/Feature/Api/Instructor/Notification/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Notification/ShowTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Notification;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_お知らせ取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/instructor/notification/2');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        //act
+        $response = $this->getJson('/api/v1/instructor/notification/aaa');
+
+        // assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'notification_id',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- JKA-1513 NotificationControllerのshowメソッドのPolicyパターンを用いた認可機能の実装

## 概要
- NotificationPolicyに`view`メソッドを追加
- Instructor/ManagerのNotificationController@showをPolicyベースの認可に修正

## 動作確認
### 【Manager】
#### 1. 自身が作成したお知らせを閲覧できることを確認
<img width="1266" height="761" alt="スクリーンショット 2025-07-31 023702" src="https://github.com/user-attachments/assets/c9002cb8-557a-4e8f-a5ad-6b7ac10f6b6b" />

#### 2. 配下の講師が作成したお知らせを閲覧できることを確認
<img width="1266" height="761" alt="スクリーンショット 2025-07-31 023725" src="https://github.com/user-attachments/assets/94f61ee0-642a-4232-b076-bd694a7c4a39" />

#### 3. 権限外の講師が作成したお知らせを閲覧できないことを確認
<img width="1261" height="638" alt="スクリーンショット 2025-07-31 023923" src="https://github.com/user-attachments/assets/6ba85456-e261-468a-99ea-1e8b74574ac7" />

### 【Instructor】
#### 1. 自身が作成したお知らせを閲覧できることを確認
<img width="1266" height="761" alt="スクリーンショット 2025-07-31 024337" src="https://github.com/user-attachments/assets/66d9d985-10df-4e5d-abcf-ca456c741d59" />

#### 2. 他の講師が作成したお知らせを閲覧できないことを確認
<img width="1261" height="638" alt="スクリーンショット 2025-07-31 024349" src="https://github.com/user-attachments/assets/6fd3045d-577c-40f8-93d4-5cf6621241fd" />

## 確認してほしいこと
- 各コードに不備などがないか