### PR TITLE
JKA-1586 受講生お知らせ詳細APIの修正（きしもと）

### DIFF
--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -12,6 +12,7 @@ use App\Http\Resources\Student\NotificationIndexResource;
 use App\Services\Notification\IndexService;
 use App\Services\Notification\MarkReadService;
 use App\Services\Notification\ShowService;
+use App\Model\Attendance;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -66,7 +67,17 @@ class NotificationController extends Controller
         $student = $request->user();
 
         $notification = $service($student, (int) $request->notification_id);
+        $course = $notification->course;
+        $attendance = Attendance::where('student_id', $student->id)
+        ->where('course_id', $course->id)
+        ->first();
 
-        return new NotificationResource($notification);
+        $responseData = [
+        'notification' => $notification,
+        'deadline_type' => $course->deadline_type,
+        'attendance_deadline' => $attendance?->attendance_deadline?->format('Y-m-d'),
+        ];
+
+        return new NotificationResource($responseData);
     }
 }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -9,10 +9,10 @@ use App\Http\Requests\Student\Notification\MarkReadRequest;
 use App\Http\Requests\Student\Notification\ShowRequest;
 use App\Http\Resources\Base\Student\NotificationResource;
 use App\Http\Resources\Student\NotificationIndexResource;
+use App\Model\Attendance;
 use App\Services\Notification\IndexService;
 use App\Services\Notification\MarkReadService;
 use App\Services\Notification\ShowService;
-use App\Model\Attendance;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -69,13 +69,13 @@ class NotificationController extends Controller
         $notification = $service($student, (int) $request->notification_id);
         $course = $notification->course;
         $attendance = Attendance::where('student_id', $student->id)
-        ->where('course_id', $course->id)
-        ->first();
+            ->where('course_id', $course->id)
+            ->first();
 
         $responseData = [
-        'notification' => $notification,
-        'deadline_type' => $course->deadline_type,
-        'attendance_deadline' => $attendance?->attendance_deadline?->format('Y-m-d'),
+            'notification' => $notification,
+            'deadline_type' => $course->deadline_type,
+            'attendance_deadline' => $attendance?->attendance_deadline?->format('Y-m-d'),
         ];
 
         return new NotificationResource($responseData);

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -73,8 +73,8 @@ class NotificationController extends Controller
             ->first();
 
         $responseData = [
-        'notification' => $notification,
-        'attendance_deadline' => $attendance?->attendance_deadline?->format('Y-m-d'),
+            'notification' => $notification,
+            'attendance_deadline' => $attendance?->attendance_deadline?->format('Y-m-d'),
         ];
 
         return new NotificationResource($responseData);

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -9,7 +9,6 @@ use App\Http\Requests\Student\Notification\MarkReadRequest;
 use App\Http\Requests\Student\Notification\ShowRequest;
 use App\Http\Resources\Base\Student\NotificationResource;
 use App\Http\Resources\Student\NotificationIndexResource;
-use App\Model\Attendance;
 use App\Services\Notification\IndexService;
 use App\Services\Notification\MarkReadService;
 use App\Services\Notification\ShowService;
@@ -40,6 +39,25 @@ class NotificationController extends Controller
     }
 
     /**
+     * お知らせ詳細
+     */
+    public function show(ShowRequest $request, ShowService $service): NotificationResource
+    {
+        /** @var \App\Model\Student $student */
+        $student = $request->user();
+
+        $response = $service(
+            student: $student,
+            notificationId: (int) $request->notification_id
+        );
+
+        return new NotificationResource([
+            'notification' => $response['notification'],
+            'attendance_deadline' => $response['attendance']->attendance_deadline?->format('Y-m-d'),
+        ]);
+    }
+
+    /**
      * お知らせ既読登録API
      */
     public function markRead(MarkReadRequest $request, MarkReadService $service): JsonResponse
@@ -56,27 +74,5 @@ class NotificationController extends Controller
         return response()->json([
             'result' => true,
         ]);
