### PR TITLE
JKA-1520 coursesテーブルの受講期限カラム反映→講師側 講座更新APIの修正

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -138,6 +138,7 @@ class CourseController extends Controller
                 title: $request->title,
                 imageFile: $request->file('image'),
                 status: $request->status,
+                attendanceDeadline: $request->attendance_deadline
             );
 
             DB::commit();

--- a/app/Http/Requests/Instructor/Course/UpdateRequest.php
+++ b/app/Http/Requests/Instructor/Course/UpdateRequest.php
@@ -37,6 +37,7 @@ class UpdateRequest extends FormRequest
             'title' => ['required', 'string'],
             'image' => ['mimes:jpg,png'],
             'status' => ['required', 'string', new CourseStatusRule],
+            'attendance_deadline' => ['nullable', 'date_format:Y-m-d', 'after_or_equal:today'],
         ];
     }
 }

--- a/app/Services/Course/UpdateCourseService.php
+++ b/app/Services/Course/UpdateCourseService.php
@@ -16,7 +16,8 @@ class UpdateCourseService
         Course $course,
         string $title,
         ?UploadedFile $imageFile,
-        string $status
+        string $status,
+        ?string $attendanceDeadline = null
     ): void {
         $imagePath = $this->getImagePath($course, $imageFile);
         // 講座を更新
@@ -24,6 +25,7 @@ class UpdateCourseService
             'title' => $title,
             'image' => $imagePath,
             'status' => $status,
+            'attendance_deadline' => $attendanceDeadline,
         ]);
     }
 


### PR DESCRIPTION
## Jila
- JKA-1520

## 概要
- coursesテーブルの受講期限カラム反映→講師側 講座更新APIの修正

## 動作確認手順
- test_instructor2@example.comでログイン
- password→password
- POST：http://localhost:8080/api/v1/instructor/course/2
-  受講期限を入力した場合

<img width="1512" height="982" alt="スクリーンショット 2025-08-25 22 22 12" src="https://github.com/user-attachments/assets/a9297d60-ff5b-4f8a-b034-240a796ae76a" />

- 受講期限を入力しなかった場合

<img width="1512" height="982" alt="スクリーンショット 2025-08-25 22 21 44" src="https://github.com/user-attachments/assets/0247c0b4-7e1c-45f3-91ed-387fe320fdf1" />

## 考慮して欲しいこと
- 今回は日付のみにしておりますので時間のところが00:00:00になります！

## 確認して欲しいこと
- 足りないことはないか、記述方法は合っているのか。