### PR TITLE
講座ステータス一括更新APIにPolicy認可チェックを追加 (丸山)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -190,12 +190,17 @@ class CourseController extends Controller
      */
     public function putStatus(PutStatusRequest $request, PutStatusService $service): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
         $courseIds = $request->input('courses', []);
         $status = $request->input('status');
 
-        // 更新処理
-        $service(courseIds: $courseIds, status: $status, instructorId: $instructorId);
+        // 認可チェック（他人の講座が混じっていたら 403）
+        $this->authorize(
+            'bulkUpdateStatus',
+            [Course::class, $courseIds]
+        );
+
+        // 更新処理（認可済みのものを更新するだけ）
+        $service(courseIds: $courseIds, status: $status,);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -193,14 +193,11 @@ class CourseController extends Controller
         $courseIds = $request->input('courses', []);
         $status = $request->input('status');
 
-         // 対象講座を取得（ここでDBアクセス）
+        // 対象講座を取得
         $courses = Course::whereIn('id', $courseIds)->get();
 
         // 認可チェック
-        $this->authorize(
-            'bulkUpdateStatus',
-            [Course::class, $courses]
-        );
+        $this->authorize('bulkUpdate', [Course::class, $courses]);
 
         // 更新処理
         $service(courseIds: $courseIds, status: $status);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -193,14 +193,17 @@ class CourseController extends Controller
         $courseIds = $request->input('courses', []);
         $status = $request->input('status');
 
-        // 認可チェック（他人の講座が混じっていたら 403）
+         // 対象講座を取得（ここでDBアクセス）
+        $courses = Course::whereIn('id', $courseIds)->get();
+
+        // 認可チェック
         $this->authorize(
             'bulkUpdateStatus',
-            [Course::class, $courseIds]
+            [Course::class, $courses]
         );
 
-        // 更新処理（認可済みのものを更新するだけ）
-        $service(courseIds: $courseIds, status: $status,);
+        // 更新処理
+        $service(courseIds: $courseIds, status: $status);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -174,7 +174,7 @@ class CourseController extends Controller
         $courseIds = Course::whereIn('instructor_id', $managingIds)->pluck('id')->toArray();
 
         // 更新処理
-        $service(courseIds: $courseIds, status: $request->status, instructorId: $instructorId);
+        $service(courseIds: $courseIds, status: $request->status);
 
         return response()->json([
             'result' => 'true',

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Model\Course;
 use App\Model\Instructor;
+use Illuminate\Support\Collection;
 
 class CoursePolicy
 {
@@ -49,25 +50,22 @@ class CoursePolicy
         return $instructor->id === $course->instructor_id;
     }
     
-    public function bulkUpdateStatus(Instructor $instructor, array $courseIds): bool
+    public function bulkUpdateStatus(Instructor $instructor, Collection $courses): bool
     {
         // マネージャー権限あり
         if ($instructor->isManager()) {
-            $instructorIds = $instructor->managings->pluck('id')->toArray();
-            $instructorIds[] = $instructor->id;
+            $allowedInstructorIds = $instructor->managings
+                ->pluck('id')
+                ->push($instructor->id);
 
-            $count = Course::whereIn('id', $courseIds)
-                ->whereIn('instructor_id', $instructorIds)
-                ->count();
-
-            return $count === count($courseIds);
+            return $courses->every(
+                fn ($course) => $allowedInstructorIds->contains($course->instructor_id)
+            );
         }
 
-        // マネージャー権限なし（一般講師）
-        $count = Course::whereIn('id', $courseIds)
-            ->where('instructor_id', $instructor->id)
-            ->count();
-
-        return $count === count($courseIds);
+        // 一般講師
+        return $courses->every(
+            fn ($course) => $course->instructor_id === $instructor->id
+        );
     }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -48,4 +48,26 @@ class CoursePolicy
         // マネージャー権限のない講師
         return $instructor->id === $course->instructor_id;
     }
+    
+    public function bulkUpdateStatus(Instructor $instructor, array $courseIds): bool
+    {
+        // マネージャー権限あり
+        if ($instructor->isManager()) {
+            $instructorIds = $instructor->managings->pluck('id')->toArray();
+            $instructorIds[] = $instructor->id;
+
+            $count = Course::whereIn('id', $courseIds)
+                ->whereIn('instructor_id', $instructorIds)
+                ->count();
+
+            return $count === count($courseIds);
+        }
+
+        // マネージャー権限なし（一般講師）
+        $count = Course::whereIn('id', $courseIds)
+            ->where('instructor_id', $instructor->id)
+            ->count();
+
+        return $count === count($courseIds);
+    }
 }

--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -49,23 +49,23 @@ class CoursePolicy
         // マネージャー権限のない講師
         return $instructor->id === $course->instructor_id;
     }
-    
-    public function bulkUpdateStatus(Instructor $instructor, Collection $courses): bool
+
+    /**
+     * 複数講座のステータス更新に関する認可処理
+     *
+     * @param  Collection<int, Course>  $courses
+     */
+    public function bulkUpdate(Instructor $instructor, Collection $courses): bool
     {
         // マネージャー権限あり
         if ($instructor->isManager()) {
-            $allowedInstructorIds = $instructor->managings
-                ->pluck('id')
-                ->push($instructor->id);
+            $managerIds = $instructor->managings->pluck('id')->toArray();
+            $managerIds[] = $instructor->id;
 
-            return $courses->every(
-                fn ($course) => $allowedInstructorIds->contains($course->instructor_id)
-            );
+            return $courses->every(fn (Course $course) => in_array($course->instructor_id, $managerIds, true));
         }
 
         // 一般講師
-        return $courses->every(
-            fn ($course) => $course->instructor_id === $instructor->id
-        );
+        return $courses->every(fn (Course $course) => $course->instructor_id === $instructor->id);
     }
 }

--- a/app/Services/Course/PutStatusService.php
+++ b/app/Services/Course/PutStatusService.php
@@ -12,9 +12,9 @@ class PutStatusService
      * @param  array<int>  $courseIds
      * @param  'public'|'private'  $status
      */
-    public function __invoke(array $courseIds, string $status, int $instructorId): void
+    public function __invoke(array $courseIds, string $status): void
     {
         // 講座のステータスを一括更新
-        Course::whereIn('id', $courseIds)->where('instructor_id', $instructorId)->update(['status' => $status]);
+        Course::whereIn('id', $courseIds)->update(['status' => $status]);
     }
 }


### PR DESCRIPTION
## Issue

- https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-1623

## 対応内容

1. CoursePolicyにbulkUpdateStatusを追加。
2. CourseController::putStatusで認可チェック
3. Service側も変更
4. 動作確認チェック

## 確認方法

- postmanで講師本人でPUTすると"result": trueと出るのを確認。

```
{
  "status": "public",
  "courses": [
    2
  ]
}
```

```
{
    "result": true
}
```

- 他人の講座IDを混ぜた場合、403エラーが出たのを確認。

```
{
  "status": "public",
  "courses": [
    1,2
  ]
}
```

```
{
    "message": "This action is unauthorized.",
　//以下略
```

- マネージャーが配下の講師の講座を更新 → 更新成功（200）するのを確認。

```
{
  "status": "public",
  "courses": [
    1,2,3,5,6,7
  ]
}
```

```
{
    "result": true
}
```

- 他managerの講座を更新しようとするとエラーになるのを確認。

```
{
  "status": "public",
  "courses": [
    4
  ]
```
}

```
{
    "message": "This action is unauthorized.",
　//以下略
```