### PR TITLE
TagControllerのshowメソッドのPolicyパターンを用いた認可機能の実装 (たつのり)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/TagController.php
+++ b/app/Http/Controllers/Api/Instructor/TagController.php
@@ -90,13 +90,10 @@ class TagController extends Controller
      */
     public function show(ShowRequest $request)
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-
         $tag = Tag::findOrFail($request->tag_id);
 
-        if ($tag->instructor_id !== $instructorId) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        // 認可処理
+        $this->authorize('view', $tag);
 
         return new TagResource($tag);
     }

--- a/app/Http/Controllers/Api/Manager/TagController.php
+++ b/app/Http/Controllers/Api/Manager/TagController.php
@@ -106,17 +106,10 @@ class TagController extends Controller
      */
     public function show(ShowRequest $request): TagResource
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
-        $manager = Instructor::with('managings')->find($instructorId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $instructorId;
-
         $tag = Tag::findOrFail($request->tag_id);
 
-        if (! in_array($tag->instructor_id, $instructorIds, true)) {
-            // 自分、または配下の講師の講座でなければエラー応答
-            throw new AuthorizationException('Invalid instructor_id.');
-        }
+        // 認可処理
+        $this->authorize('view', $tag);
 
         return new TagResource($tag);
     }

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -8,6 +8,23 @@ use App\Model\Tag;
 class TagPolicy
 {
     /**
+     * タグの詳細機能に関する認可処理
+     */
+    public function view(Instructor $instructor, Tag $tag): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($tag->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $tag->instructor_id === $instructor->id;
+    }
+
+    /**
      * タグの削除機能に関する認可処理
      */
     public function delete(Instructor $instructor, Tag $tag)
@@ -28,23 +45,6 @@ class TagPolicy
      * タグの更新機能に関する認可処理
      */
     public function update(Instructor $instructor, Tag $tag): bool
-    {
-        // マネージャー権限のある講師か判定
-        if ($instructor->isManager()) {
-            $instructorIds = $instructor->managings->pluck('id')->toArray();
-            $instructorIds[] = $instructor->id;
-
-            return in_array($tag->instructor_id, $instructorIds, true);
-        }
-
-        // マネージャー権限のない講師
-        return $tag->instructor_id === $instructor->id;
-    }
-
-    /**
-     * タグの詳細機能に関する認可処理
-     */
-    public function view(Instructor $instructor, Tag $tag): bool
     {
         // マネージャー権限のある講師か判定
         if ($instructor->isManager()) {

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -57,5 +57,4 @@ class TagPolicy
         // マネージャー権限のない講師
         return $tag->instructor_id === $instructor->id;
     }
-
 }

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -40,4 +40,22 @@ class TagPolicy
         // マネージャー権限のない講師
         return $tag->instructor_id === $instructor->id;
     }
+
+    /**
+     * タグの詳細機能に関する認可処理
+     */
+    public function view(Instructor $instructor, Tag $tag): bool
+    {
+        // マネージャー権限のある講師か判定
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            return in_array($tag->instructor_id, $instructorIds, true);
+        }
+
+        // マネージャー権限のない講師
+        return $tag->instructor_id === $instructor->id;
+    }
+
 }

--- a/tests/Feature/Api/Instructor/Tag/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Tag/ShowTest.php
@@ -21,11 +21,11 @@ class ShowTest extends TestCase
     public function test_タグ取得_成功(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act
-        $response = $this->getJson('/api/v1/instructor/tag/1');
+        $response = $this->getJson('/api/v1/instructor/tag/2');
 
         // assert
         $response->assertStatus(200);
@@ -34,7 +34,7 @@ class ShowTest extends TestCase
     public function test_バリデーションエラー(): void
     {
         // arrange
-        $instructor = Instructor::find(1);
+        $instructor = Instructor::find(2);
         $this->actingAs($instructor, 'instructor');
 
         // act


### PR DESCRIPTION
## issue
- JKA-1515 TagControllerのshowメソッドのPolicyパターンを用いた認可機能の実装

## 概要
マネージャーと講師のTagController@showの認可処理をTagPolicy::viewに委譲

## 動作確認
### 【Manager】
#### 1.自身のタグ詳細取得を確認

<img width="1265" height="642" alt="スクリーンショット 2025-08-16 171939" src="https://github.com/user-attachments/assets/c6da4184-1f3e-441a-ba90-3fba67ac7660" />

#### 2.配下の講師のタグ詳細取得を確認

<img width="1267" height="644" alt="スクリーンショット 2025-08-16 171951" src="https://github.com/user-attachments/assets/ea09f498-4571-4ed2-aa3b-dcd7488d62c1" />

#### 3.権限外の講師のタグ詳細取得不可を確認

<img width="1256" height="576" alt="スクリーンショット 2025-08-16 172050" src="https://github.com/user-attachments/assets/a004a566-479b-4a0f-86c8-4c017a1dc71e" />


### 【Instructor】
#### 1.自身のタグ詳細取得を確認

<img width="1262" height="638" alt="スクリーンショット 2025-08-16 171735" src="https://github.com/user-attachments/assets/ad2faba6-a606-4eeb-9120-d808257802d4" />

#### 2.自身以外の講師のタグ詳細取得不可を確認

<img width="1255" height="572" alt="スクリーンショット 2025-08-16 171751" src="https://github.com/user-attachments/assets/76b4176e-d26c-4575-978a-c2b9d038d19a" />

## 確認してほしいこと
- タスクの方針に沿った実装内容になっているかどうか
- 不備などはないか

