### PR TITLE
JKA-1514 StudentControllerのshowメソッドのPolicyパターンを用いた認可機能の実装(智美)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -106,7 +106,6 @@ class StudentController extends Controller
         return new StudentShowResource($student);
     }
 
-
     /**
      * 受講生登録API
      */

--- a/app/Http/Controllers/Api/Instructor/StudentController.php
+++ b/app/Http/Controllers/Api/Instructor/StudentController.php
@@ -98,24 +98,14 @@ class StudentController extends Controller
      */
     public function show(ShowRequest $request)
     {
-        // 認証ユーザー情報取得
-        $instructorId = Auth::guard('instructor')->user()->id;
+        $student = Student::with('attendances')->findOrFail($request->student_id);
 
-        // 認証された講師が作成した講座のIDを取得
-        $courseIds = Course::where('instructor_id', $instructorId)->pluck('id');
-
-        // リクエストされた受講生を取得
-        $student = Student::find($request->student_id);
-        assert($student instanceof Student);
-
-        // 受講生が講師の講座に所属しているか確認
-        $studentCourseIds = $student->attendances->pluck('course_id')->unique();
-        if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
-            throw new AuthorizationException('Forbidden, invalid instructor.');
-        }
+        // 認可チェック
+        $this->authorize('view', $student);
 
         return new StudentShowResource($student);
     }
+
 
     /**
      * 受講生登録API

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -15,7 +15,6 @@ use App\Services\Student\StoreStudentService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -112,7 +111,6 @@ class StudentController extends Controller
 
         return new StudentShowResource($student);
     }
-
 
     /**
      * 受講生登録API

--- a/app/Http/Controllers/Api/Manager/StudentController.php
+++ b/app/Http/Controllers/Api/Manager/StudentController.php
@@ -106,28 +106,13 @@ class StudentController extends Controller
      */
     public function show(ShowRequest $request, QueryService $queryService)
     {
-        // 認証されたマネージャーが管理する講師のIDのリストを取得
-        $authManagerId = Auth::guard('instructor')->user()->id;
-        $manager = Instructor::with('managings')->find($authManagerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-
-        // 自身のIDを追加
-        $instructorIds[] = $authManagerId;
-
-        // 認証されたマネージャーとマネージャーが管理する講師の講座IDのリストを取得
-        $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
-
-        // リクエストされた受講生を取得
         $student = $queryService->getStudent($request->student_id);
 
-        // 受講生が講師の講座に所属しているか確認
-        $studentCourseIds = $student->attendances->pluck('course_id')->unique();
-        if ($studentCourseIds->intersect($courseIds)->isEmpty()) {
-            throw new AuthorizationException('Forbidden, invalid instructor.');
-        }
+        $this->authorize('view', $student);
 
         return new StudentShowResource($student);
     }
+
 
     /**
      * 受講生登録API

--- a/app/Policies/StudentPolicy.php
+++ b/app/Policies/StudentPolicy.php
@@ -2,30 +2,43 @@
 
 namespace App\Policies;
 
+use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Student;
-use App\Model\Course;
+use Illuminate\Support\Collection;
 
 class StudentPolicy
 {
     /**
-     * 受講生詳細取得
+     * 受講生取得認可ポリシー
      */
     public function view(Instructor $instructor, Student $student): bool
     {
+        // 受講している講座のIDリストを取得
+        $attendedCourseIds = $student->attendances->pluck('course_id')->unique();
+
         if ($instructor->isManager()) {
-            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds = $instructor->managings->pluck('id');
             $instructorIds[] = $instructor->id;
 
-            $studentCourseIds = $student->attendances->pluck('course_id')->unique();
             $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
 
-            return $studentCourseIds->intersect($courseIds)->isNotEmpty();
+            return $this->hasCommonCourses(attendedCourseIds: $attendedCourseIds, courseIds: $courseIds);
         }
 
         $courseIds = Course::where('instructor_id', $instructor->id)->pluck('id');
-        $studentCourseIds = $student->attendances->pluck('course_id')->unique();
 
-        return $studentCourseIds->intersect($courseIds)->isNotEmpty();
+        return $this->hasCommonCourses(attendedCourseIds: $attendedCourseIds, courseIds: $courseIds);
+    }
+
+    /**
+     * 受講済みの講座IDと、講師が担当する講座IDに共通するものがあるか確認
+     *
+     * @param  Collection<int>  $attendedCourseIds
+     * @param  Collection<int>  $courseIds
+     */
+    private function hasCommonCourses(Collection $attendedCourseIds, Collection $courseIds): bool
+    {
+        return $attendedCourseIds->intersect($courseIds)->isNotEmpty();
     }
 }

