### PR TITLE
JKA-1573 講師側「全て受講期限をなくす」APIの新規作成（いのっち）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Instructor;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use App\Services\Course\ClearAllDeadlineService;
 use App\Model\Course;
 
@@ -19,7 +20,9 @@ class CourseDeadlineController extends Controller
         $courseIds = Course::where('instructor_id', $instructorId)->pluck('id');
 
         // サービスを呼び出して処理実行
-        $service($courseIds);
+        DB::transaction(function () use ($service, $courseIds) {
+            $service($courseIds);
+        });
 
         return response()->json(['result' => true], 200);
     }

--- a/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
@@ -3,17 +3,17 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
+use App\Model\Course;
+use App\Services\Course\ClearAllDeadlineService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use App\Services\Course\ClearAllDeadlineService;
-use App\Model\Course;
 
 class CourseDeadlineController extends Controller
 {
     public function clearAll(ClearAllDeadlineService $service): JsonResponse
     {
-       // 現在ログイン中の講師IDを取得
+        // 現在ログイン中の講師IDを取得
         $instructorId = Auth::guard('instructor')->id();
 
         // 講師本人の講座IDを収集

--- a/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use App\Services\Course\ClearAllDeadlineService;
+use App\Model\Course;
+
+class CourseDeadlineController extends Controller
+{
+    public function clearAll(ClearAllDeadlineService $service): JsonResponse
+    {
+       // 現在ログイン中の講師IDを取得
+        $instructorId = Auth::guard('instructor')->id();
+
+        // 講師本人の講座IDを収集
+        $courseIds = Course::where('instructor_id', $instructorId)->pluck('id');
+
+        // サービスを呼び出して処理実行
+        $service($courseIds);
+
+        return response()->json(['result' => true], 200);
+    }
+}

--- a/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
@@ -3,13 +3,12 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use App\Services\Course\ClearAllDeadlineService;
-use App\Model\Instructor;
 use App\Model\Course;
+use App\Model\Instructor;
+use App\Services\Course\ClearAllDeadlineService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-
 
 class CourseDeadlineController extends Controller
 {
@@ -21,7 +20,7 @@ class CourseDeadlineController extends Controller
         // managerIDを取得
         $managerId = Auth::guard('instructor')->id();
 
-       /** @var \App\Model\Instructor $manager */
+        /** @var \App\Model\Instructor $manager */
         $manager = Instructor::with('managings')->findOrFail($managerId);
 
         // 配下講師 + 自身 の講師ID集合

--- a/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
@@ -8,6 +8,7 @@ use App\Model\Instructor;
 use App\Model\Course;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 
 class CourseDeadlineController extends Controller
@@ -29,8 +30,10 @@ class CourseDeadlineController extends Controller
         // その全講師に紐づく講座IDを収集
         $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
 
-        // 共通サービスを実行
-        $service($courseIds);
+        // サービスを呼び出して処理実行
+        DB::transaction(function () use ($service, $courseIds) {
+            $service($courseIds);
+        });
 
         return response()->json(['result' => true], 200);
     }

--- a/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
 use App\Services\Course\ClearAllDeadlineService;
+use App\Model\Instructor;
+use App\Model\Course;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
+
 
 class CourseDeadlineController extends Controller
 {
@@ -18,9 +20,17 @@ class CourseDeadlineController extends Controller
         // managerIDを取得
         $managerId = Auth::guard('instructor')->id();
 
-        DB::transaction(function () use ($service, $managerId) {
-            $service($managerId);
-        });
+       /** @var \App\Model\Instructor $manager */
+        $manager = Instructor::with('managings')->findOrFail($managerId);
+
+        // 配下講師 + 自身 の講師ID集合
+        $instructorIds = $manager->managings->pluck('id')->push($manager->id);
+
+        // その全講師に紐づく講座IDを収集
+        $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
+
+        // 共通サービスを実行
+        $service($courseIds);
 
         return response()->json(['result' => true], 200);
     }

--- a/app/Services/Course/ClearAllDeadlineService.php
+++ b/app/Services/Course/ClearAllDeadlineService.php
@@ -5,33 +5,24 @@ namespace App\Services\Course;
 use App\Enums\Course\DeadlineTypeEnum;
 use App\Model\Course;
 use App\Model\CourseDeadline;
-use App\Model\Instructor;
+use Illuminate\Support\Facades\DB;
 
 class ClearAllDeadlineService
 {
     /**
-     * @param  int  $managerId  実行マネージャーのID
+     * @param  iterable<int,int>  $courseIds  講座IDの集合
      */
-    public function __invoke(int $managerId): void
+    public function __invoke(iterable $courseIds): void
     {
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrFail($managerId);
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $managerId;
+        $ids = collect($courseIds)->filter()->unique()->values();
+        if ($ids->isEmpty()) return;
 
-        // 対象講座ID
-        $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
-
-        if ($courseIds->isEmpty()) {
-            return; // 冪等：対象なしなら何もしない
-        }
-
-        // 講座の期限タイプを「なし」に更新
-        Course::whereIn('id', $courseIds)->update([
-            'deadline_type' => DeadlineTypeEnum::NONE,
-        ]);
-
-        // 講座の受講期限を削除
-        CourseDeadline::whereIn('course_id', $courseIds)->delete();
+        DB::transaction(function () use ($ids) {
+            Course::whereIn('id', $ids)->update([
+                'deadline_type' => DeadlineTypeEnum::NONE,
+            ]);
+            CourseDeadline::whereIn('course_id', $ids)->delete();
+        });
     }
 }
+

--- a/app/Services/Course/ClearAllDeadlineService.php
+++ b/app/Services/Course/ClearAllDeadlineService.php
@@ -14,12 +14,14 @@ class ClearAllDeadlineService
     public function __invoke(iterable $courseIds): void
     {
         $ids = collect($courseIds)->filter()->unique()->values();
-        if ($ids->isEmpty()) return;
+        if ($ids->isEmpty()) {
+            return;
+        }
 
-            Course::whereIn('id', $ids)->update([
-                'deadline_type' => DeadlineTypeEnum::NONE,
-            ]);
-            
+        Course::whereIn('id', $ids)->update([
+            'deadline_type' => DeadlineTypeEnum::NONE,
+        ]);
+
         CourseDeadline::whereIn('course_id', $ids)->delete();
     }
 }

--- a/app/Services/Course/ClearAllDeadlineService.php
+++ b/app/Services/Course/ClearAllDeadlineService.php
@@ -5,7 +5,6 @@ namespace App\Services\Course;
 use App\Enums\Course\DeadlineTypeEnum;
 use App\Model\Course;
 use App\Model\CourseDeadline;
-use Illuminate\Support\Facades\DB;
 
 class ClearAllDeadlineService
 {
@@ -17,12 +16,10 @@ class ClearAllDeadlineService
         $ids = collect($courseIds)->filter()->unique()->values();
         if ($ids->isEmpty()) return;
 
-        DB::transaction(function () use ($ids) {
             Course::whereIn('id', $ids)->update([
                 'deadline_type' => DeadlineTypeEnum::NONE,
             ]);
-            CourseDeadline::whereIn('course_id', $ids)->delete();
-        });
+            
+        CourseDeadline::whereIn('course_id', $ids)->delete();
     }
 }
