### PR TITLE
JKA-1638 空の配列を返すルーターとコントローラの作成(すさ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -206,4 +206,13 @@ class CourseController extends Controller
             'result' => true,
         ]);
     }
+
+    /**
+     * 講座一括削除API
+     * 
+     */
+    public function bulkDelete()
+    {
+        return response()->json([]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -74,6 +74,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                 Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index']);
                 Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store']);
                 Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus']);
+                Route::delete('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'bulkDelete']);
                 Route::get('tag/index', [App\Http\Controllers\Api\Instructor\Course\TagController::class, 'index']);
                 Route::prefix('{course_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'show']);


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-1638
## 対応内容
routes/api.phpにルーティングを追記。
app/Http/Controllers/Api/Instructor/CourseController.php にメソッドを追加。
## 確認方法
ポストマンで以下実施
DELETE　URL: http://localhost:8080/api/v1/instructor/course
レスポンスで200OKと空の配列[ ]を確認
## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)