### PR TITLE
マネージャー側 受講状況取得APIを修正して、受講期限切れの講座は受講状況取得APIの中に含めないように修正（智美）

### DIFF
--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -6,6 +6,7 @@ use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Student;
+use App\Services\Course\AttendanceDeadlineValidator;
 
 class AttendancePolicy
 {
@@ -27,8 +28,10 @@ class AttendancePolicy
      */
     public function view(Instructor $instructor, Course $course): bool
     {
+        $validator = new AttendanceDeadlineValidator();
+        
         // 期限切れならNG
-        if ($course->attendance_deadline_end && now()->greaterThan($course->attendance_deadline_end)) {
+        if (!$validator($course)) {
             return false;
         }
         

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -31,7 +31,7 @@ class AttendancePolicy
         if ($course->attendance_deadline_end && now()->greaterThan($course->attendance_deadline_end)) {
             return false;
         }
-        
+
         if ($instructor->isManager()) {
             $instructorIds = $instructor->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -28,10 +28,10 @@ class AttendancePolicy
      */
     public function view(Instructor $instructor, Course $course): bool
     {
-        $validator = new AttendanceDeadlineValidator();
-        
+        $validator = new AttendanceDeadlineValidator;
+
         // 期限切れならNG
-        if (!$validator($course)) {
+        if (! $validator(course: $course)) {
             return false;
         }
 

--- a/app/Policies/AttendancePolicy.php
+++ b/app/Policies/AttendancePolicy.php
@@ -27,6 +27,11 @@ class AttendancePolicy
      */
     public function view(Instructor $instructor, Course $course): bool
     {
+        // 期限切れならNG
+        if ($course->attendance_deadline_end && now()->greaterThan($course->attendance_deadline_end)) {
+            return false;
+        }
+        
         if ($instructor->isManager()) {
             $instructorIds = $instructor->managings->pluck('id')->toArray();
             $instructorIds[] = $instructor->id;

--- a/app/Services/Course/AttendanceDeadlineValidator.php
+++ b/app/Services/Course/AttendanceDeadlineValidator.php
@@ -3,22 +3,20 @@
 namespace App\Services\Course;
 
 use App\Model\Course;
-use Illuminate\Support\Carbon;
+use Carbon\CarbonImmutable;
 
 class AttendanceDeadlineValidator
 {
     /**
-     * 受講期限チェック
-     *
-     * @param  Course  $course
-     * @return bool
+     * 受講期限の検証
+     * 期限内の場合は true、期限切れの場合は false を返す
      */
     public function __invoke(Course $course): bool
     {
-        if (!$course->attendance_deadline_end) {
+        if (! $course->attendance_deadline_end) {
             return true;
         }
 
-        return now()->lessThanOrEqualTo($course->attendance_deadline_end);
+        return CarbonImmutable::now()->lessThanOrEqualTo($course->attendance_deadline_end);
     }
 }

--- a/app/Services/Course/AttendanceDeadlineValidator.php
+++ b/app/Services/Course/AttendanceDeadlineValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\Course;
+
+use App\Model\Course;
+use Illuminate\Support\Carbon;
+
+class AttendanceDeadlineValidator
+{
+    /**
+     * 受講期限チェック
+     *
+     * @param  Course  $course
+     * @return bool
+     */
+    public function __invoke(Course $course): bool
+    {
+        if (!$course->attendance_deadline_end) {
+            return true;
+        }
+
+        return now()->lessThanOrEqualTo($course->attendance_deadline_end);
+    }
+}


### PR DESCRIPTION
## Jira
- JKA-1545

## 概要
マネージャー側 受講状況取得APIを修正して、受講期限切れの講座は受講状況取得APIの中に含めないように修正

## 動作確認手順
- 下記でログイン(山田太郎)
test_instructor@example.com
password

- GET：http://localhost:8080/api/v1/manager/course/1/attendance/status
- 受講期限内
<img width="1471" height="900" alt="スクリーンショット 2025-08-20 031606" src="https://github.com/user-attachments/assets/72196eda-c0dc-44e7-bd30-61865f01f005" />

- 受講期限切れ
<img width="1477" height="872" alt="スクリーンショット 2025-08-20 031806" src="https://github.com/user-attachments/assets/1445fbe0-2c2f-469f-b619-98afd87a707e" />

- 受講期限なし
<img width="1466" height="622" alt="スクリーンショット 2025-08-20 031721" src="https://github.com/user-attachments/assets/bb6af53c-46b8-42c5-94e2-ce16a5259573" />

## 考慮してほしいこと
動作確認はAdminerを直接編集して確認しています。

## 確認してほしいこと
Controllerではなく、Policyに組み込む形の実装をしたのですが、これでよかったでしょうか？
また、タスク内容の意図と違っていましたら、ご教授いただきたいです。