### PR TITLE
JKA-1582 受講生側 お知らせ取得APIの修正 講座の受講期限の新設定「受講開始から⚪︎ヶ月有効」などを考慮して対応

### DIFF
--- a/app/Http/Resources/Student/NotificationIndexResource.php
+++ b/app/Http/Resources/Student/NotificationIndexResource.php
@@ -36,7 +36,6 @@ class NotificationIndexResource extends JsonResource
      * @param  Collection<int, Notification>  $notifications
      * @return array
      */
-    
     private function mapNotifications($notifications)
     {
         return $notifications->map(function (Notification $notification) {

--- a/app/Http/Resources/Student/NotificationIndexResource.php
+++ b/app/Http/Resources/Student/NotificationIndexResource.php
@@ -36,19 +36,29 @@ class NotificationIndexResource extends JsonResource
      * @param  Collection<int, Notification>  $notifications
      * @return array
      */
+    
     private function mapNotifications($notifications)
     {
-        return $notifications->map(fn (Notification $notification) => [
-            'notification_id' => $notification->id,
-            'course_id' => $notification->course_id,
-            'instructor_id' => $notification->instructor_id,
-            'course_title' => $notification->course->title,
-            'title' => $notification->title,
-            'type' => $notification->type,
-            'content' => $notification->content,
-            'start_date' => $notification->start_date,
-            'end_date' => $notification->end_date,
-        ])
-            ->toArray();
+        return $notifications->map(function (Notification $notification) {
+            $deadline = optional($notification->course->courseDeadline);
+
+            return [
+                'notification_id' => $notification->id,
+                'course_id' => $notification->course_id,
+                'instructor_id' => $notification->instructor_id,
+                'course_title' => $notification->course->title,
+                'title' => $notification->title,
+                'type' => $notification->type,
+                'content' => $notification->content,
+                'start_date' => $notification->start_date,
+                'end_date' => $notification->end_date,
+
+                // 期限情報（null か、オブジェクト）
+                'deadline' => $deadline ? [
+                    'fixed_date' => optional($deadline->fixed_date)->toDateString(),  // Y-m-d 等（cast/formatは必要に応じて）
+                    'relative_days' => $deadline->relative_days,  // int|null
+                ] : null,
+            ];
+        })->toArray();
     }
 }

--- a/app/Http/Resources/Student/NotificationIndexResource.php
+++ b/app/Http/Resources/Student/NotificationIndexResource.php
@@ -3,7 +3,7 @@
 namespace App\Http\Resources\Student;
 
 use App\Model\Notification;
-use Illuminate\Database\Eloquent\Collection;
+use App\Http\Resources\Base\Student\NotificationResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
 
@@ -12,52 +12,32 @@ class NotificationIndexResource extends JsonResource
     /** @var LengthAwarePaginator */
     public $resource;
 
-    /**
-     * Transform the resource into an array.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return array
-     */
     #[\Override]
     public function toArray($request)
     {
+        /** @var LengthAwarePaginator $notifications */
         $notifications = $this->resource;
 
         return [
-            'notifications' => $this->mapNotifications($notifications->getCollection()),
+            'notifications' => $notifications->getCollection()
+                ->map(function (Notification $notification) use ($request) {
+                    // Service側で積んだ擬似リレーションを使う
+                    $attendance = $notification->getRelation('student_attendance');
+                    $deadline   = $attendance?->attendance_deadline; // DATE型（cast）
+
+                    // 既存ベースに追記
+                    return (new NotificationResource($notification))->toArray($request) + [
+                        'attendance_deadline' => $deadline?->toDateString(), // 'Y-m-d' or null
+                    ];
+                })
+                ->values()
+                ->toArray(),
+
+            // totalはServiceでフィルタ後件数になっているので整合性◎
             'pagination' => [
-                'page' => $notifications->currentPage(),
+                'page'  => $notifications->currentPage(),
                 'total' => $notifications->total(),
             ],
         ];
-    }
-
-    /**
-     * @param  Collection<int, Notification>  $notifications
-     * @return array
-     */
-    private function mapNotifications($notifications)
-    {
-        return $notifications->map(function (Notification $notification) {
-            $deadline = optional($notification->course->courseDeadline);
-
-            return [
-                'notification_id' => $notification->id,
-                'course_id' => $notification->course_id,
-                'instructor_id' => $notification->instructor_id,
-                'course_title' => $notification->course->title,
-                'title' => $notification->title,
-                'type' => $notification->type,
-                'content' => $notification->content,
-                'start_date' => $notification->start_date,
-                'end_date' => $notification->end_date,
-
-                // 期限情報（null か、オブジェクト）
-                'deadline' => $deadline ? [
-                    'fixed_date' => optional($deadline->fixed_date)->toDateString(),  // Y-m-d 等（cast/formatは必要に応じて）
-                    'relative_days' => $deadline->relative_days,  // int|null
-                ] : null,
-            ];
-        })->toArray();
     }
 }

--- a/app/Services/Notification/IndexService.php
+++ b/app/Services/Notification/IndexService.php
@@ -21,9 +21,14 @@ class IndexService
         $studentId = $dto->studentId;
         $currentDateTime = CarbonImmutable::now();
         $courseIds = Attendance::where('student_id', $studentId)->pluck('course_id')->toArray();
-
-        // お知らせ取得
-        $query = Notification::with('students', 'course')
+        // お知らせ取得クエリ
+        $query = Notification::with([
+            'students',
+            'course.courseDeadline',
+            'course.attendances' => fn ($q) => $q
+                ->where('student_id', $studentId)
+                ->select('id', 'course_id', 'student_id', 'created_at', 'attendance_deadline'),
+        ])
             ->whereIn('course_id', $courseIds)
             ->where('status', StatusEnum::PUBLIC)
             ->where('start_date', '<=', $currentDateTime)
@@ -33,10 +38,21 @@ class IndexService
                     $sub
                         // ① 期限なし（none）
                         ->where('deadline_type', DeadlineTypeEnum::NONE->value)
-                        // ②・③ 固定期限日（fixed_date）と相対日数（relative_days）
+
+                        // ② 固定期限（fixed_date）を許可：course_deadlines.fixed_date >= 今日
+                        ->orWhere(function (Builder $fx) use ($currentDateTime) {
+                            $fx->where('deadline_type', DeadlineTypeEnum::FIXED_DATE->value)
+                            ->whereHas('courseDeadline', function (Builder $cd) use ($currentDateTime) {
+                                // fixed_date が DATE 型なら toDateString() 比較が安全
+                                $cd->whereNotNull('fixed_date')
+                                    ->where('fixed_date', '>=', $currentDateTime->toDateString());
+                            });
+                        })
+
+                        // ③ 相対日数（relative_days）：受講生ごとの attendance_deadline >= now
                         ->orWhereHas('attendances', function (Builder $q2) use ($studentId, $currentDateTime) {
                             $q2->where('student_id', $studentId)
-                                ->where('attendance_deadline', '>=', $currentDateTime);
+                            ->where('attendance_deadline', '>=', $currentDateTime);
                         });
                 });
             });