--- a/app/Policies/StudentPolicy.php
+++ b/app/Policies/StudentPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Policies;
+
+use App\Model\Instructor;
+use App\Model\Student;
+use App\Model\Course;
+
+class StudentPolicy
+{
+    /**
+     * 受講生詳細取得
+     */
+    public function view(Instructor $instructor, Student $student): bool
+    {
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            $studentCourseIds = $student->attendances->pluck('course_id')->unique();
+            $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
+
+            return $studentCourseIds->intersect($courseIds)->isNotEmpty();
+        }
+
+        $courseIds = Course::where('instructor_id', $instructor->id)->pluck('id');
+        $studentCourseIds = $student->attendances->pluck('course_id')->unique();
+
+        return $studentCourseIds->intersect($courseIds)->isNotEmpty();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -8,12 +8,14 @@ use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Notification;
 use App\Model\Tag;
+use App\Model\Student;
 use App\Policies\AttendancePolicy;
 use App\Policies\ChapterPolicy;
 use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
 use App\Policies\NotificationPolicy;
 use App\Policies\TagPolicy;
+use App\Policies\StudentPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,15 +7,15 @@ use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Notification;
-use App\Model\Tag;
 use App\Model\Student;
+use App\Model\Tag;
 use App\Policies\AttendancePolicy;
 use App\Policies\ChapterPolicy;
 use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
 use App\Policies\NotificationPolicy;
-use App\Policies\TagPolicy;
 use App\Policies\StudentPolicy;
+use App\Policies\TagPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -30,6 +30,7 @@ class AuthServiceProvider extends ServiceProvider
         Notification::class => NotificationPolicy::class,
         Tag::class => TagPolicy::class,
         Attendance::class => AttendancePolicy::class,
+        Student::class => StudentPolicy::class,
     ];
 
     /**

--- a/tests/Feature/Api/Instructor/Student/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Student/ShowTest.php
@@ -21,7 +21,7 @@ class ShowTest extends TestCase
     public function test_生徒取得_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
@@ -43,14 +43,14 @@ class ShowTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 
     public function test_バリデーションエラー(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act

--- a/tests/Feature/Api/Manager/Student/ShowTest.php
+++ b/tests/Feature/Api/Manager/Student/ShowTest.php
@@ -43,7 +43,7 @@ class ShowTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid instructor.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 
@@ -60,6 +60,22 @@ class ShowTest extends TestCase
         $response->assertStatus(422);
         $response->assertJsonValidationErrors([
             'student_id',
+        ]);
+    }
+
+    public function test_権限エラー(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/student/bbb');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
         ]);
     }
 }


### PR DESCRIPTION
## Jira
- JKA-1514

## 概要
- StudentControllerのshowメソッドのPolicyパターンを用いた認可機能の実装

## 動作確認手順
- 山田太郎でログイン
test_instructor@example.com
password

- GET：http://localhost:8080/api/v1/instructor/student/1
<img width="1184" height="757" alt="スクリーンショット 2025-07-31 234256" src="https://github.com/user-attachments/assets/c1d7c4ac-d028-40c3-a68c-beb102379457" />

- GET：http://localhost:8080/api/v1/manager/student/2
<img width="1172" height="739" alt="スクリーンショット 2025-07-31 234325" src="https://github.com/user-attachments/assets/f7189190-133c-4473-b8f4-7067c63000af" />

## 確認してほしいこと
Policyの書き方に少し不安があるのでご指摘ありましたらご教授いただきたいです。