### PR TITLE
講師側 お知らせ登録APIを修正して、受講期限切れの講座のお知らせを登録しようとした際にエラーを出力するように対応(智美)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -75,10 +75,10 @@ class NotificationController extends Controller
     {
         $course = Course::findOrFail($request->course_id);
 
-         // 受講期限チェック
+        // 受講期限チェック
         if ($course->attendance_deadline && now()->gt($course->attendance_deadline)) {
             return response()->json([
-                'message' => 'The course has expired.'
+                'message' => 'The course has expired.',
             ], 422); // 422 Unprocessable Entity
         }
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -75,13 +75,6 @@ class NotificationController extends Controller
     {
         $course = Course::findOrFail($request->course_id);
 
-         // 受講期限チェック
-        if ($course->attendance_deadline && now()->gt($course->attendance_deadline)) {
-            return response()->json([
-                'message' => 'The course has expired.'
-            ], 422); // 422 Unprocessable Entity
-        }
-
         // Policyによる認可チェック
         $this->authorize('store', [Notification::class, $course]);
 

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -75,6 +75,13 @@ class NotificationController extends Controller
     {
         $course = Course::findOrFail($request->course_id);
 
+         // 受講期限チェック
+        if ($course->attendance_deadline && now()->gt($course->attendance_deadline)) {
+            return response()->json([
+                'message' => 'The course has expired.'
+            ], 422); // 422 Unprocessable Entity
+        }
+
         // Policyによる認可チェック
         $this->authorize('store', [Notification::class, $course]);
 

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -148,4 +148,14 @@ class Course extends Model
             'attendance_deadline' => 'immutable_datetime',
         ];
     }
+
+    /**
+     * 受講期限を当日 23:59:59 に揃えて返す
+     */
+    public function getAttendanceDeadlineEndAttribute(): ?\Carbon\CarbonImmutable
+    {
+        return $this->attendance_deadline
+            ? $this->attendance_deadline->endOfDay()
+            : null;
+    }
 }

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -152,7 +152,7 @@ class Course extends Model
     /**
      * 受講期限を当日 23:59:59 に揃えて返す
      */
-    public function getAttendanceDeadlineEndAttribute(): ?\Carbon\CarbonImmutable
+    public function getAttendanceDeadlineEndAttribute(): ?CarbonImmutable
     {
         return $this->attendance_deadline
             ? $this->attendance_deadline->endOfDay()

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -6,6 +6,8 @@ use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
 use Illuminate\Database\Eloquent\Collection;
+use Carbon\CarbonImmutable;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class NotificationPolicy
 {
@@ -114,6 +116,11 @@ class NotificationPolicy
      */
     public function store(Instructor $instructor, Course $course): bool
     {
+        // 受講期限チェック
+        if ($course->attendance_deadline_end && CarbonImmutable::now()->gte($course->attendance_deadline_end)) {
+            throw new AuthorizationException('The course has expired.');
+        }
+
         if ($instructor->isManager()) {
             // 管理者の場合、配下の講師の講座も可能
             $instructorIds = $instructor->managings->pluck('id')->toArray();

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -5,9 +5,9 @@ namespace App\Policies;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
-use Illuminate\Database\Eloquent\Collection;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Collection;
 
 class NotificationPolicy
 {

--- a/tests/Feature/Api/Instructor/Notification/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Notification/StoreTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api\Instructor\Notification;
 
 use App\Enums\Notification\TypeEnum;
+use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -45,6 +46,30 @@ class StoreTest extends TestCase
             'end_date' => '2022-01-02 00:00:00',
             'content' => 'content',
             'status' => 'private',
+        ]);
+    }
+
+    public function test_期限切れの講座_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        Course::find(6)->update(['attendance_deadline' => now()->subDays(1)]);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/6/notification', [
+            'title' => 'title',
+            'type' => 'always',
+            'start_date' => '2022-01-01 00:00:00',
+            'end_date' => '2022-01-02 00:00:00',
+            'content' => 'content',
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'The course has expired.',
         ]);
     }
 

--- a/tests/Feature/Api/Manager/Notification/StoreTest.php
+++ b/tests/Feature/Api/Manager/Notification/StoreTest.php
@@ -49,6 +49,30 @@ class StoreTest extends TestCase
         ]);
     }
 
+    public function test_期限切れの講座_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        Course::find(1)->update(['attendance_deadline' => now()->subDays(1)]);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/1/notification', [
+            'title' => 'title',
+            'type' => 'always',
+            'start_date' => '2022-01-01 00:00:00',
+            'end_date' => '2022-01-02 00:00:00',
+            'content' => 'content',
+            'status' => 'private',
+        ]);
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'The course has expired.',
+        ]);
+    }
+
     public function test_お知らせ登録_バリデーションエラー(): void
     {
         // arrange


### PR DESCRIPTION
## Jira
- JKA-1541

## 概要
- 講師側 お知らせ登録APIを修正して、受講期限切れの講座のお知らせを登録しようとした際にエラーを出力するように対応(智美)

## 動作確認手順
- 下記でログイン（山田太郎）
test_instructor@example.com
password

- POST：http://localhost:8080/api/v1/instructor/course/999/notification
<img width="1297" height="568" alt="スクリーンショット 2025-08-16 232856" src="https://github.com/user-attachments/assets/64fb5040-583a-4d27-944f-f640c63c2b2a" />

## 確認してほしいこと
動作確認はしていますが、再度、ご確認をお願いいたします。