### PR TITLE
JKA-1575 講座削除時にモデルを使って期限も削除（きしもと）

### DIFF
--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -67,6 +67,11 @@ class Course extends Model
             foreach ($course->chapters()->get() as $child) {
                 $child->delete();
             }
+
+            // 講座期限設定があれば削除
+            if ($course->courseDeadline()->exists()) {
+                $course->courseDeadline()->delete();
+            }
         });
     }
 

--- a/app/Services/Course/DeleteService.php
+++ b/app/Services/Course/DeleteService.php
@@ -27,9 +27,6 @@ class DeleteService
             $disk->delete($course->image);
         }
 
-        // 講座締切データ削除
-        $course->courseDeadline()->delete();
-
         // 講座データ削除
         $course->delete();
     }


### PR DESCRIPTION
## 概要
講座が削除されたら講座に紐付くCourseDeadlineを削除する内容をCourseモデルに記述する

## 動作確認手順
- コースID2を講座期限を含むデータに更新
![POST講座の更新で講座期限を入力①ID指定](https://github.com/user-attachments/assets/ddcf4a1b-9266-4bb6-a54b-17f2f3d004e5)
![POST講座の更新で講座期限を入力②内容](https://github.com/user-attachments/assets/9743bc9b-0e7b-4590-9857-691e0b1fa228)
![講座を更新し、講座期限を設定](https://github.com/user-attachments/assets/ccd7aba7-7510-42d4-96bc-7a9679d80304)

- 更新したコースID2を削除し、期限まで削除できているか確認
![DELETE講座を削除](https://github.com/user-attachments/assets/6b44be30-d04a-44af-9b79-f91d010d21e8)
![DELETE講座を削除　DB確認（コース）](https://github.com/user-attachments/assets/782679a1-7aa2-4404-9410-7d284d691d5d)
![DELETE講座を削除　DB確認（コース期限）](https://github.com/user-attachments/assets/07827131-991d-4962-9c7d-738e9e3a831a)

講座削除 時に、course_deadlines も削除されていることを確認。

## 確認してほしいこと
- 指示としては、その他の講座削除系も同様に対応とありましたが、マネージャー側には削除APIがなく、他の削除に関しても、コースの削除に関連する内容はなかったと思いましたので、上記の対応のみとなります。