### PR TITLE
マネージャー側 講座更新APIの修正 講座の受講期限の新設定「受講開始から⚪︎ヶ月有効」などを考慮して対応(智美)

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -136,6 +136,9 @@ class CourseController extends Controller
                 title: $request->title,
                 imageFile: $request->file('image'),
                 status: $request->status,
+                deadlineType: DeadlineTypeEnum::from($request->deadline_type),
+                fixedDate: $request->fixed_date,
+                relativeDays: $request->relative_days,
             );
 
             DB::commit();

--- a/app/Http/Requests/Manager/Course/UpdateRequest.php
+++ b/app/Http/Requests/Manager/Course/UpdateRequest.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests\Manager\Course;
 
 use App\Rules\CourseStatusRule;
+use App\Enums\Course\DeadlineTypeEnum;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
 
 class UpdateRequest extends FormRequest
 {
@@ -37,7 +39,7 @@ class UpdateRequest extends FormRequest
             'title' => ['required', 'string'],
             'image' => ['mimes:jpg,png'],
             'status' => ['required', 'string', new CourseStatusRule],
-            'deadline_type' => ['required', 'string', 'in:none,fixed_date,relative_days'],
+            'deadline_type' => ['required', new Enum(DeadlineTypeEnum::class)],
             'fixed_date' => ['nullable', 'date_format:Y-m-d'],
             'relative_days' => ['nullable', 'integer', 'min:1'],
         ];

--- a/app/Http/Requests/Manager/Course/UpdateRequest.php
+++ b/app/Http/Requests/Manager/Course/UpdateRequest.php
@@ -37,6 +37,9 @@ class UpdateRequest extends FormRequest
             'title' => ['required', 'string'],
             'image' => ['mimes:jpg,png'],
             'status' => ['required', 'string', new CourseStatusRule],
+            'deadline_type' => ['required', 'string', 'in:none,fixed_date,relative_days'],
+            'fixed_date' => ['nullable', 'date_format:Y-m-d'],
+            'relative_days' => ['nullable', 'integer', 'min:1'],
         ];
     }
 }

--- a/app/Http/Requests/Manager/Course/UpdateRequest.php
+++ b/app/Http/Requests/Manager/Course/UpdateRequest.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Requests\Manager\Course;
 
-use App\Rules\CourseStatusRule;
 use App\Enums\Course\DeadlineTypeEnum;
+use App\Rules\CourseStatusRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Enum;
 

--- a/tests/Feature/Api/Manager/Course/UpdateTest.php
+++ b/tests/Feature/Api/Manager/Course/UpdateTest.php
@@ -19,7 +19,7 @@ class UpdateTest extends TestCase
         $this->seed();
     }
 
-    public function test_講座更新_成功(): void
+    public function test_受講期限なし_講座更新_成功(): void
     {
         // arrange
         $instructor = Instructor::find(1);
@@ -32,6 +32,7 @@ class UpdateTest extends TestCase
             'title' => 'テスト講座',
             'image' => $file,
             'status' => 'private',
+            'deadline_type' => 'none',
         ]);
 
         // assert
@@ -40,6 +41,69 @@ class UpdateTest extends TestCase
             'id' => 1,
             'title' => 'テスト講座',
             'status' => 'private',
+        ]);
+        $this->assertDatabaseMissing('course_deadlines', [
+            'course_id' => 1,
+        ]);
+    }
+
+    public function test_固定受講期限あり_講座更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/manager/course/1', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'status' => 'private',
+            'deadline_type' => 'fixed_date',
+            'fixed_date' => now()->addDays(30)->format('Y-m-d'),
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('courses', [
+            'id' => 1,
+            'title' => 'テスト講座',
+            'status' => 'private',
+        ]);
+        $this->assertDatabaseHas('course_deadlines', [
+            'course_id' => 1,
+            'fixed_date' => now()->addDays(30)->format('Y-m-d'),
+        ]);
+    }
+
+    public function test_相対受講期限あり_講座更新_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        $file = UploadedFile::fake()->image('test.jpg');
+
+        // act
+        $response = $this->post('/api/v1/manager/course/1', [
+            'title' => 'テスト講座',
+            'image' => $file,
+            'status' => 'private',
+            'deadline_type' => 'relative_days',
+            'relative_days' => 30,
+        ]);
+
+        // assert
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('courses', [
+            'id' => 1,
+            'title' => 'テスト講座',
+            'status' => 'private',
+        ]);
+        $this->assertDatabaseHas('course_deadlines', [
+            'course_id' => 1,
+            'relative_days' => 30,
         ]);
     }
 
@@ -56,6 +120,7 @@ class UpdateTest extends TestCase
             'title' => 'テスト講座',
             'image' => $file,
             'status' => 'private',
+            'deadline_type' => 'none',
         ]);
 
         // assert
@@ -77,6 +142,7 @@ class UpdateTest extends TestCase
             'title' => 'テスト講座',
             'image' => $file,
             'status' => 'private',
+            'deadline_type' => 'none',
         ]);
 
         // assert
@@ -97,12 +163,17 @@ class UpdateTest extends TestCase
             'title' => '', // 空のタイトル
             'image' => null, // 画像なし
             'status' => 'invalid_status', // 無効なステータス
+            'deadline_type' => '',
         ]);
 
         // assert
         $response->assertStatus(422);
         $response->assertJsonValidationErrors([
-            'course_id', 'title', 'image', 'status',
+            'course_id',
+            'title',
+            'image',
+            'status',
+            'deadline_type',
         ]);
     }
 }


### PR DESCRIPTION
## Jira
- JKA-1554

## 概要
- マネージャー側 講座更新APIの修正 講座の受講期限の新設定「受講開始から⚪︎ヶ月有効」などを考慮して対応

## 動作確認手順
下記でログイン（山田太郎）
test_instructor@example.com
password

- POST：http://localhost:8080/api/v1/manager/course/1
- 受講期限なし
<img width="1370" height="712" alt="スクリーンショット 2025-08-29 130915" src="https://github.com/user-attachments/assets/57ba4857-5f22-4096-b5ce-1d18360b0858" />
Adminerのcourse_deadlinesにレコードが追加されないことを確認


- 受講期限あり（固定日）
<img width="1373" height="698" alt="スクリーンショット 2025-08-29 131136" src="https://github.com/user-attachments/assets/3a7a457c-7ab1-4432-af0a-3be1e90e2ba2" />

- 受講期限あり（受講開始から30日後など）
<img width="1372" height="705" alt="スクリーンショット 2025-08-29 131239" src="https://github.com/user-attachments/assets/b84595fd-f3b2-441d-a5fc-a7c65eaca406" />

## 考慮してほしいこと
今回、UpdateService.phpに、
 
```php
$course->courseDeadline()->updateOrCreate(
            ['course_id' => $course->id],
            [
                'fixed_date' => $deadlineType === DeadlineTypeEnum::FIXED_DATE ? $fixedDate : null,
                'relative_days' => $deadlineType === DeadlineTypeEnum::RELATIVE_DAYS ? $relativeDays : null,
            ]
        );
``` 
この記述があった為、UpdateService.phpは触っておりません。

## 確認してほしいこと
動作確認はしていますが、再度、ご確認の程、よろしくお願いいたします。