### PR TITLE
JKA-1666 講師側 講座更新APIで講座定員人数も更新できるように変更する(永渕)

### DIFF
--- a/app/Http/Resources/Base/Instructor/CourseResource.php
+++ b/app/Http/Resources/Base/Instructor/CourseResource.php
@@ -19,6 +19,7 @@ class CourseResource extends JsonResource
             'title' => $this->resource->title,
             'image' => $this->resource->image,
             'status' => $this->resource->status,
+            'capacity' => $this->resource->capacity,
             'deadline_type' => $this->resource->deadline_type,
             'course_deadline' => $this->resource->courseDeadline
                 ? new CourseDeadlineResource($this->resource->courseDeadline)


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-1666

## 対応内容
・URL・リクエスト・レスポンスを考えてSlackで提出
・ロジックの修正を実施
　変更内容）
　　App\Http\Resources\Base\Instructor\CourseResource.php内に「'capacity' => $this->resource->capacity,」を追加。

## 確認方法

## 関連資料(任意)
・'capaity'を表示させるため、マイグレーションを実行し、Adiｍner（SQL）内を更新。
その後、Postmanで特定講師下にて'capaity'が表示されるか確認を行い、成功（200 OK）
・別の講師でログインし、認証エラーが起こるか確認し、成功（403 Forbidden）

## スクショ(任意)

## 質問(任意)

## その他(任意)