-    }
-
-    /**
-     * お知らせ詳細
-     */
-    public function show(ShowRequest $request, ShowService $service): NotificationResource
-    {
-        /** @var \App\Model\Student $student */
-        $student = $request->user();
-
-        $notification = $service($student, (int) $request->notification_id);
-        $course = $notification->course;
-        $attendance = Attendance::where('student_id', $student->id)
-            ->where('course_id', $course->id)
-            ->first();
-
-        $responseData = [
-            'notification' => $notification,
-            'attendance_deadline' => $attendance?->attendance_deadline?->format('Y-m-d'),
-        ];
-
-        return new NotificationResource($responseData);
     }
 }

--- a/app/Http/Controllers/Api/Student/NotificationController.php
+++ b/app/Http/Controllers/Api/Student/NotificationController.php
@@ -74,7 +74,6 @@ class NotificationController extends Controller
 
         $responseData = [
         'notification' => $notification,
-        'deadline_type' => $course->deadline_type,
         'attendance_deadline' => $attendance?->attendance_deadline?->format('Y-m-d'),
         ];
 

--- a/app/Http/Resources/Base/Student/NotificationResource.php
+++ b/app/Http/Resources/Base/Student/NotificationResource.php
@@ -29,7 +29,6 @@ class NotificationResource extends JsonResource
             'content' => $notification->content,
             'start_date' => $notification->start_date,
             'end_date' => $notification->end_date,
-            'deadline_type' => $this->resource['deadline_type'] ?? null,
             'attendance_deadline' => $this->resource['attendance_deadline'] ?? null,
         ];
     }

