### PR TITLE
coursesテーブルの受講期限カラム反映→講師側 講座登録APIの修正(智美)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -102,7 +102,8 @@ class CourseController extends Controller
                 title: $request->title,
                 image: $request->file('image'),
                 tagId: $request->tag_id,
-                instructorId: $instructorId
+                instructorId: $instructorId,
+                attendanceDeadline: $request->attendance_deadline
             );
 
             DB::commit();

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -91,14 +91,14 @@ class CourseController extends Controller
     /**
      * 講座登録API
      */
-    public function store(StoreRequest $request, StoreCourseService $storeCourseService): JsonResponse
+    public function store(StoreRequest $request, StoreCourseService $service): JsonResponse
     {
         DB::beginTransaction();
 
         $instructorId = Auth::guard('instructor')->user()->id;
 
         try {
-            $storeCourseService(
+            $service(
                 title: $request->title,
                 image: $request->file('image'),
                 tagId: $request->tag_id,

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -86,14 +86,14 @@ class CourseController extends Controller
     /**
      * 講座登録API
      */
-    public function store(StoreRequest $request, StoreCourseService $storeCourseService): JsonResponse
+    public function store(StoreRequest $request, StoreCourseService $service): JsonResponse
     {
         $managerId = Auth::guard('instructor')->user()->id;
 
         DB::beginTransaction();
 
         try {
-            $course = $storeCourseService(
+            $course = $service(
                 title: $request->title,
                 image: $request->file('image'),
                 tagId: $request->tag_id,

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -97,7 +97,8 @@ class CourseController extends Controller
                 title: $request->title,
                 image: $request->file('image'),
                 tagId: $request->tag_id,
-                instructorId: $managerId
+                instructorId: $managerId,
+                attendanceDeadline: $request->attendance_deadline
             );
 
             DB::commit();

--- a/app/Http/Requests/Instructor/Course/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Course/StoreRequest.php
@@ -27,7 +27,6 @@ class StoreRequest extends FormRequest
             'title' => ['required'],
             'image' => ['required', 'file', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
             'tag_id' => ['required', 'exists:tags,id'],
-            // 受講期限（任意）
             'attendance_deadline' => ['nullable', 'date', 'after_or_equal:today'],
         ];
     }

--- a/app/Http/Requests/Instructor/Course/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Course/StoreRequest.php
@@ -27,7 +27,7 @@ class StoreRequest extends FormRequest
             'title' => ['required'],
             'image' => ['required', 'file', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
             'tag_id' => ['required', 'exists:tags,id'],
-            'attendance_deadline' => ['nullable', 'date', 'after_or_equal:today'],
+            'attendance_deadline' => ['nullable', 'date_format:Y-m-d', 'after_or_equal:today'],
         ];
     }
 }

--- a/app/Http/Requests/Instructor/Course/StoreRequest.php
+++ b/app/Http/Requests/Instructor/Course/StoreRequest.php
@@ -27,6 +27,8 @@ class StoreRequest extends FormRequest
             'title' => ['required'],
             'image' => ['required', 'file', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
             'tag_id' => ['required', 'exists:tags,id'],
+            // 受講期限（任意）
+            'attendance_deadline' => ['nullable', 'date', 'after_or_equal:today'],
         ];
     }
 }

--- a/app/Http/Requests/Manager/Course/StoreRequest.php
+++ b/app/Http/Requests/Manager/Course/StoreRequest.php
@@ -24,8 +24,9 @@ class StoreRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => ['required', 'string', 'max:30'],
-            'image' => ['required', 'mimes:jpg,png', 'max:2048'],
+            'title' => ['required'],
+            'image' => ['required', 'file', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
+            'tag_id' => ['required', 'exists:tags,id'],
             'attendance_deadline' => ['nullable', 'date', 'after_or_equal:today'],
         ];
     }

--- a/app/Http/Requests/Manager/Course/StoreRequest.php
+++ b/app/Http/Requests/Manager/Course/StoreRequest.php
@@ -26,6 +26,7 @@ class StoreRequest extends FormRequest
         return [
             'title' => ['required', 'string', 'max:30'],
             'image' => ['required', 'mimes:jpg,png', 'max:2048'],
+            'attendance_deadline' => ['nullable', 'date', 'after_or_equal:today'],
         ];
     }
 }