--- a/app/Services/Notification/IndexService.php
+++ b/app/Services/Notification/IndexService.php
@@ -3,62 +3,69 @@
 namespace App\Services\Notification;
 
 use App\Dto\Student\Notification\IndexDto;
-use App\Enums\Course\DeadlineTypeEnum;
 use App\Enums\Notification\StatusEnum;
 use App\Model\Attendance;
 use App\Model\Notification;
 use Carbon\CarbonImmutable;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class IndexService
 {
     /**
      * お知らせ取得
      */
-    public function __invoke(IndexDto $dto)
+    public function __invoke(IndexDto $dto): LengthAwarePaginator
     {
-        // ユーザID取得(DTO使用)
         $studentId = $dto->studentId;
-        $currentDateTime = CarbonImmutable::now();
-        $courseIds = Attendance::where('student_id', $studentId)->pluck('course_id')->toArray();
-        // お知らせ取得クエリ
-        $query = Notification::with([
-            'students',
-            'course.courseDeadline',
-            'course.attendances' => fn ($q) => $q
-                ->where('student_id', $studentId)
-                ->select('id', 'course_id', 'student_id', 'created_at', 'attendance_deadline'),
-        ])
+        $now = CarbonImmutable::now();
+
+        // ① 受講生の受講情報をまとめて取得
+        $attendances = Attendance::where('student_id', $studentId)->get();
+
+        // 受講している講座がなければ空のページネーションを返す
+        if ($attendances->isEmpty()) {
+            return new LengthAwarePaginator(collect(), 0, $dto->perPage, $dto->page);
+        }
+
+        // ② course_id => Attendance のマップを作る
+        $attendanceByCourse = $attendances->keyBy('course_id');
+
+        // ③ Notification 用の course_id 一覧
+        $courseIds = $attendanceByCourse->keys();
+
+        // ④ 基本条件だけ DB で絞る
+        $items = Notification::with([
+                'students',
+                'course:id,title', 
+            ])
             ->whereIn('course_id', $courseIds)
             ->where('status', StatusEnum::PUBLIC)
-            ->where('start_date', '<=', $currentDateTime)
-            ->where('end_date', '>=', $currentDateTime)
-            ->whereHas('course', function (Builder $q) use ($studentId, $currentDateTime) {
-                $q->where(function (Builder $sub) use ($studentId, $currentDateTime) {
-                    $sub
-                        // ① 期限なし（none）
-                        ->where('deadline_type', DeadlineTypeEnum::NONE->value)
+            ->where('start_date', '<=', $now)
+            ->where('end_date', '>=', $now)
+            ->orderBy($dto->sortBy, $dto->order)
+            ->get();
 
-                        // ② 固定期限（fixed_date）を許可：course_deadlines.fixed_date >= 今日
-                        ->orWhere(function (Builder $fx) use ($currentDateTime) {
-                            $fx->where('deadline_type', DeadlineTypeEnum::FIXED_DATE->value)
-                                ->whereHas('courseDeadline', function (Builder $cd) use ($currentDateTime) {
-                                    // fixed_date が DATE 型なら toDateString() 比較が安全
-                                    $cd->whereNotNull('fixed_date')
-                                        ->where('fixed_date', '>=', $currentDateTime->toDateString());
-                                });
-                        })
+            // 受講期限が null（期限なし） or 未来（now以降）だけ残す
+        $filtered = $items->filter(function (Notification $n) use ($attendanceByCourse, $now) {
+            $att = $attendanceByCourse->get($n->course_id);
+            if (!$att || is_null($att->attendance_deadline)) return true;
+            return $att->attendance_deadline->toDateString() >= $now->toDateString(); 
+        })->values();
 
-                        // ③ 相対日数（relative_days）：受講生ごとの attendance_deadline >= now
-                        ->orWhereHas('attendances', function (Builder $q2) use ($studentId, $currentDateTime) {
-                            $q2->where('student_id', $studentId)
-                                ->where('attendance_deadline', '>=', $currentDateTime);
-                        });
-                });
-            });
+        // 各通知へ受講情報を紐付け
+        $filtered->each(function (Notification $n) use ($attendanceByCourse) {
+            if ($att = $attendanceByCourse->get($n->course_id)) {
+                $n->setRelation('student_attendance', $att);
+            }
+        });
 
-        // ソート条件とページネーションを適用して結果を返却
-        return $query->orderBy($dto->sortBy, $dto->order)
-            ->paginate($dto->perPage, ['*'], 'page', $dto->page);
+        // ⑦ フィルタ済みコレクションを手動ページネーション
+        $total   = $filtered->count();
+        $page    = max(1, (int) $dto->page);
+        $perPage = max(1, (int) $dto->perPage);
+
+        $slice = $filtered->forPage($page, $perPage)->values();
+
+        return new LengthAwarePaginator($slice, $total, $perPage, $page);
     }
 }

