### PR TITLE
#JKA-1629 LessonControllerのdeleteメソッドの認可処理(Policyパターン)により不要になったManager側メソッドの削除と…（荒川）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -108,6 +108,10 @@ class LessonController extends Controller
             // ログイン講師のidと削除レッスンの講師IDが一致しないと削除できない
             $this->authorize('delete', $lesson);
 
+            // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
+            if ((int) $request->course_id !== $lesson->chapter->course_id) {
+                throw new AuthorizationException('Invalid course_id.');
+        }
             if ((int) $request->chapter_id !== $lesson->chapter->id) {
                 // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は更新を許可しない
                 throw new AuthorizationException('Invalid chapter_id.');

--- a/app/Http/Controllers/Api/Manager/LessonController.php
+++ b/app/Http/Controllers/Api/Manager/LessonController.php
@@ -98,48 +98,6 @@ class LessonController extends Controller
         ]);
     }
 
-    /**
-     * レッスン削除API
-     */
-    public function delete(DeleteRequest $request, DeleteLessonService $deleteLessonService): JsonResponse
-    {
-        DB::beginTransaction();
-        try {
-            // レッスン情報を取得
-            /** @var Lesson $lesson */
-            $lesson = Lesson::with('chapter')->findOrFail($request->lesson_id);
-
-            // 自分、または配下の講師の講座でないと削除できない
-            $this->authorize('delete', $lesson);
-
-            // 指定したチャプターIDがレッスンのチャプターIDと一致しない場合は許可しない
-            if ((int) $request->chapter_id !== $lesson->chapter->id) {
-                throw new AuthorizationException('Invalid chapter_id.');
-            }
-
-            // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
-            if ((int) $request->course_id !== $lesson->chapter->course_id) {
-                throw new AuthorizationException('Invalid course_id.');
-            }
-
-            // 受講情報が登録されている場合は許可しない
-            if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
-                throw new AuthorizationException('Forbidden, not allowed to delete this lesson.');
-            }
-
-            $deleteLessonService($lesson);
-
-            DB::commit();
-
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
-        }
-    }
 
     /**
      * レッスン並び替えAPI

--- a/app/Http/Controllers/Api/Manager/NotificationController.php
+++ b/app/Http/Controllers/Api/Manager/NotificationController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api\Manager;
 use App\Dto\Notification\PutDto;
 use App\Enums\Notification\StatusEnum;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Manager\Notification\BulkDeleteRequest;
 use App\Http\Requests\Manager\Notification\DeleteRequest;
 use App\Http\Requests\Manager\Notification\IndexRequest;
 use App\Http\Requests\Manager\Notification\PutRequest;
@@ -20,7 +19,6 @@ use App\Http\Resources\Manager\NotificationIndexResource;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
-use App\Services\Notification\BulkDeleteService;
 use App\Services\Notification\DeleteService;
 use App\Services\Notification\PutNotificationService;
 use App\Services\Notification\PutStatusAllService;
@@ -230,35 +228,6 @@ class NotificationController extends Controller
         return response()->json([
             'result' => true,
         ]);
-    }
-
-    /**
-     * お知らせ一括削除API
-     */
-    public function bulkDelete(BulkDeleteRequest $request, BulkDeleteService $service): JsonResponse
-    {
-        // 選択されたお知らせリストを取得
-        $notifications = Notification::whereIn('id', $request->notifications)->get();
-
-        // 講師と一致しないお知らせが含まれている場合はエラー
-        $this->authorize('bulkDelete', [Notification::class, $notifications]);
-
-        DB::beginTransaction();
-        try {
-            // viewed_once_notifications, notificationsテーブルのレコードを一括削除するサービス
-            $service($notifications);
-
-            // コミット
-            DB::commit();
-
-            return response()->json([
-                'result' => true,
-            ]);
-        } catch (Exception $e) {
-            DB::rollBack();
-            Log::error($e);
-            throw $e;
-        }
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -219,7 +219,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                                     Route::delete('all', [App\Http\Controllers\Api\Manager\LessonController::class, 'deleteAll']);
                                     Route::prefix('{lesson_id}')->group(function () {
                                         Route::put('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'put']);
-                                        Route::delete('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'delete']);
                                         Route::patch('status', [App\Http\Controllers\Api\Manager\LessonController::class, 'updateStatus']);
                                         Route::patch('title', [App\Http\Controllers\Api\Manager\LessonController::class, 'updateTitle']);
                                     });
@@ -259,7 +258,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::put('type/{notification_type}', [App\Http\Controllers\Api\Manager\NotificationController::class, 'updateType']);
                     Route::put('status', [App\Http\Controllers\Api\Manager\NotificationController::class, 'putStatus']);
                     Route::put('status/all', [App\Http\Controllers\Api\Manager\NotificationController::class, 'putStatusAll']);
-                    Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);
 
                     Route::prefix('{notification_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'show']);


### PR DESCRIPTION
…動作確認

## Issue
・NotificationControllerのputStatusメソッドの認可処理(Policyパターン)により不要になったManager側メソッドの削除と動作確認

## 対応内容
・app/Http/Controllers/Api/Instructor/LessonController.php
-下記のコードを追加
            // 指定した講座IDがレッスンの講座IDと一致しない場合は許可しない
            if ((int) $request->course_id !== $lesson->chapter->course_id) {
                throw new AuthorizationException('Invalid course_id.');
        }

・app/Http/Controllers/Api/Manager/LessonController.php
-deleteメソッドを削除

・app/Http/Controllers/Api/Manager/NotificationController.php
-bulkDeleteメソッドを削除
-下記のコードを削除
use App\Http\Requests\Manager\Notification\BulkDeleteRequest;
use App\Services\Notification\BulkDeleteService;

・routes/api.php
-下記のコードを削除
Route::delete('/', [App\Http\Controllers\Api\Manager\LessonController::class, 'delete']);
Route::delete('/', [App\Http\Controllers\Api\Manager\NotificationController::class, 'bulkDelete']);

## 確認方法
・instructor権限
DELETE：http://localhost:8080/api/v1/instructor/course/5/chapter/6/lesson/10　をDELETEメソッドで送信

・manager権限
DELETE：http://localhost:8080/api/v1/manager/course/5/chapter/6/lesson/10　をDELETEメソッドで送信

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)