### PR TITLE
マネージャー側 講師-講座情報一覧取得APIへの定員情報の追加（丸山）

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -39,6 +39,7 @@ class CourseController extends Controller
         }
 
         $courses = Course::with(['tags', 'courseDeadline'])
+            ->withCount('attendances') 
             ->where('instructor_id', $request->instructor_id)
             ->paginate($perPage, ['*'], 'page', $page);
 

--- a/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/CourseController.php
@@ -39,7 +39,7 @@ class CourseController extends Controller
         }
 
         $courses = Course::with(['tags', 'courseDeadline'])
-            ->withCount('attendances') 
+            ->withCount('attendances')
             ->where('instructor_id', $request->instructor_id)
             ->paginate($perPage, ['*'], 'page', $page);
 

--- a/app/Http/Resources/Base/Instructor/CourseResource.php
+++ b/app/Http/Resources/Base/Instructor/CourseResource.php
@@ -23,6 +23,10 @@ class CourseResource extends JsonResource
             'course_deadline' => $this->resource->courseDeadline
                 ? new CourseDeadlineResource($this->resource->courseDeadline)
                 : null,
+            'capacity' => $this->resource->capacity,
+            'current_attendance_count' => $this->resource->capacity !== null
+                ? ($this->resource->attendances_count ?? 0)
+                : null,
         ];
     }
 }

--- a/app/Http/Resources/Base/Instructor/CourseResource.php
+++ b/app/Http/Resources/Base/Instructor/CourseResource.php
@@ -23,10 +23,6 @@ class CourseResource extends JsonResource
             'course_deadline' => $this->resource->courseDeadline
                 ? new CourseDeadlineResource($this->resource->courseDeadline)
                 : null,
-            'capacity' => $this->resource->capacity,
-            'current_attendance_count' => $this->resource->capacity !== null
-                ? ($this->resource->attendances_count ?? 0)
-                : null,
         ];
     }
 }

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -25,6 +25,10 @@ class InstructorCourseIndexResource extends JsonResource
             ...(new CourseResource($this->resource))->toArray($request),
             'updated_at' => $this->resource->updated_at->format('Y/m/d H:i:s'),
             'tags' => TagResource::collection($this->resource->tags),
+            'capacity' => $this->resource->capacity,
+            'current_attendance_count' => $this->resource->capacity !== null
+                ? ($this->resource->attendances_count ?? 0)
+                : null,            
         ];
     }
 }

--- a/app/Http/Resources/Manager/InstructorCourseIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorCourseIndexResource.php
@@ -28,7 +28,7 @@ class InstructorCourseIndexResource extends JsonResource
             'capacity' => $this->resource->capacity,
             'current_attendance_count' => $this->resource->capacity !== null
                 ? ($this->resource->attendances_count ?? 0)
-                : null,            
+                : null,
         ];
     }
 }

--- a/tests/Feature/Api/Manager/Instructor/Course/IndexTest.php
+++ b/tests/Feature/Api/Manager/Instructor/Course/IndexTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Manager\Instructor\Course;
 
+use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\ManageInstructor;
@@ -46,6 +47,55 @@ class IndexTest extends TestCase
         $response->assertJson([
             'message' => 'Forbidden, invalid instructor_id.',
         ]);
+    }
+
+    public function test_定員あり講座_受講者数が返却される(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $subordinate = Instructor::factory()->create(['type' => 'instructor']);
+        ManageInstructor::factory()->create([
+            'manager_id' => $manager->id,
+            'instructor_id' => $subordinate->id,
+        ]);
+        $course = Course::factory()->create([
+            'instructor_id' => $subordinate->id,
+            'capacity' => 10,
+        ]);
+        Attendance::factory()->count(3)->create(['course_id' => $course->id]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('manager.instructor.course.index', ['instructor_id' => $subordinate->id]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.capacity', 10);
+        $response->assertJsonPath('data.0.current_attendance_count', 3);
+    }
+
+    public function test_定員なし講座_受講者数がnullで返却される(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $subordinate = Instructor::factory()->create(['type' => 'instructor']);
+        ManageInstructor::factory()->create([
+            'manager_id' => $manager->id,
+            'instructor_id' => $subordinate->id,
+        ]);
+        Course::factory()->create([
+            'instructor_id' => $subordinate->id,
+            'capacity' => null,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('manager.instructor.course.index', ['instructor_id' => $subordinate->id]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.capacity', null);
+        $response->assertJsonPath('data.0.current_attendance_count', null);
     }
 
     public function test_バリデーションエラー(): void


### PR DESCRIPTION
## Issue
・https://gut-familie.atlassian.net/browse/JKA-1677
## 対応内容
【Controller】
indexにwithCount を追加
$courses = Course::with(['tags', 'courseDeadline'])
　　->withCount('attendances')   // 追加
    ->where('instructor_id', $request->instructor_id)
    ->paginate($perPage, ['*'], 'page', $page);

【CourseResource 】
追加
'capacity' => $this->resource->capacity,
'current_attendance_count' => $this->resource->capacity !== null
     ? ($this->resource->attendances_count ?? 0)
     : null,
## 確認方法　Postman

- 定員あり講座
<img width="582" height="330" alt="c67956271434236223938c20c4568f82" src="https://github.com/user-attachments/assets/5d58fc5e-fd36-4086-ad53-7b0f052cc4bf" />

- 定員なし講座
<img width="498" height="304" alt="cf83f07e542e2a022d44c6fa0698c023" src="https://github.com/user-attachments/assets/dcfa7ad6-9075-41dd-87f3-ff3254ee2f15" />
