### PR TITLE
講座一覧APIの変更→講座ごとに受講可能な人数の上限を設ける機能（丸山）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -54,7 +54,12 @@ class CourseController extends Controller
             }
         }
 
-        $query = Course::where('instructor_id', $instructorId)->withCount('attendances')
+        $query = Course::where('instructor_id', $instructorId)
+            ->withCount([
+                'attendances as current_attendance_count' => function ($query) {
+                    $query->where('attendance_deadline', '>=', now());
+                }
+            ])
             ->with(['tags', 'courseDeadline'])
             ->when($searchWord, function (Builder $query) use ($searchWord) {
                 $query->where(function (Builder $query) use ($searchWord) {
@@ -72,7 +77,7 @@ class CourseController extends Controller
         $courses = $query->paginate((int) $perPage);
 
         $courses->getCollection()->map(function (Course $course) {
-            $course->has_active_students = $course->attendances_count > 0;
+            $course->has_active_students = $course->current_attendance_count > 0;
         });
 
         return CourseIndexResource::collection($courses);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -58,7 +58,7 @@ class CourseController extends Controller
             ->withCount([
                 'attendances as current_attendance_count' => function ($query) {
                     $query->where('attendance_deadline', '>=', today());
-                }
+                },
             ])
             ->with(['tags', 'courseDeadline'])
             ->when($searchWord, function (Builder $query) use ($searchWord) {

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -57,7 +57,7 @@ class CourseController extends Controller
         $query = Course::where('instructor_id', $instructorId)
             ->withCount([
                 'attendances as current_attendance_count' => function ($query) {
-                    $query->where('attendance_deadline', '>=', now());
+                    $query->where('attendance_deadline', '>=', today());
                 }
             ])
             ->with(['tags', 'courseDeadline'])

--- a/app/Http/Resources/Instructor/CourseIndexResource.php
+++ b/app/Http/Resources/Instructor/CourseIndexResource.php
@@ -31,6 +31,8 @@ class CourseIndexResource extends JsonResource
             'course_deadline' => $this->resource->courseDeadline
                 ? new CourseDeadlineResource($this->resource->courseDeadline)
                 : null,
+            'capacity' => $this->resource->capacity,
+            'current_attendance_count' => $this->resource->current_attendance_count ?? 0,
         ];
     }
 }

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property bool $has_active_students
  * @property int $progress_percentage
  * @property int|null $capacity
+ * @property int $current_attendance_count
  */
 class Course extends Model
 {


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-1658
## 対応内容

- CourseController.phpで withCount を追加して一部修正。
```
->withCount([
     'attendances as current_attendance_count' => function ($query) {
         $query->where('attendance_deadline', '>=', now());
     }
])
```
- CourseIndexResource.phpにcapacity とカウント追加

```
　'capacity' => $this->resource->capacity,
    'current_attendance_count' => $this->resource->current_attendance_count ?? 0,
```

## 確認方法

- postmanでinstructor_id2でログイン後、GETでhttp://localhost:8080/api/v1/instructor/course/index を送信後、以下のレスポンスを確認（一部省略）
```
{
    "data": [
        {
            "course_id": 2,
            "image": "course/dbe1f6ef-66b4-4ce0-bfef-7555b6213bd4.png",
            "title": "Laravel入門講座",
            "status": "public",
            "has_active_students": true,
            "tags": [
                {
                    "tag_id": 2,
                    "content": "バックエンド講座"
                }
            ],
            "course_deadline": {
                "course_deadline_id": 1,
                "fixed_date": "2026-03-21",
                "relative_days": null
            },
            "capacity": null,
            "current_attendance_count": 1
        },
        {
            "course_id": 6,
            "image": "course/3904fc96-affc-4671-89a4-a2ae91dc27f8.png",
            "title": "Vue入門講座",
            "status": "public",
            "has_active_students": false,
            "tags": [],
            "course_deadline": null,
            "capacity": null,
            "current_attendance_count": 0
        }
    ],
}

```
## 補足(任意)
・テーブル関連がマージされるまでは一旦自分でテーブルに仮で反映させて動作させる必要がある。
とのことでしたが自分がdevelopからpullしたときにはおそらく、すささんのタスクがマージされてたのか仮で反映させる必要がありませんでした。