### PR TITLE
bulkDeleteメソッドの削除

### DIFF
--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\Manager;
 use App\Dto\Notification\PutDto;
 use App\Enums\Notification\StatusEnum;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Manager\Notification\BulkDeleteRequest;
 use App\Http\Requests\Manager\Notification\DeleteRequest;
 use App\Http\Requests\Manager\Notification\IndexRequest;
 use App\Http\Requests\Manager\Notification\PutRequest;
@@ -18,7 +17,6 @@ use App\Http\Resources\Manager\NotificationIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
-use App\Services\Notification\BulkDeleteService;
 use App\Services\Notification\DeleteService;
 use App\Services\Notification\PutNotificationService;
 use App\Services\Notification\PutStatusAllService;
@@ -221,34 +219,7 @@ class NotificationController extends Controller
         ]);
     }
 
-    /**
-     * お知らせ一括削除API
-     */
-    public function bulkDelete(BulkDeleteRequest $request, BulkDeleteService $service): JsonResponse
-    {
-        // 選択されたお知らせリストを取得
-        $notifications = Notification::whereIn('id', $request->notifications)->get();
-
-        // 講師と一致しないお知らせが含まれている場合はエラー
-        $this->authorize('bulkDelete', [Notification::class, $notifications]);
-
-        DB::beginTransaction();
-        try {
-            // viewed_once_notifications, notificationsテーブルのレコードを一括削除するサービス
-            $service($notifications);
-
-            // コミット
-            DB::commit();
-
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
-        }
-    }
+    
 
     /**
      * お知らせ一括公開・非公開API

--- a/routes/api.php
+++ b/routes/api.php
@@ -259,7 +259,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::put('status', [App\Http\Controllers\Api\Manager\NotificationController::class, 'putStatus']);
                     Route::put('status/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'putStatusAll']);
-                    Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
 
                     Route::prefix('{notification_id}')->group(function () {
                         Route::put('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'put']);


### PR DESCRIPTION
## Issue
JKA-1613
## 対応内容
Manager/NotificationController の bulkDelete メソッドを削除
上記に紐づくルーティングを削除
## 確認方法
◆instructor_idのid:2の方でログイン
・( http://localhost:8080/api/v1/instructor/notification ) true
◆instructor_idのid:1の方でログイン
・( http://localhost:8080/api/v1/instructor/notification ) true

PostmanのボディにRawで下記を入力
{
   "notifications":[1]
}
[ ]内に対応するidを入力でtrue、対応しないidだとエラーコード422"The selected notifications.0 is invalid."
## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)
(疑問)Postmanのボディ項目Rawとfrom-dateで入力方法以外でどういう違いがあるのでしょうか？
ご確認宜しくお願いします。