### PR TITLE
マネージャー側 講座一覧APIの修正 講座の受講期限の新設定「受講開始から⚪︎ヶ月有効」などを考慮して対応(ちゃこ)

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -51,7 +51,7 @@ class CourseController extends Controller
         $instructorIds[] = $instructorId;
 
         // 自分、または配下の講師の講座情報を取得
-        $courses = Course::with('instructor', 'tags')
+        $courses = Course::with('instructor', 'tags', 'courseDeadline:id,course_id,fixed_date,relative_days',)
             ->whereIn('instructor_id', $instructorIds)
             ->when($tagId, fn (Builder $q) => $q->whereHas('tags', fn (Builder $q) => $q->where('tags.id', $tagId)))
             ->when($searchWord, function (Builder $query) use ($searchWord) {

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -51,7 +51,7 @@ class CourseController extends Controller
         $instructorIds[] = $instructorId;
 
         // 自分、または配下の講師の講座情報を取得
-        $courses = Course::with('instructor', 'tags', 'courseDeadline:id,course_id,fixed_date,relative_days',)
+        $courses = Course::with('instructor', 'tags', 'courseDeadline')
             ->whereIn('instructor_id', $instructorIds)
             ->when($tagId, fn (Builder $q) => $q->whereHas('tags', fn (Builder $q) => $q->where('tags.id', $tagId)))
             ->when($searchWord, function (Builder $query) use ($searchWord) {

--- a/app/Http/Resources/Manager/CourseIndexResource.php
+++ b/app/Http/Resources/Manager/CourseIndexResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Manager;
 
+use App\Enums\Course\DeadlineTypeEnum;
 use App\Http\Resources\Base\Instructor\CourseResource;
 use App\Http\Resources\Base\Instructor\TagResource;
 use App\Http\Resources\Base\Student\InstructorResource;
@@ -22,11 +23,43 @@ class CourseIndexResource extends JsonResource
     #[\Override]
     public function toArray(Request $request): array
     {
+        $course = $this->resource;
+
         return [
             ...(new CourseResource($this->resource))->toArray($request),
             'instructor' => new InstructorResource($this->resource->instructor),
             'has_active_students' => $this->resource->attendances()->exists(),
             'tags' => TagResource::collection($this->resource['tags']),
+            'deadline' => $this->buildDeadlinePayload($course),
         ];
+    }
+
+    /**
+     * 期限情報（none / fixed_date / relative_days）を統一フォーマットで生成
+     *
+     * @return array{deadline_type:string,fixed_date:?string,relative_days:?int}
+     */
+    private function buildDeadlinePayload(Course $course): array
+    {
+        $enum = DeadlineTypeEnum::tryFrom($course->deadline_type) ?? DeadlineTypeEnum::NONE;
+        $rel  = $course->courseDeadline;
+
+        return match ($enum) {
+            DeadlineTypeEnum::FIXED_DATE => [
+                'deadline_type' => $enum->value,
+                'fixed_date'    => $rel?->fixed_date ? (string) $rel->fixed_date : null,
+                'relative_days' => null,
+            ],
+            DeadlineTypeEnum::RELATIVE_DAYS => [
+                'deadline_type' => $enum->value,
+                'fixed_date'    => null,
+                'relative_days' => is_null($rel?->relative_days) ? null : (int) $rel->relative_days,
+            ],
+            default => [
+                'deadline_type' => DeadlineTypeEnum::NONE->value,
+                'fixed_date'    => null,
+                'relative_days' => null,
+            ],
+        };
     }
 }

--- a/app/Http/Resources/Manager/CourseIndexResource.php
+++ b/app/Http/Resources/Manager/CourseIndexResource.php
@@ -2,11 +2,9 @@
 
 namespace App\Http\Resources\Manager;
 
-use App\Enums\Course\DeadlineTypeEnum;
 use App\Http\Resources\Base\Instructor\CourseResource;
 use App\Http\Resources\Base\Instructor\TagResource;
 use App\Http\Resources\Base\Student\InstructorResource;
-use App\Http\Resources\Base\Instructor\CourseDeadlineResource;
 use App\Model\Course;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -29,9 +27,6 @@ class CourseIndexResource extends JsonResource
             'instructor' => new InstructorResource($this->resource->instructor),
             'has_active_students' => $this->resource->attendances()->exists(),
             'tags' => TagResource::collection($this->resource['tags']),
-            'deadline' => $this->resource->courseDeadline
-                ? new CourseDeadlineResource($this->resource->courseDeadline)
-                : null,
         ];
     }
 }

