### PR TITLE
InstructorControllerのshowメソッドのPolicyパターンを用いた認可機能の実装（きしもと）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Instructor/InstructorController.php
@@ -37,9 +37,9 @@ class InstructorController extends Controller
     /**
      * 講師取得API
      */
-    public function show(): InstructorResource
+    public function show(int $id): InstructorResource
     {
-        $instructor = Instructor::findOrFail(Auth::guard('instructor')->user()->id);
+        $instructor = Instructor::findOrFail($id);
 
         $this->authorize('view', $instructor);
 

--- a/app/Policies/InstructorPolicy.php
+++ b/app/Policies/InstructorPolicy.php
@@ -8,14 +8,15 @@ class InstructorPolicy
 {
     public function view(Instructor $loginUser, Instructor $instructor): bool
     {
+        // マネージャーの場合、管理する講師と自分自身のみ許可
         if ($loginUser->isManager()) {
             $instructorIds = $loginUser->managings->pluck('id')->toArray();
             // 自分自身も許可対象に含める
             $instructorIds[] = $loginUser->id;
-
+            // 管理する講師の中に対象の講師がいるかどうか
             return in_array($instructor->id, $instructorIds, true);
         }
-
+        // 一般講師の場合、自分自身のみ許可
         return $loginUser->id === $instructor->id;
     }
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -8,6 +8,7 @@ use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\Notification;
 use App\Model\Student;
+use App\Model\Instructor;
 use App\Model\Tag;
 use App\Policies\AttendancePolicy;
 use App\Policies\ChapterPolicy;
@@ -15,6 +16,7 @@ use App\Policies\CoursePolicy;
 use App\Policies\LessonPolicy;
 use App\Policies\NotificationPolicy;
 use App\Policies\StudentPolicy;
+use App\Policies\InstructorPolicy;
 use App\Policies\TagPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -33,7 +35,7 @@ class AuthServiceProvider extends ServiceProvider
         Tag::class => TagPolicy::class,
         Attendance::class => AttendancePolicy::class,
         Student::class => StudentPolicy::class,
-        \App\Model\Instructor::class => \App\Policies\InstructorPolicy::class,
+        Instructor::class => InstructorPolicy::class,
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,7 +50,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
     Route::middleware('instructor')->group(function () {
         // TODO 講師側APIはここに記述
         Route::prefix('instructor')->group(function () {
-            Route::get('/', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'show']);
+            Route::get('{id}', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'show']);
             Route::post('update', [App\Http\Controllers\Api\Instructor\InstructorController::class, 'update']);
 
             // 講師-講座タグ一覧


### PR DESCRIPTION
## Jira
- JKA-1570

## 概要
- InstructorPolicyでログイン講師にマネージャー権限がある場合は、管理する講師の情報を見れる状況
- 一方で、InstructorControllerのshowメソッドでは、ログイン中の本人しか見れない状況
- InstructorPolicyで定義された内容とInstructorControllerの整合を図るため、講師のIDを取得するようにし、
- 自分自身は見れる
- 管理権限のある講師は管理下の講師も見れる
- 管理権限のない人は見れない　という内容で作業を行った。
- 
## 動作確認手順
- 1.Postmanで管理権限を持つ講師でログイン(ID:1)
![ID1ログイン](https://github.com/user-attachments/assets/4f4d42ab-a7e7-4d82-be88-8f1ba39c9ec6)

- 2.ログイン講師の講師情報を確認(ID:1)
![ID1ログイン後、ID1講師確認](https://github.com/user-attachments/assets/30bce534-0b51-4f6a-9d6b-a6270f9080d8)

- 3.管理下の講師情報を確認(ID:2)
![ID1ログイン後、ID2講師確認](https://github.com/user-attachments/assets/554bb6e6-62af-4e25-9a36-86c0c1f26529)

- 4.管理外の講師情報を確認(ID:4)
![ID1ログイン後、ID4講師確認](https://github.com/user-attachments/assets/152785ec-df01-421c-9416-1e0a57a571e3)

- 5.Postmanで管理権限のない講師でログイン(ID:2)
![ID2ログイン](https://github.com/user-attachments/assets/01ce23b7-3dad-45bf-8a58-b2cca9eaef23)

- 6.ログイン講師の講師情報を確認(ID:2)
![ID2ログイン後、ID2講師確認](https://github.com/user-attachments/assets/19b945ed-ad08-4759-b5d9-cd17acfb2e14)

- 7.管理権限のある講師情報を確認(ID:1)
![ID2ログイン後、ID1講師確認](https://github.com/user-attachments/assets/96408ce9-c14e-489d-a872-81e56fa5a30b)

- 8.管理権限のない自分以外の講師情報を確認(ID:3)
![ID2ログイン後、ID3講師確認](https://github.com/user-attachments/assets/27c24c82-569c-4e26-9867-e1b84d27e8eb)

## 確認してほしいこと
- タスクと実施の方向性はあっているのか。