-

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,6 +60,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::prefix('course')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index']);
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
+                Route::post('deadline/clear-all', [App\Http\Controllers\Api\Instructor\CourseDeadlineController::class, 'clearAll']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
                 Route::get('tag/index', [App\Http\Controllers\Api\Instructor\Course\TagController::class, 'index']);
                 Route::prefix('{course_id}')->group(function () {

--- a/tests/Feature/Api/Instructor/CourseDeadline/ClearAllTest.php
+++ b/tests/Feature/Api/Instructor/CourseDeadline/ClearAllTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\CourseDeadline;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClearAllTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // setup
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_講座期限をクリアしている(): void
+    {
+        // arrange
+        $instructor = Instructor::find(2);
+        $this->actingAs($instructor, 'instructor');
+
+        // act
+        $response = $this->postJson('/api/v1/instructor/course/deadline/clear-all');
+
+        // assert
+        $response->assertStatus(200)
+            ->assertJson([
+                'result' => true,
+            ]);
+        $this->assertDatabaseMissing('course_deadlines', [
+            'course_id' => 2,
+        ]);
+        $this->assertDatabaseHas('courses', [
+            'id' => 2,
+            'deadline_type' => 'none',
+        ]);
+    }
+}


### PR DESCRIPTION
## Jira
- JKA-1573

## 概要
- 講師側「全て受講期限をなくす」APIの新規作成、マネージャー側一部修正

## 動作確認手順
- 講師でログイン
test_instructor@example.com
password→password
- adminerでcoursesテーブルとcourse_deadlinesテーブルを確認（受講期限が指定されていること）

<img width="1260" height="367" alt="スクリーンショット 2025-10-14 12 48 22" src="https://github.com/user-attachments/assets/741533ed-93f4-48d6-ad88-d4647aa7bb10" />
<img width="921" height="336" alt="スクリーンショット 2025-10-14 13 18 29" src="https://github.com/user-attachments/assets/3308f2b9-83a1-4da5-81d6-115425b5e6ca" />

- POST:http://localhost:8080/api/v1/instructor/course/deadline/clear-all を実行し"result": trueが返ってくることを確認しadminerでcoursesテーブルとcourse_deadlinesテーブルを確認（受講期限がなくなっていること）

<img width="1213" height="455" alt="スクリーンショット 2025-10-14 13 21 46" src="https://github.com/user-attachments/assets/79d471d1-7039-4b62-836c-1adb172f8605" />
<img width="1188" height="367" alt="スクリーンショット 2025-10-14 13 22 24" src="https://github.com/user-attachments/assets/150809cc-87e7-4f7b-8c77-e53c7efc6386" />

## 考慮して欲しいこと
- マネージャー側の動作確認手順は省略してますが画像を載せておきます

<img width="1255" height="326" alt="スクリーンショット 2025-10-15 12 25 10" src="https://github.com/user-attachments/assets/63d0d9b5-5af6-40e9-b904-a6de45129158" />
<img width="706" height="297" alt="スクリーンショット 2025-10-15 12 27 04" src="https://github.com/user-attachments/assets/a9e90c0c-c559-465a-82ee-e92b3c0baa5c" />
↓
<img width="1225" height="321" alt="スクリーンショット 2025-10-15 12 29 36" src="https://github.com/user-attachments/assets/07704ea7-0d9f-4aa0-b19f-22c500af8646" />
<img width="421" height="306" alt="スクリーンショット 2025-10-15 12 28 58" src="https://github.com/user-attachments/assets/aa472737-ee21-4f2d-8aa8-be2445c0954d" />

## 確認して欲しいこと
- 動作は問題ありませんでしたが、再度、ご確認の程、よろしくお願いいたします。



