### PR TITLE
Student/AttendanceControllerのprogressメソッド他の認可チェックのPolicyパターン実装(たつのり)

### DIFF
--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -79,7 +79,6 @@ class AttendanceController extends Controller
      */
     public function progress(ProgressRequest $request): AttendanceCourseProgressResource
     {
-        $authId = Auth::id();
         $attendance = Attendance::with([
             'course.chapters.lessons',
             'lessonAttendances',
@@ -91,9 +90,8 @@ class AttendanceController extends Controller
             throw new AuthorizationException('The course has expired.');
         }
 
-        if ($authId !== $attendance->student_id) {
-            throw new AuthorizationException('Not authorized.');
-        }
+        // 本人チェックは Policy に委譲
+        $this->authorize('progress', $attendance);
 
         $progressData = [
             'completedChaptersCount' => $this->getCompletedChaptersCount($attendance),
@@ -114,16 +112,11 @@ class AttendanceController extends Controller
      */
     public function completeAllLessons(CompleteAllLessonsRequest $request): JsonResponse
     {
-        // ログイン中の生徒ID
-        $studentId = Auth::id();
-
         // 受講レコードを取得
         $attendance = Attendance::findOrFail($request->attendance_id);
 
-        // 認証チェック: この生徒が対象の受講レコードにアクセスできるか
-        if ($attendance->student_id !== $studentId) {
-            throw new AuthorizationException('Forbidden, invalid student.');
-        }
+        // 本人のみ更新可
+        $this->authorize('update', $attendance);
 
         // 該当チャプターを取得
         $chapter = Chapter::with('lessons')->findOrFail($request->chapter_id);
@@ -155,14 +148,10 @@ class AttendanceController extends Controller
      */
     public function completeAllChapters(CompleteAllChaptersRequest $request): JsonResponse
     {
-        $studentId = Auth::id();
-
         $attendance = Attendance::findOrFail($request->attendance_id);
 
-        if ($studentId !== $attendance->student_id) {
-            // ログインしている生徒が受講している講座ではない場合エラー応答
-            throw new AuthorizationException('Not authorized.');
-        }
+        // 本人のみ更新可
+        $this->authorize('update', $attendance);
 
         $lessonAttendanceIds = LessonAttendance::where('attendance_id', $attendance->id)
             ->pluck('id')

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -91,7 +91,7 @@ class AttendanceController extends Controller
         }
 
         // 本人チェックは Policy に委譲
-        $this->authorize('progress', $attendance);
+        $this->authorize('view', $attendance);
 
         $progressData = [
             'completedChaptersCount' => $this->getCompletedChaptersCount($attendance),

--- a/app/Http/Controllers/Api/Student/AttendanceController.php
+++ b/app/Http/Controllers/Api/Student/AttendanceController.php
@@ -90,7 +90,6 @@ class AttendanceController extends Controller
             throw new AuthorizationException('The course has expired.');
         }
 
-        // 本人チェックは Policy に委譲
         $this->authorize('view', $attendance);
 
         $progressData = [
@@ -115,7 +114,6 @@ class AttendanceController extends Controller
         // 受講レコードを取得
         $attendance = Attendance::findOrFail($request->attendance_id);
 
-        // 本人のみ更新可
         $this->authorize('update', $attendance);
 
         // 該当チャプターを取得

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Student;
 
 class AttendancePolicy
 {
@@ -40,5 +41,17 @@ class AttendancePolicy
 
         // マネージャー権限のない講師
         return $instructor->id === $attendance->course->instructor_id;
+    }
+
+    /** Student: 進捗閲覧（progress） */
+    public function progress(Student $student, Attendance $attendance): bool
+    {
+        return $attendance->student_id === $student->id;        
+    }
+
+    /** Student: 更新（completeAllLessons / completeAllChapters） */
+    public function update(Student $student, Attendance $attendance): bool
+    {
+        return $attendance->student_id === $student->id;
     }
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -10,6 +10,14 @@ use App\Model\Student;
 class AttendancePolicy
 {
     /**
+     * 閲覧権限
+     */
+    public function view(Student $student, Attendance $attendance): bool
+    {
+        return $attendance->student_id === $student->id;
+    }
+
+    /**
      * 受講作成時のポリシー
      */
     public function create(Instructor $instructor, Course $course): bool
@@ -27,7 +35,15 @@ class AttendancePolicy
     }
 
     /**
-     * 受講状況削除時のポリシー
+     * 更新権限
+     */
+    public function update(Student $student, Attendance $attendance): bool
+    {
+        return $attendance->student_id === $student->id;
+    }
+
+    /**
+     * 削除権限
      */
     public function delete(Instructor $instructor, Attendance $attendance): bool
     {
@@ -41,17 +57,5 @@ class AttendancePolicy
 
         // マネージャー権限のない講師
         return $instructor->id === $attendance->course->instructor_id;
-    }
-
-    /** Student: 進捗閲覧（progress） */
-    public function view(Student $student, Attendance $attendance): bool
-    {
-        return $attendance->student_id === $student->id;        
-    }
-
-    /** Student: 更新（completeAllLessons / completeAllChapters） */
-    public function update(Student $student, Attendance $attendance): bool
-    {
-        return $attendance->student_id === $student->id;
     }
 }

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -44,7 +44,7 @@ class AttendancePolicy
     }
 
     /** Student: 進捗閲覧（progress） */
-    public function progress(Student $student, Attendance $attendance): bool
+    public function view(Student $student, Attendance $attendance): bool
     {
         return $attendance->student_id === $student->id;        
     }

--- a/tests/Feature/Api/Student/Attendance/CompleteAllChaptersTest.php
+++ b/tests/Feature/Api/Student/Attendance/CompleteAllChaptersTest.php
@@ -47,7 +47,7 @@ class CompleteAllChaptersTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Not authorized.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 

--- a/tests/Feature/Api/Student/Attendance/CompleteAllLessonsTest.php
+++ b/tests/Feature/Api/Student/Attendance/CompleteAllLessonsTest.php
@@ -48,7 +48,7 @@ class CompleteAllLessonsTest extends TestCase
         // assert
         $response->assertStatus(403);
         $response->assertJson([
-            'message' => 'Forbidden, invalid student.',
+            'message' => 'This action is unauthorized.',
         ]);
     }
 


### PR DESCRIPTION
## issue
- JKA-1534 Student/AttendanceControllerのprogressメソッド他の認可チェックのPolicyパターン実装

## 概要
- Student/AttendanceControllerのprogress、completeAllLessons、completeAllChaptersの各メソッドの認可チェックを
Policyに委譲
- ログインユーザと受講者が合致の場合はtrue、不一致の場合は403エラーを返却

## 動作確認

### 1.受講講座の進捗状況
#### 【正常系】

<img width="1269" height="849" alt="スクリーンショット 2025-08-13 161247" src="https://github.com/user-attachments/assets/d2fc0b9d-1a09-43f8-aa25-46387cba3aaa" />

#### 【異常系】

<img width="1136" height="573" alt="スクリーンショット 2025-08-13 161611" src="https://github.com/user-attachments/assets/dbc09f36-2cba-4f4f-9c4c-315ae81288cb" />

### 2.全チャプター完了
#### 【正常系】

<img width="1262" height="585" alt="スクリーンショット 2025-08-13 162026" src="https://github.com/user-attachments/assets/b1696570-8016-4ea4-bcb4-fa752fde911a" />

#### 【異常系】

<img width="1246" height="567" alt="スクリーンショット 2025-08-13 162146" src="https://github.com/user-attachments/assets/8938999f-a94f-4b69-90a5-c462ebdf28a2" />

### 3.全レッスン完了
#### 【正常系】

<img width="1263" height="588" alt="スクリーンショット 2025-08-13 162835" src="https://github.com/user-attachments/assets/d5eea15c-3fc3-41d6-8edc-8d08a0d2945a" />

#### 【異常系】

<img width="1247" height="568" alt="スクリーンショット 2025-08-13 162853" src="https://github.com/user-attachments/assets/d4c2b330-99b9-405d-a6b7-75fa18f30481" />

## 確認してほしいこと
- 認可チェックの対象メソッドが正しいかどうか
- 記述内容に不備はないか