### PR TITLE
マネージャー側 講師一覧APIを修正して、受講期限切れの講座の受講生は「受講中受講生数」に含めないように修正(ちゃこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -18,6 +18,7 @@ use App\Services\Auth\CredentialGeneratorService;
 use App\Services\Instructor\StoreService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -33,37 +34,9 @@ use RuntimeException;
 class InstructorController extends Controller
 {
     /**
-     * 講師情報取得API
-     *
-     * @return InstructorShowResource|\Illuminate\Http\JsonResponse
-     */
-    public function show(ShowRequest $request)
-    {
-        $managerId = Auth::guard('instructor')->user()->id;
-
-        // 配下の講師情報を取得
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrFail($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
-        // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
-        if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, not allowed to this instructor.');
-        }
-
-        /** @var Instructor $instructor */
-        $instructor = Instructor::findOrFail($request->instructor_id);
-
-        return new InstructorShowResource($instructor);
-    }
-
-    /**
      * 講師一覧取得API
-     *
-     * @return InstructorIndexResource
      */
-    public function index(IndexRequest $request)
+    public function index(IndexRequest $request): InstructorIndexResource
     {
         // デフォルト値を設定
         $perPage = $request->input('per_page', 20);
@@ -82,9 +55,9 @@ class InstructorController extends Controller
         // 講師情報を取得
         $instructors = Instructor::whereIn('id', $instructorIds)
             ->withCount([
-                'courses as student_count' => function ($query) {
+                'courses as student_count' => function (Builder $query) {
                     $query->join('attendances', 'courses.id', '=', 'attendances.course_id')
-                        ->where(function ($query) {
+                        ->where(function (Builder $query) {
                             $query->whereNull('courses.attendance_deadline')
                                 ->orWhere('courses.attendance_deadline', '>', now());
                         })
@@ -98,63 +71,27 @@ class InstructorController extends Controller
     }
 
     /**
-     * 講師更新API
-     *
-     * @return \Illuminate\Http\JsonResponse
+     * 講師情報取得API
      */
-    public function update(UpdateRequest $request)
+    public function show(ShowRequest $request): InstructorShowResource
     {
-        // マネージャーと配下の講師情報を取得
-        $managerId = $request->user()->id;
+        $managerId = Auth::guard('instructor')->user()->id;
 
+        // 配下の講師情報を取得
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->findOrFail($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $manager->id;
 
-        try {
-            /** @var Instructor $instructor */
-            $instructor = Instructor::FindOrFail($request->instructor_id);
-
-            // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
-            if (! in_array($instructor->id, $instructorIds, true)) {
-                throw new AuthorizationException('Forbidden, not allowed to this instructor.');
-            }
-
-            // 更新前の画像情報を取得
-            $imagePath = $instructor->profile_image;
-            $file = $request->file('profile_image');
-
-            if (isset($file)) {
-                // 更新前の画像ファイルを削除
-                if (Storage::disk('public')->exists($instructor->profile_image)) {
-                    Storage::disk('public')->delete($instructor->profile_image);
-                }
-
-                // 画像ファイルを保存
-                $extension = $file->getClientOriginalExtension();
-                $filename = Str::uuid()->toString().'.'.$extension;
-                $imagePath = Storage::disk('public')->putFileAs('instructor', $file, $filename);
-            }
-
-            $instructor->update([
-                'nick_name' => $request->nick_name,
-                'last_name' => $request->last_name,
-                'first_name' => $request->first_name,
-                'email' => $request->email,
-                'profile_image' => $imagePath,
-            ]);
-
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (RuntimeException $e) {
-            Log::error($e);
-
-            return response()->json([
-                'result' => false,
-            ], 500);
+        // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+        if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
+            throw new AuthorizationException('Forbidden, not allowed to this instructor.');
         }
+
+        /** @var Instructor $instructor */
+        $instructor = Instructor::findOrFail($request->instructor_id);
+
+        return new InstructorShowResource($instructor);
     }
 
     /**
@@ -225,6 +162,64 @@ class InstructorController extends Controller
             DB::rollBack();
             Log::error($e);
             throw $e;
+        }
+    }
+
+    /**
+     * 講師更新API
+     */
+    public function update(UpdateRequest $request): JsonResponse
+    {
+        // マネージャーと配下の講師情報を取得
+        $managerId = $request->user()->id;
+
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->findOrFail($managerId);
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        try {
+            /** @var Instructor $instructor */
+            $instructor = Instructor::FindOrFail($request->instructor_id);
+
+            // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+            if (! in_array($instructor->id, $instructorIds, true)) {
+                throw new AuthorizationException('Forbidden, not allowed to this instructor.');
+            }
+
+            // 更新前の画像情報を取得
+            $imagePath = $instructor->profile_image;
+            $file = $request->file('profile_image');
+
+            if (isset($file)) {
+                // 更新前の画像ファイルを削除
+                if (Storage::disk('public')->exists($instructor->profile_image)) {
+                    Storage::disk('public')->delete($instructor->profile_image);
+                }
+
+                // 画像ファイルを保存
+                $extension = $file->getClientOriginalExtension();
+                $filename = Str::uuid()->toString().'.'.$extension;
+                $imagePath = Storage::disk('public')->putFileAs('instructor', $file, $filename);
+            }
+
+            $instructor->update([
+                'nick_name' => $request->nick_name,
+                'last_name' => $request->last_name,
+                'first_name' => $request->first_name,
+                'email' => $request->email,
+                'profile_image' => $imagePath,
+            ]);
+
+            return response()->json([
+                'result' => true,
+            ]);
+        } catch (RuntimeException $e) {
+            Log::error($e);
+
+            return response()->json([
+                'result' => false,
+            ], 500);
         }
     }
 }

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -84,6 +84,10 @@ class InstructorController extends Controller
             ->withCount([
                 'courses as student_count' => function ($query) {
                     $query->join('attendances', 'courses.id', '=', 'attendances.course_id')
+                        ->where(function ($query) {
+                            $query->whereNull('courses.attendance_deadline')
+                                ->orWhere('courses.attendance_deadline', '>', now());
+                        })
                         ->select(DB::raw('COUNT(DISTINCT attendances.student_id)'));
                 },
             ])

--- a/app/Http/Resources/Manager/InstructorIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorIndexResource.php
@@ -26,7 +26,6 @@ class InstructorIndexResource extends JsonResource
                 'nick_name' => $instructor->nick_name,
                 'email' => $instructor->email,
                 'profile_image' => $instructor->profile_image,
-                'created_at' => $instructor->created_at,
                 'course_count' => $instructor->courses()->count(),
                 'student_count' => $instructor->student_count ?? 0,
             ]),

--- a/tests/Feature/Api/Manager/Instructor/IndexTest.php
+++ b/tests/Feature/Api/Manager/Instructor/IndexTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Instructor;
+
+use App\Model\Course;
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師講座一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/index');
+
+        // assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data.instructors');
+        $response->assertJson([
+            'data' => [
+                'instructors' => [
+                    [
+                        'instructor_id' => 3,
+                        'nick_name' => 'Suzuki',
+                        'email' => 'test_instructor3@example.com',
+                        'profile_image' => null,
+                        'course_count' => 2,
+                        'student_count' => 0,
+                    ],
+                    [
+                        'instructor_id' => 2,
+                        'nick_name' => 'Hanako',
+                        'email' => 'test_instructor2@example.com',
+                        'profile_image' => null,
+                        'course_count' => 2,
+                        'student_count' => 1,
+                    ],
+                ],
+                'pagination' => [
+                    'page' => 1,
+                    'total' => 2,
+                ],
+            ],
+        ]);
+    }
+
+    public function test_期限切れの講座が存在_講師講座一覧取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        Course::find(6)->update(['attendance_deadline' => now()->subDays(1)]); // 期限切れの講座を設定
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/index');
+
+        // assert
+        $response->dump();
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data.instructors');
+        $response->assertJson([
+            'data' => [
+                'instructors' => [
+                    [
+                        'instructor_id' => 3,
+                        'nick_name' => 'Suzuki',
+                        'email' => 'test_instructor3@example.com',
+                        'profile_image' => null,
+                        'course_count' => 2,
+                        'student_count' => 0,
+                    ],
+                    [
+                        'instructor_id' => 2,
+                        'nick_name' => 'Hanako',
+                        'email' => 'test_instructor2@example.com',
+                        'profile_image' => null,
+                        'course_count' => 2,
+                        'student_count' => 1,
+                    ],
+                ],
+                'pagination' => [
+                    'page' => 1,
+                    'total' => 2,
+                ],
+            ],
+        ]);
+    }
+
+    public function test_マネージャーではない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/aaa/course/index');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+}


### PR DESCRIPTION
## JIRA
- [JKA-1542]マネージャー側 講師一覧APIを修正して、受講期限切れの講座の受講生は「受講中受講生数」に含めないように修正

## 概要
- マネージャーが講師一覧を確認する際、「受講中受講生数（student_count）」に受講期限切れの講座の受講生が含まれていたため、これを除外するようにロジックを修正しました。

## 動作確認手順
1. 講師に紐づく講座の attendance_deadline を過去日時に設定
2. 対象講師の student_count の数字が変わることを Postman にて確認
3. attendance_deadline が NULL または未来日時の場合は、student_count に反映されることを確認

<img width="917" height="778" alt="スクリーンショット 2025-08-18 6 33 29" src="https://github.com/user-attachments/assets/b0e85608-3758-4afa-b376-53c663091906" />


対象スクランブル：
http://localhost:8080/docs/api#/operations/instructor.index

## 考慮してほしいこと
- 講座の attendance_deadline が NULL の場合は「期限なし」と判断し、student_count に含めています

## 確認してほしいこと
- student_count のカウントロジックが仕様通りであるか
- 他の影響範囲がないか（例：講師一覧表示）