--- a/app/Http/Requests/Manager/Course/StoreRequest.php
+++ b/app/Http/Requests/Manager/Course/StoreRequest.php
@@ -27,7 +27,7 @@ class StoreRequest extends FormRequest
             'title' => ['required'],
             'image' => ['required', 'file', 'image', 'mimes:jpeg,png,jpg', 'max:2048'],
             'tag_id' => ['required', 'exists:tags,id'],
-            'attendance_deadline' => ['nullable', 'date', 'after_or_equal:today'],
+            'attendance_deadline' => ['nullable', 'date_format:Y-m-d', 'after_or_equal:today'],
         ];
     }
 }

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -39,6 +39,7 @@ class Course extends Model
         'title',
         'image',
         'status',
+        'attendance_deadline',
     ];
 
     /**

--- a/app/Services/Course/StoreCourseService.php
+++ b/app/Services/Course/StoreCourseService.php
@@ -35,12 +35,13 @@ class StoreCourseService
         $tag = Tag::where('id', $tagId)
             ->where('instructor_id', $instructorId)
             ->first();
+
         if ($tag === null) {
             throw new NotFoundHttpException('Not Found Tag.');
         }
 
         // タグを中間テーブルに紐づける
-        $course->tags()->attach($tagId);
+        $course->tags()->attach($tag->id);
 
         return $course;
     }

--- a/app/Services/Course/StoreCourseService.php
+++ b/app/Services/Course/StoreCourseService.php
@@ -14,7 +14,7 @@ class StoreCourseService
     /**
      * 講座登録サービス
      */
-    public function __invoke(string $title, UploadedFile $image, int $tagId, int $instructorId): Course
+    public function __invoke(string $title, UploadedFile $image, int $tagId, int $instructorId, ?string $attendanceDeadline = null): Course
     {
         // ファイルパスを作成
         $extension = $image->getClientOriginalExtension();
@@ -28,6 +28,7 @@ class StoreCourseService
             'title' => $title,
             'image' => $filePath,
             'status' => Course::STATUS_PRIVATE,
+            'attendance_deadline' => $attendanceDeadline,
         ]);
 
         // ログイン中の講師が作成したタグかどうか確認

--- a/database/migrations/2022_10_19_215031_create_courses_table.php
+++ b/database/migrations/2022_10_19_215031_create_courses_table.php
@@ -19,11 +19,11 @@ class CreateCoursesTable extends Migration
             $table->string('title', 50)->comment('タイトル');
             $table->text('image')->comment('サムネイルファイルパス');
             $table->string('status', 30)->comment('ステータス');
+            $table->dateTime('attendance_deadline')->nullable()->comment('受講期限');
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
             $table->softDeletes();
             $table->foreign('instructor_id')->references('id')->on('instructors');
-            $table->dateTime('attendance_deadline')->nullable()->comment('受講期限');
         });
     }
 

--- a/database/migrations/2022_10_19_215031_create_courses_table.php
+++ b/database/migrations/2022_10_19_215031_create_courses_table.php
@@ -23,7 +23,7 @@ class CreateCoursesTable extends Migration
             $table->dateTime('updated_at');
             $table->softDeletes();
             $table->foreign('instructor_id')->references('id')->on('instructors');
-            $table->dateTime('attendance_deadline')->nullable();
+            $table->dateTime('attendance_deadline')->nullable()->comment('受講期限');
         });
     }
 

--- a/database/migrations/2022_10_19_215031_create_courses_table.php
+++ b/database/migrations/2022_10_19_215031_create_courses_table.php
@@ -23,6 +23,7 @@ class CreateCoursesTable extends Migration
             $table->dateTime('updated_at');
             $table->softDeletes();
             $table->foreign('instructor_id')->references('id')->on('instructors');
+            $table->dateTime('attendance_deadline')->nullable();
         });
     }
 

--- a/tests/Feature/Api/Instructor/Course/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Course/StoreTest.php
@@ -89,7 +89,7 @@ class StoreTest extends TestCase
             'title' => 'The title field is required.',
             'image' => 'The image field is required.',
             'tag_id' => 'The tag id field is required.',
