### PR TITLE
NotificationControllerのputStatusメソッドのPolicyパターンを用いた認可処理の実装 (たつのり)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -28,7 +28,6 @@ use App\Services\Notification\StoreNotificationService;
 use App\Services\Notification\UpdateTypeAllService;
 use App\Services\Notification\UpdateTypeService;
 use Exception;
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -260,7 +259,6 @@ class NotificationController extends Controller
         $notificationIds = $request->input('notifications', []);
         $status = $request->input('status');
 
-        // Policy判定で使うので instructor_id を含めて取得
         $notifications = Notification::whereIn('id', $notificationIds)
             ->get(['id', 'instructor_id', 'status']);
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -256,31 +256,21 @@ class NotificationController extends Controller
      */
     public function putStatus(PutStatusRequest $request, PutStatusService $service): JsonResponse
     {
-        // ログインしている講師のIDを取得
-        $instructorId = Auth::guard('instructor')->user()->id;
-
         // 選択されたお知らせidを取得
         $notificationIds = $request->input('notifications', []);
-        $status = $request->status;
+        $status = $request->input('status');
 
-        // 選択されたお知らせを取得
-        $chosenNotifications = Notification::whereIn('id', $notificationIds)->pluck('instructor_id');
+        // Policy判定で使うので instructor_id を含めて取得
+        $notifications = Notification::whereIn('id', $notificationIds)
+            ->get(['id', 'instructor_id', 'status']);
 
-        // 選択されたお知らせの中に、講師と一致しないお知らせが、１つでも含まれている場合はエラー
-        if (
-            $chosenNotifications->contains(fn ($instructorIdFromNotificationsTable) => $instructorIdFromNotificationsTable !== $instructorId)
-        ) {
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        // 認可はPolicyへ一任
+        $this->authorize('bulkUpdate', [Notification::class, $notifications]);
 
         // トランザクション開始
         DB::beginTransaction();
 
         try {
-            $notifications = Notification::where('instructor_id', $instructorId)
-                ->whereIn('id', $notificationIds)
-                ->get(['id', 'instructor_id', 'status']);
-
             $service(
                 notifications: $notifications,
                 status: $status

--- a/app/Services/Notification/PutStatusAllService.php
+++ b/app/Services/Notification/PutStatusAllService.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 class PutStatusAllService
 {
     /**
-     * お知らせ内容を削除する
+     * お知らせのステータスを一括更新する
      *
      * @param  \Illuminate\Database\Eloquent\Collection<int, \App\Model\Notification>  $notifications
      */

--- a/tests/Feature/Api/Instructor/Notification/PutStatusTest.php
+++ b/tests/Feature/Api/Instructor/Notification/PutStatusTest.php
@@ -21,13 +21,13 @@ class PutStatusTest extends TestCase
     public function test_お知らせ更新_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
         $response = $this->putJson('/api/v1/instructor/notification/status', [
             'notifications' => [
-                1,
+                2,
             ],
             'status' => 'private',
         ]);
@@ -35,7 +35,7 @@ class PutStatusTest extends TestCase
         // assert
         $response->assertStatus(200);
         $this->assertDatabaseHas('notifications', [
-            'id' => 1,
+            'id' => 2,
             'status' => 'private',
         ]);
     }
@@ -43,7 +43,7 @@ class PutStatusTest extends TestCase
     public function test_権限がない講師_失敗(): void
     {
         // arrange
-        $instructor = Instructor::find(4);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
@@ -57,14 +57,14 @@ class PutStatusTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Invalid instructor_id.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 
     public function test_バリデーションエラー(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act


### PR DESCRIPTION
## issue
- JKA-1533 NotificationControllerのputStatusメソッドのPolicyパターンを用いた認可処理の実装

## 概要
- Instructor/ManagerのNotificationController@putstatusメソッドにおける認可処理を、Policy パターンを用いた実装に統一
- Manager側は既に実装済みだったため、修正はインストラクター側のみ実施

## 動作確認
### 【Manager】
- #### 自身及び配下の講師のお知らせの一括更新を確認

<img width="1829" height="171" alt="スクリーンショット 2025-08-10 203523" src="https://github.com/user-attachments/assets/17bcdfc8-0d3f-4fb5-bcd5-87f27359b018" />

<img width="1255" height="590" alt="スクリーンショット 2025-08-10 203504" src="https://github.com/user-attachments/assets/02082a5a-0808-4e7a-9765-49e6ef90dee7" />

<img width="1824" height="163" alt="スクリーンショット 2025-08-10 203540" src="https://github.com/user-attachments/assets/4678f66d-dfbe-473f-9d33-e521a465d658" />

### 【Instructor】
- #### 自身のお知らせの更新を確認
　
<img width="1255" height="590" alt="スクリーンショット 2025-08-10 204136" src="https://github.com/user-attachments/assets/897098ce-3bd5-4b2e-9eba-869339431311" />

- #### 権限外のお知らせの更新ができないこと(403 Forbidden)を確認

<img width="1261" height="568" alt="スクリーンショット 2025-08-10 204150" src="https://github.com/user-attachments/assets/2f89208b-2b59-4a25-9590-68690cce413f" />

## 確認してほしいこと
- 方針通りの実装になっているか
- 不備などはないか

