### PR TITLE
JKA-1644　空の配列を返すルーターとコントローラ実装（タマキ）

### DIFF
--- a/app/Http/Controllers/Api/Student/LearningHistoryController.php
+++ b/app/Http/Controllers/Api/Student/LearningHistoryController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Api\Student;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class LearningHistoryController extends Controller
+{
+    public function index() {
+        return response()->json([]);
+    }
+}

--- a/app/Http/Controllers/Api/Student/LearningHistoryController.php
+++ b/app/Http/Controllers/Api/Student/LearningHistoryController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Api\Student;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 
 class LearningHistoryController extends Controller
 {
-    public function index() {
+    public function index()
+    {
         return response()->json([]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::prefix('student')->group(function () {
             Route::get('/', [App\Http\Controllers\Api\Student\StudentController::class, 'show'])->name('show');
             Route::post('update', [App\Http\Controllers\Api\Student\StudentController::class, 'update'])->name('update');
+            Route::get('learning_history', [App\Http\Controllers\Api\Student\LearningHistoryController::class, 'index']);
         });
 
         // 受講生-受講

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,7 +36,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
         Route::prefix('student')->group(function () {
             Route::get('/', [App\Http\Controllers\Api\Student\StudentController::class, 'show'])->name('show');
             Route::post('update', [App\Http\Controllers\Api\Student\StudentController::class, 'update'])->name('update');
-            Route::get('learning_history', [App\Http\Controllers\Api\Student\LearningHistoryController::class, 'index']);
+            Route::get('learning-history', [App\Http\Controllers\Api\Student\LearningHistoryController::class, 'index'])->name('learning-history.index');
         });
 
         // 受講生-受講


### PR DESCRIPTION
## Issue
・ https://gut-familie.atlassian.net/browse/JKA-1644
## 対応内容
・ routes\api.php内に
```
Route::get('learning_history', [App\Http\Controllers\Api\Student\LearningHistoryController::class, 'index']);
```
・ Api\Student\LearningHistoryController.php

　上記を作成。
## 確認方法
・ postmanにて

・ http://localhost:8080/login でログイン後

・ http://localhost:8080/api/v1/student/learning_history にて
```
[]
```
上記の確認。
## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)