-            'attendance_deadline' => 'The attendance deadline is not a valid date.',
+            'attendance_deadline' => 'The attendance deadline does not match the format Y-m-d.',
         ]);
     }
 }

--- a/tests/Feature/Api/Manager/Course/StoreTest.php
+++ b/tests/Feature/Api/Manager/Course/StoreTest.php
@@ -89,7 +89,7 @@ class StoreTest extends TestCase
             'title' => 'The title field is required.',
             'image' => 'The image field is required.',
             'tag_id' => 'The tag id field is required.',
-            'attendance_deadline' => 'The attendance deadline is not a valid date.',
+            'attendance_deadline' => 'The attendance deadline does not match the format Y-m-d.',
         ]);
     }
 }

--- a/tests/Feature/Api/Manager/Course/StoreTest.php
+++ b/tests/Feature/Api/Manager/Course/StoreTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api\Instructor\Course;
+namespace Tests\Feature\Api\Manager\Course;
 
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -22,16 +22,16 @@ class StoreTest extends TestCase
     public function test_講座登録_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(2);
+        $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
         $file = UploadedFile::fake()->image('test.jpg');
 
         // act
-        $response = $this->post('/api/v1/instructor/course', [
+        $response = $this->post('/api/v1/manager/course', [
             'title' => 'テスト講座',
             'image' => $file,
-            'tag_id' => 2,
+            'tag_id' => 1,
             'attendance_deadline' => now()->addDays(30)->format('Y-m-d'),
         ]);
 
@@ -43,23 +43,23 @@ class StoreTest extends TestCase
 
         $this->assertDatabaseHas('course_tag', [
             'course_id' => 8,
-            'tag_id' => 2,
+            'tag_id' => 1,
         ]);
     }
 
     public function test_無効なタグの指定_失敗(): void
     {
         // arrange
-        $instructor = Instructor::find(2);
+        $instructor = Instructor::find(1);
         $this->actingAs($instructor, 'instructor');
 
         $file = UploadedFile::fake()->image('test.jpg');
 
         // act
-        $response = $this->post('/api/v1/instructor/course', [
+        $response = $this->post('/api/v1/manager/course', [
             'title' => 'テスト講座',
             'image' => $file,
-            'tag_id' => 1,
+            'tag_id' => 2,
         ]);
 
         // assert
@@ -76,7 +76,7 @@ class StoreTest extends TestCase
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->post('/api/v1/instructor/course', [
+        $response = $this->post('/api/v1/manager/course', [
             'title' => '',
             'image' => null,
             'tag_id' => '',


### PR DESCRIPTION
## Jira
- JKA-1521

## 概要
- coursesテーブルの受講期限カラム反映→講師側 講座登録APIの修正

## 動作確認手順
- 下記でログイン(山田太郎)
email：test_instructor@example.com
pw：password

- POST：http://localhost:8080/api/v1/instructor/course
<img width="1183" height="583" alt="スクリーンショット 2025-08-04 220311" src="https://github.com/user-attachments/assets/48efe47d-1b60-4b2a-9c5e-9b0dbc5dd870" />

- attendance_deadlineが空白の場合
<img width="1178" height="536" alt="スクリーンショット 2025-08-04 220420" src="https://github.com/user-attachments/assets/5a6ad38e-47aa-48ca-b472-577cb7533f7f" />

- POST：http://localhost:8080/api/v1/manager/course
<img width="1179" height="687" alt="スクリーンショット 2025-08-05 070247" src="https://github.com/user-attachments/assets/56d8614e-68cd-4220-a905-a9fd8b3c26df" />

- attendance_deadlineが空白の場合
<img width="1176" height="681" alt="スクリーンショット 2025-08-05 070033" src="https://github.com/user-attachments/assets/b92dcb71-bffa-4214-be59-e4195887f338" />

## 考慮してほしいこと
attendance_deadlineカラムがmergeされていない為、作成してあります。
また、Manager側の動作確認をする際にScrambleではボディーがRawになっていましたが、imageのファイル指定をしないといけなかった為、instructor側と同じようにform-dataにて動作確認いたしました。

## 確認してほしいこと
Manager側の動作確認ですが、ScrambleとはResponses内容が少し異なっているのですが、Adminerにはちゃんとデータが反映されているのを確認したので動作確認としては大丈夫でしょうか？