### PR TITLE
講師側 全ての講座受講期限をなくすAPIを変更

### DIFF
--- a/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
@@ -7,19 +7,22 @@ use App\Services\Course\ClearAllDeadlineService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use App\Http\Requests\Manager\Course\ClearSelectedDeadlineRequest;
 
 class CourseDeadlineController extends Controller
 {
     /**
      * すべての講座の受講期限をクリアする
      */
-    public function clearAll(ClearAllDeadlineService $service): JsonResponse
+    public function clearSelected(ClearSelectedDeadlineRequest $request, ClearAllDeadlineService $service): JsonResponse
     {
+        $courseIds = $request->validated()['course_ids'];
+
         // managerIDを取得
         $managerId = Auth::guard('instructor')->id();
 
-        DB::transaction(function () use ($service, $managerId) {
-            $service($managerId);
+        DB::transaction(function () use ($service, $managerId, $courseIds) {
+            $service($managerId, $courseIds);
         });
 
         return response()->json(['result' => true], 200);

--- a/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Http\Controllers\Controller;
-use App\Services\Course\ClearAllDeadlineService;
+use App\Services\Course\ClearSelectedDeadlineService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -14,7 +14,7 @@ class CourseDeadlineController extends Controller
     /**
      * すべての講座の受講期限をクリアする
      */
-    public function clearSelected(ClearSelectedDeadlineRequest $request, ClearAllDeadlineService $service): JsonResponse
+    public function clearSelected(ClearSelectedDeadlineRequest $request, ClearSelectedDeadlineService $service): JsonResponse
     {
         $courseIds = $request->validated()['courses'];
 

--- a/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
+++ b/app/Http/Controllers/Api/Manager/CourseDeadlineController.php
@@ -16,7 +16,7 @@ class CourseDeadlineController extends Controller
      */
     public function clearSelected(ClearSelectedDeadlineRequest $request, ClearAllDeadlineService $service): JsonResponse
     {
-        $courseIds = $request->validated()['course_ids'];
+        $courseIds = $request->validated()['courses'];
 
         // managerIDを取得
         $managerId = Auth::guard('instructor')->id();

--- a/app/Http/Requests/Manager/Course/ClearSelectedDeadlineRequest.php
+++ b/app/Http/Requests/Manager/Course/ClearSelectedDeadlineRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Manager\Course;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ClearSelectedDeadlineRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // middlewareで権限制御しているならtrueでOK
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'course_ids' => ['required', 'array'],
+            'course_ids.*' => ['integer', 'exists:courses,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Manager/Course/ClearSelectedDeadlineRequest.php
+++ b/app/Http/Requests/Manager/Course/ClearSelectedDeadlineRequest.php
@@ -15,16 +15,11 @@ class ClearSelectedDeadlineRequest extends FormRequest
         return true;
     }
 
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
-     */
     public function rules(): array
     {
         return [
-            'course_ids' => ['required', 'array'],
-            'course_ids.*' => ['integer', 'exists:courses,id'],
+            'courses' => ['required', 'array'],
+            'courses.*' => ['integer', 'exists:courses,id,deleted_at,NULL'],
         ];
     }
 }

--- a/app/Services/Course/ClearAllDeadlineService.php
+++ b/app/Services/Course/ClearAllDeadlineService.php
@@ -20,7 +20,7 @@ class ClearAllDeadlineService
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $managerId;
 
-        // マネージャー配下かつ、選択された講座だけに限定
+         // マネージャー配下かつ、選択された講座だけに限定
         $courseIds = Course::whereIn('instructor_id', $instructorIds)
             ->whereIn('id', $selectedCourseIds)
             ->pluck('id');

--- a/app/Services/Course/ClearAllDeadlineService.php
+++ b/app/Services/Course/ClearAllDeadlineService.php
@@ -11,16 +11,19 @@ class ClearAllDeadlineService
 {
     /**
      * @param  int  $managerId  実行マネージャーのID
+     * @param array $selectedCourseIds
      */
-    public function __invoke(int $managerId): void
+    public function __invoke(int $managerId, array $selectedCourseIds): void
     {
         /** @var Instructor $manager */
         $manager = Instructor::with('managings')->findOrFail($managerId);
         $instructorIds = $manager->managings->pluck('id')->toArray();
         $instructorIds[] = $managerId;
 
-        // 対象講座ID
-        $courseIds = Course::whereIn('instructor_id', $instructorIds)->pluck('id');
+        // マネージャー配下かつ、選択された講座だけに限定
+        $courseIds = Course::whereIn('instructor_id', $instructorIds)
+            ->whereIn('id', $selectedCourseIds)
+            ->pluck('id');
 
         if ($courseIds->isEmpty()) {
             return; // 冪等：対象なしなら何もしない

--- a/app/Services/Course/ClearSelectedDeadlineService.php
+++ b/app/Services/Course/ClearSelectedDeadlineService.php
@@ -7,7 +7,7 @@ use App\Model\Course;
 use App\Model\CourseDeadline;
 use App\Model\Instructor;
 
-class ClearAllDeadlineService
+class ClearSelectedDeadlineService
 {
     /**
      * @param  int  $managerId  実行マネージャーのID

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,7 +135,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-受講
             Route::prefix('attendance')->group(function () {
                 Route::post('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'store']);
-                Route::post('deadline/clear-Selected', [App\Http\Controllers\Api\Manager\CourseDeadlineController::class, 'clearSelected']);
                 // 講師-生徒学習状況
                 Route::prefix('{attendance_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -201,7 +201,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\CourseController::class, 'index']);
                     Route::put('status', [App\Http\Controllers\Api\Manager\CourseController::class, 'putStatus']);
                     Route::post('/', [App\Http\Controllers\Api\Manager\CourseController::class, 'store']);
-                    Route::post('deadline/clear-Selected', [App\Http\Controllers\Api\Manager\CourseDeadlineController::class, 'clearSelected']);
+                    Route::post('deadline/clear-selected',[App\Http\Controllers\Api\Manager\CourseDeadlineController::class, 'clearSelected']);
                     Route::prefix('{course_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\CourseController::class, 'show']);
                         Route::post('/', [App\Http\Controllers\Api\Manager\CourseController::class, 'update']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,6 +135,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             // 講師-受講
             Route::prefix('attendance')->group(function () {
                 Route::post('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'store']);
+                Route::post('deadline/clear-Selected', [App\Http\Controllers\Api\Manager\CourseDeadlineController::class, 'clearSelected']);
                 // 講師-生徒学習状況
                 Route::prefix('{attendance_id}')->group(function () {
                     Route::get('/', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'show']);
@@ -200,7 +201,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Manager\CourseController::class, 'index']);
                     Route::put('status', [App\Http\Controllers\Api\Manager\CourseController::class, 'putStatus']);
                     Route::post('/', [App\Http\Controllers\Api\Manager\CourseController::class, 'store']);
-                    Route::post('deadline/clear-all', [App\Http\Controllers\Api\Manager\CourseDeadlineController::class, 'clearAll']);
+                    Route::post('deadline/clear-Selected', [App\Http\Controllers\Api\Manager\CourseDeadlineController::class, 'clearSelected']);
                     Route::prefix('{course_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\CourseController::class, 'show']);
                         Route::post('/', [App\Http\Controllers\Api\Manager\CourseController::class, 'update']);


### PR DESCRIPTION
## Issue
JKA-1592
## 対応内容
「選択して受講期限をなくす」ボタンを押下したときに、
選択した講座を一括で受講期限をなくすようにする。

元々は選択されていなくても、存在する全ての受講期限をなくす仕様だったのを
選択したものだけの受講期限をなくすように変更。

・URL・リクエスト・レスポンスを考えてSlackで提出（済み）
・ロジック（コントローラなど）の修正
・フォームリクエストの作成

## 確認方法
Instructor ID➀( http://localhost:8080/api/v1/manager/course/deadline/clear-selected )true
Instructor ID➁( http://localhost:8080/api/v1/manager/course/deadline/clear-selected )Forbidden, not allowed to use manager api.マネージャー API の使用は許可されていません。

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)
チャットGPTを使用しながら進めました。足りない部分や間違っている部分があれば教えてください。
ご確認宜しくお願いします。