--- a/app/Http/Resources/Base/Student/NotificationResource.php
+++ b/app/Http/Resources/Base/Student/NotificationResource.php
@@ -19,6 +19,7 @@ class NotificationResource extends JsonResource
     #[\Override]
     public function toArray($request)
     {
+        /** @var Notification $notification */
         $notification = $this->resource['notification'];
 
         return [

--- a/app/Http/Resources/Base/Student/NotificationResource.php
+++ b/app/Http/Resources/Base/Student/NotificationResource.php
@@ -20,7 +20,7 @@ class NotificationResource extends JsonResource
     public function toArray($request)
     {
         $notification = $this->resource['notification'];
-        
+
         return [
             'notification_id' => $notification->id,
             'course_id' => $notification->course_id,

--- a/app/Http/Resources/Base/Student/NotificationResource.php
+++ b/app/Http/Resources/Base/Student/NotificationResource.php
@@ -19,14 +19,18 @@ class NotificationResource extends JsonResource
     #[\Override]
     public function toArray($request)
     {
+        $notification = $this->resource['notification'];
+        
         return [
-            'notification_id' => $this->resource->id,
-            'course_id' => $this->resource->course_id,
-            'course_title' => $this->resource->course->title,
-            'title' => $this->resource->title,
-            'content' => $this->resource->content,
-            'start_date' => $this->resource->start_date,
-            'end_date' => $this->resource->end_date,
+            'notification_id' => $notification->id,
+            'course_id' => $notification->course_id,
+            'course_title' => $notification->course->title,
+            'title' => $notification->title,
+            'content' => $notification->content,
+            'start_date' => $notification->start_date,
+            'end_date' => $notification->end_date,
+            'deadline_type' => $this->resource['deadline_type'] ?? null,
+            'attendance_deadline' => $this->resource['attendance_deadline'] ?? null,
         ];
     }
 }

--- a/app/Services/Notification/ShowService.php
+++ b/app/Services/Notification/ShowService.php
@@ -25,7 +25,7 @@ class ShowService
         $attendance = Attendance::where('student_id', $student->id)
             ->where('course_id', $notification->course_id)
             ->firstOrFail();
-            
+
         if ($attendance->isExpired()) {
             throw new AuthorizationException('The course has expired.');
         }

--- a/app/Services/Notification/ShowService.php
+++ b/app/Services/Notification/ShowService.php
@@ -24,8 +24,14 @@ class ShowService
         /** @var Attendance|null $attendance */
         $attendance = Attendance::where('student_id', $student->id)
             ->where('course_id', $notification->course_id)
-            ->firstOrFail();
+            ->first();
 
+        // 受講していないとき    
+        if (!$attendance) {
+            throw new AuthorizationException('You are not enrolled in the course.');
+        }
+
+        // 期限切れのとき
         if ($attendance->isExpired()) {
             throw new AuthorizationException('The course has expired.');
         }

--- a/app/Services/Notification/ShowService.php
+++ b/app/Services/Notification/ShowService.php
@@ -26,8 +26,8 @@ class ShowService
             ->where('course_id', $notification->course_id)
             ->first();
 
-        // 受講していないとき    
-        if (!$attendance) {
+        // 受講していないとき
+        if (! $attendance) {
             throw new AuthorizationException('You are not enrolled in the course.');
         }
 

--- a/app/Services/Notification/ShowService.php
+++ b/app/Services/Notification/ShowService.php
@@ -24,14 +24,8 @@ class ShowService
         /** @var Attendance|null $attendance */
         $attendance = Attendance::where('student_id', $student->id)
             ->where('course_id', $notification->course_id)
-            ->first();
-
-        // 受講していないとき    
-        if (!$attendance) {
-            throw new AuthorizationException('You are not enrolled in the course.');
-        }
-
-        // 期限切れのとき
+            ->firstOrFail();
+            
         if ($attendance->isExpired()) {
             throw new AuthorizationException('The course has expired.');
         }

--- a/app/Services/Notification/ShowService.php
+++ b/app/Services/Notification/ShowService.php
@@ -10,26 +10,30 @@ use Illuminate\Auth\Access\AuthorizationException;
 class ShowService
 {
     /**
-     * お知らせ詳細 + 受講期限チェック（最小）
-     * 期限判定は Attendance::isExpired() に委譲
-     * 期限切れ時: 403 "The course has expired."
+     * お知らせ詳細取得
+     *
+     * @return array {notification: Notification, attendance: Attendance}
      */
-    public function __invoke(Student $student, int $notificationId): Notification
+    public function __invoke(Student $student, int $notificationId): array
     {
         /** @var Notification $notification */
         $notification = Notification::public()
             ->with('course') // 不要なら外してOK
             ->findOrFail($notificationId);
 
-        /** @var Attendance|null $attendance */
+        /** @var Attendance $attendance */
         $attendance = Attendance::where('student_id', $student->id)
             ->where('course_id', $notification->course_id)
             ->firstOrFail();
 
         if ($attendance->isExpired()) {
+            // 受講期限切れ
             throw new AuthorizationException('The course has expired.');
         }
 
-        return $notification;
+        return [
+            'notification' => $notification,
+            'attendance' => $attendance,
+        ];
     }
 }


### PR DESCRIPTION
## Jira
- JKA-1586

## 概要
- NotificationResource.phpはコントローラから受け取ったdeadline_type、attendance_deadlineを受け取れるように修正
- NotificationController.phpはNotification, Course, Attendance をまとめて取得し、表示するだけのResourceに渡す。
- ShowService.phpには、期限切れの表示が記述されていたので、受講していない講座のお知らせについても記述しました。

## 動作確認手順
- Postmanにて
- 生徒1でログイン
- GET　http://localhost:8080/api/v1/notification/:notification_id
- notification_idを1,2,3と変えていく。
- notification_idを２にする際は、notificationsテーブルのstatusカラムをpublicに修正
- ①notification_id１の場合は
- 期限なしのため、"deadline_type":"none","attendance_deadline": nullが返ってくる。
- ②notification_id２の場合は期限固定で、
- "deadline_type": "fixed_date","attendance_deadline": "2026-10-02"が返ってくる。
- ③notification_id３の場合は、生徒１が受講していない講座のため、
- 403エラーで"message": "You are not enrolled in the course.",が返ってくる。
- ④期限切れの場合を確認するため、notification_id１に戻し、
- attendancesテーブルのID1のattendance_deadlineを現在日時より前に設定し、送信する。
- 403エラーで"message": "The course has expired.",が返ってくる。
- 作業後、attendancesテーブルのID1のattendance_deadlineをnullに戻す。

## 考慮してほしいこと

## 確認してほしいこと
- 作業会で確認した方向性通りの実装となっているか。