### PR TITLE
JKA-1591 選択した講座ステータスの一括更新（きしもと）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -191,12 +191,15 @@ class CourseController extends Controller
     public function putStatus(PutStatusRequest $request, PutStatusService $service): JsonResponse
     {
         $instructorId = Auth::guard('instructor')->user()->id;
+        $courseIds = $request->input('course_ids', []);
+        $status = $request->input('status');
 
         // 更新処理
-        $service(instructorIds: [$instructorId], status: $request->status);
+        $service(courseIds: $courseIds, status: $status, instructorId: $instructorId);
 
         return response()->json([
             'result' => 'true',
+            'updated_ids' => $courseIds,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -170,14 +170,15 @@ class CourseController extends Controller
         $managingIds = $instructor->managings->pluck('id')->toArray();
         $managingIds[] = $instructorId;
 
-        // 更新処理
-        $service(
-            instructorIds: $managingIds,
-            status: $request->status
-        );
+        // 更新対象の講座IDを抽出
+        $courseIds = Course::whereIn('instructor_id', $managingIds)->pluck('id')->toArray();
+
+        // 更新処理(instructorと同様に変更)
+        $service(courseIds: $courseIds, status: $request->status, instructorId: $instructorId);
 
         return response()->json([
             'result' => 'true',
+            'updated_ids' => $courseIds,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -173,7 +173,7 @@ class CourseController extends Controller
         // 更新対象の講座IDを抽出
         $courseIds = Course::whereIn('instructor_id', $managingIds)->pluck('id')->toArray();
 
-        // 更新処理(instructorと同様に変更)
+        // 更新処理
         $service(courseIds: $courseIds, status: $request->status, instructorId: $instructorId);
 
         return response()->json([

--- a/app/Http/Requests/Instructor/Course/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Course/PutStatusRequest.php
@@ -25,9 +25,7 @@ class PutStatusRequest extends FormRequest
     public function rules()
     {
         return [
-            // 入力値が配列であり、かつ空ではなく、最低1つの要素が含まれている必要がある
             'course_ids' => ['required', 'array', 'min:1'],
-            // 配列の各要素が整数であり、coursesテーブルに存在しており、削除されていないことを確認
             'course_ids.*' => ['integer', 'exists:courses,id,deleted_at,NULL'],
             'status' => ['required', 'string', new CourseStatusRule],
         ];

--- a/app/Http/Requests/Instructor/Course/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Course/PutStatusRequest.php
@@ -25,6 +25,10 @@ class PutStatusRequest extends FormRequest
     public function rules()
     {
         return [
+            // 入力値が配列であり、かつ空ではなく、最低1つの要素が含まれている必要がある
+            'course_ids' => ['required', 'array', 'min:1'],
+            // 配列の各要素が整数であり、coursesテーブルに存在しており、削除されていないことを確認
+            'course_ids.*' => ['integer', 'exists:courses,id,deleted_at,NULL'],
             'status' => ['required', 'string', new CourseStatusRule],
         ];
     }

--- a/app/Services/Course/PutStatusService.php
+++ b/app/Services/Course/PutStatusService.php
@@ -7,13 +7,15 @@ use App\Model\Course;
 class PutStatusService
 {
     /**
-     * 講座の状態を更新
+     * 選択した講座のステータスを更新する
      *
-     * @param  array<int>  $instructorIds
+     * @param  array<int>  $courseIds
      * @param  'public'|'private'  $status
+     * @param  int $instructorId
      */
-    public function __invoke(array $instructorIds, string $status): void
+    public function __invoke(array $courseIds, string $status, int $instructorId): void
     {
-        Course::whereIn('instructor_id', $instructorIds)->update(['status' => $status]);
+        // 講座のステータスを一括更新
+        Course::whereIn('id', $courseIds)->where('instructor_id', $instructorId)->update(['status' => $status]);
     }
 }

--- a/app/Services/Course/PutStatusService.php
+++ b/app/Services/Course/PutStatusService.php
@@ -11,7 +11,6 @@ class PutStatusService
      *
      * @param  array<int>  $courseIds
      * @param  'public'|'private'  $status
-     * @param  int $instructorId
      */
     public function __invoke(array $courseIds, string $status, int $instructorId): void
     {


### PR DESCRIPTION
## 概要
選択された講座（リクエストで指定された course_ids）のみ更新する仕様に変更しました。
リクエストに course_ids を追加。配列の各要素が有効な講座IDであるかを確認。
サービスでは、courseIdsを受け取り、ログイン中の講師IDと一致する講座のみ更新。
コントローラでは、リクエストから course_ids と status を取得し、サービスに渡して更新を実行する。

## 動作確認手順
- ①講師１でログイン
- ②コースID1（講師１）、コースID２（講師２）、コースID５（講師１）のステータスを更新
![PUT 講座ステータスを更新前DB（成功）](https://github.com/user-attachments/assets/a6ecef31-2826-4b36-98bf-d0969b82556b)
![PUT 講座ステータスを更新（成功）](https://github.com/user-attachments/assets/583e29b3-dc87-471d-a083-851f169bfc08)
![PUT 講座ステータスを更新前DB（成功）](https://github.com/user-attachments/assets/6168257b-7a1f-4762-9aa4-d8fba6ee0d11)
- ③講師１が持つコースID1,5のみ更新していることを確認。

- ④コースID1をDBを直接編集し、deleted_atを入力（ソフトデリートする） 
- ⑤削除済みのコースID1を含み、コースID３、コースID５のステータスを更新。
![PUT 講座ステータスを更新前DB（失敗）](https://github.com/user-attachments/assets/523da0e7-997e-42b3-8362-c7ef74072386)
![PUT 講座ステータスを更新（失敗）](https://github.com/user-attachments/assets/8352441a-29b3-4c00-8c49-e31ca94167a8)
- ⑥削除済みのコースがあるため、更新できず。

## 考慮してほしいこと
- PutStatusRequest.phpでは、自分の勉強のために補足説明を入れています。
少し長く書きすぎている気もするので、いつでも消します💦

## 確認してほしいこと
- 実施方法として問題ないか確認お願いします。