### PR TITLE
空の配列を返すルーターとコントローラの作成

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
@@ -15,9 +15,4 @@ class CourseDeadlineController extends Controller
         return response()->json([]);
     }
 
-    // 受講期限単一変更
-    public function update(): JsonResponse
-    {
-        return response()->json([]);
-    }
 }

--- a/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
@@ -12,5 +12,4 @@ class CourseDeadlineController extends Controller
     {
         return response()->json([]);
     }
-
 }

--- a/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api\Instructor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;    
+use Illuminate\Http\JsonResponse;
+
+
+class CourseDeadlineController extends Controller
+{
+    // 受講期限一括変更
+    public function bulkUpdate(): JsonResponse
+    {
+        return response()->json([]);
+    }
+
+    // 受講期限単一変更
+    public function update(): JsonResponse
+    {
+        return response()->json([]);
+    }
+}

--- a/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseDeadlineController.php
@@ -3,9 +3,7 @@
 namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;    
 use Illuminate\Http\JsonResponse;
-
 
 class CourseDeadlineController extends Controller
 {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -75,10 +76,12 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
                 Route::get('tag/index', [App\Http\Controllers\Api\Instructor\Course\TagController::class, 'index']);
+                Route::patch('deadline', [App\Http\Controllers\Api\Instructor\CourseDeadlineController::class, 'bulkUpdate']);
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'update']);
                     Route::delete('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'delete']);
+                    Route::patch('deadline', [App\Http\Controllers\Api\Instructor\CourseDeadlineController::class, 'update']);
                     // 講師-講座-チャプター
                     Route::prefix('chapter')->group(function () {
                         Route::post('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -81,7 +81,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'update']);
                     Route::delete('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'delete']);
-                    Route::patch('deadline', [App\Http\Controllers\Api\Instructor\CourseDeadlineController::class, 'update']);
                     // 講師-講座-チャプター
                     Route::prefix('chapter')->group(function () {
                         Route::post('/', [App\Http\Controllers\Api\Instructor\ChapterController::class, 'store']);


### PR DESCRIPTION
## Issue
・https://gut-familie.atlassian.net/jira/software/projects/JKA/boards/1/backlog?selectedIssue=JKA-1587

## 対応内容
ルートに追記して、コントローラーを作成して記述。

## 確認方法
postmanを使って

- http://localhost:8080/api/v1/instructor/course/1/deadline
- http://localhost:8080/api/v1/instructor/course/deadline

に
```
{
  "deadline_type": "none"
}
```
でアクセス。空の配列が返ってくることを確認しました。

## 質問

**- {course_id} をパスパラメータとして指定する形で表現できれば差別化できると考えています。**

この部分について、ControllerのUpdateメソッド内の記述で、$courseIdsみたいな感じで記述していくということでしたでしょうか？
それとも今回のように、ルートに単一、一括を二つ記述してメソッドで単一、一括を記述するのでよかったでしょうか？