### PR TITLE
InstructorControllerのshowメソッドのPolicyパターンを用いた認可機能の実装（みこ）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -40,7 +40,7 @@ class InstructorController extends Controller
     public function show(): InstructorResource
     {
         $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
-        
+
         $this->authorize('view', $instructor);
 
         return new InstructorResource($instructor);

--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -40,6 +40,8 @@ class InstructorController extends Controller
     public function show(): InstructorResource
     {
         $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
+        
+        $this->authorize('view', $instructor);
 
         return new InstructorResource($instructor);
     }

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -75,12 +75,9 @@ class InstructorController extends Controller
      */
     public function show(ShowRequest $request): InstructorShowResource
     {
-
-        $managerId = Auth::guard('instructor')->user()->id;
-
         /** @var Instructor $instructor */
         $instructor = Instructor::findOrFail($request->instructor_id);
-    
+
         $this->authorize('view', $instructor);
 
         return new InstructorShowResource($instructor);

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -78,19 +78,10 @@ class InstructorController extends Controller
 
         $managerId = Auth::guard('instructor')->user()->id;
 
-        // 配下の講師情報を取得
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrFail($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
-
-        // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
-        if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, not allowed to this instructor.');
-        }
-
         /** @var Instructor $instructor */
         $instructor = Instructor::findOrFail($request->instructor_id);
+    
+        $this->authorize('view', $instructor);
 
         return new InstructorShowResource($instructor);
     }

--- a/app/Policies/InstructorPolicy.php
+++ b/app/Policies/InstructorPolicy.php
@@ -6,29 +6,24 @@ use App\Model\Instructor;
 
 class InstructorPolicy
 {
-   public function view(Instructor $loginUser, Instructor $instructor): bool
+    public function view(Instructor $loginUser, Instructor $instructor): bool
     {
         if ($loginUser->isManager()) {
-            $ids = $loginUser->managings->pluck('id')->toArray();
-            $ids[] = $loginUser->id; // 自分自身も許可対象に含める
-            return in_array($instructor->id, $ids, true);
+            $instructorIds = $loginUser->managings->pluck('id')->toArray();
+            // 自分自身も許可対象に含める
+            $instructorIds[] = $loginUser->id;
+
+            return in_array($instructor->id, $instructorIds, true);
         }
 
         return $loginUser->id === $instructor->id;
     }
-    
-    /**
-     * マネージャーは配下の講師と自分自身を更新可能。
-     * 講師は自分自身のみ更新可能。
-     *
-     * @param  \App\Model\Instructor  $loginUser  ログイン中の講師
-     * @param  \App\Model\Instructor  $instructor  更新対象の講師
-     * @return bool
-     */
-    public function update(Instructor $loginUser, Instructor $instructor)
+
+    public function update(Instructor $loginUser, Instructor $instructor): bool
     {
         if ($loginUser->isManager()) {
             $instructorIds = $loginUser->managings->pluck('id')->toArray();
+            // 自分自身も許可対象に含める
             $instructorIds[] = $loginUser->id;
 
             return in_array($instructor->id, $instructorIds, true);
@@ -37,4 +32,3 @@ class InstructorPolicy
         return $loginUser->id === $instructor->id;
     }
 }
-

--- a/app/Policies/InstructorPolicy.php
+++ b/app/Policies/InstructorPolicy.php
@@ -6,6 +6,17 @@ use App\Model\Instructor;
 
 class InstructorPolicy
 {
+   public function view(Instructor $loginUser, Instructor $instructor): bool
+    {
+        if ($loginUser->isManager()) {
+            $ids = $loginUser->managings->pluck('id')->toArray();
+            $ids[] = $loginUser->id; // 自分自身も許可対象に含める
+            return in_array($instructor->id, $ids, true);
+        }
+
+        return $loginUser->id === $instructor->id;
+    }
+    
     /**
      * マネージャーは配下の講師と自分自身を更新可能。
      * 講師は自分自身のみ更新可能。
@@ -26,3 +37,4 @@ class InstructorPolicy
         return $loginUser->id === $instructor->id;
     }
 }
+

--- a/tests/Feature/Api/Manager/Instructor/ShowTest.php
+++ b/tests/Feature/Api/Manager/Instructor/ShowTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Instructor;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講師講座取得_成功(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/2');
+
+        // assert
+        $response->assertStatus(200);
+    }
+
+    public function test_権限がない_講師講座取得_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(1);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/4');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
+    public function test_マネージャーではない_失敗(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->getJson('/api/v1/manager/instructor/1');
+
+        // assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Jira
- JKA-1570

## 概要
- InstructorControllerのshowメソッドのPolicyパターンを用いた認可機能の実装

## 動作確認手順
- ログイン
　test_instructor@example.com
　password

- GET:http://localhost:8080/api/v1/instructor
<img width="1357" height="716" alt="image" src="https://github.com/user-attachments/assets/bd9d7cc1-a571-4758-a375-4e524660a87a" />
 
- GET:http://localhost:8080/api/v1/manager/instructor/1
<img width="1359" height="715" alt="image" src="https://github.com/user-attachments/assets/47bd5e3e-0988-4d81-a11b-74a85cb53ab7" />

## 考慮してほしいこと
- お伝えした通り、智美さんに教わりました。

## 確認してほしいこと
- もし、指摘部分と特に覚えときたいPointあれば教えて頂きたいです。