--- a/app/Services/Notification/IndexService.php
+++ b/app/Services/Notification/IndexService.php
@@ -42,17 +42,17 @@ class IndexService
                         // ② 固定期限（fixed_date）を許可：course_deadlines.fixed_date >= 今日
                         ->orWhere(function (Builder $fx) use ($currentDateTime) {
                             $fx->where('deadline_type', DeadlineTypeEnum::FIXED_DATE->value)
-                            ->whereHas('courseDeadline', function (Builder $cd) use ($currentDateTime) {
-                                // fixed_date が DATE 型なら toDateString() 比較が安全
-                                $cd->whereNotNull('fixed_date')
-                                    ->where('fixed_date', '>=', $currentDateTime->toDateString());
-                            });
+                                ->whereHas('courseDeadline', function (Builder $cd) use ($currentDateTime) {
+                                    // fixed_date が DATE 型なら toDateString() 比較が安全
+                                    $cd->whereNotNull('fixed_date')
+                                        ->where('fixed_date', '>=', $currentDateTime->toDateString());
+                                });
                         })
 
                         // ③ 相対日数（relative_days）：受講生ごとの attendance_deadline >= now
                         ->orWhereHas('attendances', function (Builder $q2) use ($studentId, $currentDateTime) {
                             $q2->where('student_id', $studentId)
-                            ->where('attendance_deadline', '>=', $currentDateTime);
+                                ->where('attendance_deadline', '>=', $currentDateTime);
                         });
                 });
             });


### PR DESCRIPTION
## Jira
- JKA-1582

## 概要
受講生側 お知らせ取得APIの修正 講座の受講期限の新設定「受講開始から⚪︎ヶ月有効」などを考慮して対応

## 動作確認手順
- 生徒でログイン
- email:test_student_1@example.com
- password:password1
- GET:http://localhost:8080/api/v1/notification/index

- 期限切れ

<img width="1512" height="982" alt="スクリーンショット 2025-11-15 10 22 57" src="https://github.com/user-attachments/assets/51ea1da3-22a2-465e-ad6b-4b8099612711" />

- 期限内

<img width="1512" height="982" alt="スクリーンショット 2025-11-15 10 19 20" src="https://github.com/user-attachments/assets/b5763901-503b-48f8-b8ec-69ec6d506d35" />

- null

<img width="1512" height="982" alt="スクリーンショット 2025-11-15 10 18 33" src="https://github.com/user-attachments/assets/5dd9dade-1119-4d44-b8a8-cf54d3063bb7" />

## 考慮して欲しいこと
- Serviceでフィルタ完結、Resourceは整形のみ（Resourceでのfilterは撤去済み）。

## 確認して欲しいこと
- 動作確認は問題なさそうでしたが、再度確認お願いします！