--- a/app/Http/Resources/Manager/CourseIndexResource.php
+++ b/app/Http/Resources/Manager/CourseIndexResource.php
@@ -6,6 +6,7 @@ use App\Enums\Course\DeadlineTypeEnum;
 use App\Http\Resources\Base\Instructor\CourseResource;
 use App\Http\Resources\Base\Instructor\TagResource;
 use App\Http\Resources\Base\Student\InstructorResource;
+use App\Http\Resources\Base\Instructor\CourseDeadlineResource;
 use App\Model\Course;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -23,43 +24,14 @@ class CourseIndexResource extends JsonResource
     #[\Override]
     public function toArray(Request $request): array
     {
-        $course = $this->resource;
-
         return [
             ...(new CourseResource($this->resource))->toArray($request),
             'instructor' => new InstructorResource($this->resource->instructor),
             'has_active_students' => $this->resource->attendances()->exists(),
             'tags' => TagResource::collection($this->resource['tags']),
-            'deadline' => $this->buildDeadlinePayload($course),
+            'deadline' => $this->resource->courseDeadline
+                ? new CourseDeadlineResource($this->resource->courseDeadline)
+                : null,
         ];
-    }
-
-    /**
-     * 期限情報（none / fixed_date / relative_days）を統一フォーマットで生成
-     *
-     * @return array{deadline_type:string,fixed_date:?string,relative_days:?int}
-     */
-    private function buildDeadlinePayload(Course $course): array
-    {
-        $enum = DeadlineTypeEnum::tryFrom($course->deadline_type) ?? DeadlineTypeEnum::NONE;
-        $rel  = $course->courseDeadline;
-
-        return match ($enum) {
-            DeadlineTypeEnum::FIXED_DATE => [
-                'deadline_type' => $enum->value,
-                'fixed_date'    => $rel?->fixed_date ? (string) $rel->fixed_date : null,
-                'relative_days' => null,
-            ],
-            DeadlineTypeEnum::RELATIVE_DAYS => [
-                'deadline_type' => $enum->value,
-                'fixed_date'    => null,
-                'relative_days' => is_null($rel?->relative_days) ? null : (int) $rel->relative_days,
-            ],
-            default => [
-                'deadline_type' => DeadlineTypeEnum::NONE->value,
-                'fixed_date'    => null,
-                'relative_days' => null,
-            ],
-        };
     }
 }


### PR DESCRIPTION
## JIRA
- [JKA-1559] マネージャー側 講座一覧API：受講期限表示対応

## 概要
- マネージャー側 講座一覧APIにて受講期限情報を返却するように修正
- 期限タイプ（none, fixed_date, relative_days）に応じてレスポンスを統一フォーマットで追加
- CourseController@index で courseDeadline リレーションを eager load
- CourseIndexResource に deadline ブロックを追加し、期限を返却するよう対応

## 動作確認手順
1. Postmanで以下の各ケースを登録し、講座一覧APIを実行
(none, fixed_date, relative_days)


2. 各タイプに応じて正しい値が返却されることを確認

  - none → fixed_date: null, relative_days: null
  - fixed_date → 指定した日付が返却される
  - relative_days → 指定した日数が返却される

<img width="837" height="783" alt="スクリーンショット 2025-08-30 11 59 56" src="https://github.com/user-attachments/assets/35ecd34c-228d-464e-a055-d75e8c81ce44" />


## 考慮してほしいこと
- fixed_date はキャスト未設定のため string (YYYY-MM-DD) として返却しています

## 確認してほしいこと
- 実装方針（期限情報をResourceでまとめる形）が問題ないか