### PR TITLE
JKA-1684 受講状況取得APIのロジック（コントローラ等）修正(すさ)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -95,7 +95,7 @@ class AttendanceController extends Controller
      */
     public function show(ShowRequest $request): AttendanceShowResource
     {
-        $attendance = Attendance::with('course.tags')->findOrFail($request->attendance_id);
+        $attendance = Attendance::with(['course.tags', 'course.courseDeadline'])->findOrFail($request->attendance_id);
 
         $this->authorize('view', [Attendance::class, $attendance]);
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -109,7 +109,6 @@ class AttendanceController extends Controller
         return new AttendanceShowResource([
             'attendance' => $attendance,
             'studentsCount' => $studentsCount,
-            'capacity' => $attendance->course->capacity,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -109,6 +109,7 @@ class AttendanceController extends Controller
         return new AttendanceShowResource([
             'attendance' => $attendance,
             'studentsCount' => $studentsCount,
+            'capacity' => $attendance->course->capacity,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -12,7 +12,6 @@ use App\Http\Requests\Instructor\Attendance\StoreRequest;
 use App\Http\Resources\Instructor\Attendance\StatusResource;
 use App\Http\Resources\Instructor\AttendanceShowResource;
 use App\Model\Attendance;
-use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
@@ -98,10 +97,6 @@ class AttendanceController extends Controller
         $attendance = Attendance::with(['course.tags', 'course.courseDeadline'])->findOrFail($request->attendance_id);
 
         $this->authorize('view', [Attendance::class, $attendance]);
-
-        Chapter::with([
-            'lessons.lessonAttendances',
-        ])->where('course_id', $attendance->course_id)->get();
 
         /** @var int */
         $studentsCount = Attendance::where('course_id', $attendance->course_id)->count();

--- a/app/Http/Resources/Base/Instructor/CourseResource.php
+++ b/app/Http/Resources/Base/Instructor/CourseResource.php
@@ -19,6 +19,7 @@ class CourseResource extends JsonResource
             'title' => $this->resource->title,
             'image' => $this->resource->image,
             'status' => $this->resource->status,
+            'capacity' => $this->resource->capacity,
             'deadline_type' => $this->resource->deadline_type,
             'course_deadline' => $this->resource->courseDeadline
                 ? new CourseDeadlineResource($this->resource->courseDeadline)

--- a/app/Http/Resources/Instructor/AttendanceShowResource.php
+++ b/app/Http/Resources/Instructor/AttendanceShowResource.php
@@ -19,6 +19,7 @@ class AttendanceShowResource extends JsonResource
         return [
             ...(new AttendanceResource($this->resource['attendance']))->toArray($request),
             'students_count' => $this->resource['studentsCount'],
+            'capacity' => $this->resource['attendance']->course->capacity,
         ];
     }
 }

--- a/app/Http/Resources/Instructor/AttendanceShowResource.php
+++ b/app/Http/Resources/Instructor/AttendanceShowResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources\Instructor;
 
 use App\Http\Resources\Base\Instructor\AttendanceResource;
+use App\Http\Resources\Base\Instructor\CourseResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AttendanceShowResource extends JsonResource
@@ -18,8 +19,8 @@ class AttendanceShowResource extends JsonResource
     {
         return [
             ...(new AttendanceResource($this->resource['attendance']))->toArray($request),
+            'course' => new CourseResource($this->resource['attendance']->course),
             'students_count' => $this->resource['studentsCount'],
-            'capacity' => $this->resource['attendance']->course->capacity,
         ];
     }
 }

--- a/tests/Feature/Api/Instructor/Attendance/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowTest.php
@@ -4,9 +4,11 @@ namespace Tests\Feature\Api\Instructor\Attendance;
 
 use App\Model\Attendance;
 use App\Model\Course;
+use App\Model\CourseDeadline;
 use App\Model\Instructor;
 use App\Model\ManageInstructor;
 use App\Model\Student;
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -35,6 +37,15 @@ class ShowTest extends TestCase
             'data' => [
                 'attendance_id',
                 'attendance_deadline',
+                'course' => [
+                    'course_id',
+                    'title',
+                    'image',
+                    'status',
+                    'capacity',
+                    'deadline_type',
+                    'course_deadline',
+                ],
                 'students_count',
             ],
         ]);
@@ -66,12 +77,21 @@ class ShowTest extends TestCase
             'data' => [
                 'attendance_id',
                 'attendance_deadline',
+                'course' => [
+                    'course_id',
+                    'title',
+                    'image',
+                    'status',
+                    'capacity',
+                    'deadline_type',
+                    'course_deadline',
+                ],
                 'students_count',
             ],
         ]);
     }
 
-    public function test_講師で状況状況を取得(): void
+    public function test_講師で受講状況を取得(): void
     {
         // Arrange — 講師が自分の講座の受講を取得
         $instructor = Instructor::factory()->create(['type' => 'instructor']);
@@ -92,9 +112,128 @@ class ShowTest extends TestCase
             'data' => [
                 'attendance_id',
                 'attendance_deadline',
+                'course' => [
+                    'course_id',
+                    'title',
+                    'image',
+                    'status',
+                    'capacity',
+                    'deadline_type',
+                    'course_deadline',
+                ],
                 'students_count',
             ],
         ]);
+    }
+
+    public function test_レスポンスの値が正しい(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'capacity' => 30,
+        ]);
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create([
+            'student_id' => $student->id,
+            'course_id' => $course->id,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $attendance->id]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'attendance_id' => $attendance->id,
+                'course' => [
+                    'course_id' => $course->id,
+                    'title' => $course->title,
+                    'status' => $course->status,
+                    'capacity' => 30,
+                ],
+                'students_count' => 1,
+            ],
+        ]);
+    }
+
+    public function test_定員未設定の場合capacityがnullで返る(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'capacity' => null,
+        ]);
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create([
+            'student_id' => $student->id,
+            'course_id' => $course->id,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $attendance->id]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'course' => [
+                    'capacity' => null,
+                ],
+            ],
+        ]);
+    }
+
+    public function test_受講生が複数いる場合のカウント(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $students = Student::factory()->count(3)->create();
+        foreach ($students as $student) {
+            Attendance::factory()->create([
+                'student_id' => $student->id,
+                'course_id' => $course->id,
+            ]);
+        }
+        $firstAttendance = Attendance::where('course_id', $course->id)->first();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $firstAttendance->id]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'students_count' => 3,
+            ],
+        ]);
+    }
+
+    public function test_受講期限切れの場合は閲覧不可(): void
+    {
+        // Arrange — 受講期限が過去の受講
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create([
+            'student_id' => $student->id,
+            'course_id' => $course->id,
+            'attendance_deadline' => CarbonImmutable::yesterday(),
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $attendance->id]));
+
+        // Assert
+        $response->assertStatus(403);
     }
 
     public function test_権限がない講師_失敗(): void
@@ -120,7 +259,63 @@ class ShowTest extends TestCase
         ]);
     }
 
-    public function test_バリデーションエラー(): void
+    public function test_マネージャーで配下でない講師の受講は取得不可(): void
+    {
+        // Arrange — マネージャーだが配下でない講師の講座
+        $manager = Instructor::factory()->create();
+        $unrelatedInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $unrelatedInstructor->id]);
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create([
+            'student_id' => $student->id,
+            'course_id' => $course->id,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $attendance->id]));
+
+        // Assert
+        $response->assertStatus(403);
+    }
+
+    public function test_論理削除済みの受講はバリデーションエラー(): void
+    {
+        // Arrange — 論理削除された受講
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create([
+            'student_id' => $student->id,
+            'course_id' => $course->id,
+        ]);
+        $attendanceId = $attendance->id;
+        $attendance->delete();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $attendanceId]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['attendance_id']);
+    }
+
+    public function test_存在しないattendance_idはバリデーションエラー(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => 99999]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['attendance_id']);
+    }
+
+    public function test_バリデーションエラー_文字列(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
@@ -134,5 +329,39 @@ class ShowTest extends TestCase
         $response->assertJsonValidationErrors([
             'attendance_id',
         ]);
+    }
+
+    public function test_講座に期限設定がある場合のレスポンス(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'deadline_type' => 'fixed',
+        ]);
+        CourseDeadline::factory()->create([
+            'course_id' => $course->id,
+            'fixed_date' => '2026-12-31',
+        ]);
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create([
+            'student_id' => $student->id,
+            'course_id' => $course->id,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $attendance->id]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'course' => [
+                    'deadline_type' => 'fixed',
+                ],
+            ],
+        ]);
+        $response->assertJsonPath('data.course.course_deadline.fixed_date', '2026-12-31');
     }
 }


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1684
## 対応内容
- Instructor/AttendanceController.php の show メソッドで、リソースに渡すデータに capacity（$attendance->course->capacity）を追加
## 確認方法
- app/Http/Resources/Instructor/AttendanceShowResource.php
toArray メソッド内に 'capacity'が返ってくるよう追記し定員上限数有り・無しでリクエスト。スクショのレスポンス確認。（その後toArray メソッド内の記述は削除しています）
## 関連資料(任意)

## スクショ(任意)
<img width="903" height="788" alt="スクリーンショット 2026-03-06 0 31 31" src="https://github.com/user-attachments/assets/58ef9a5b-636b-4a88-9a6a-b0337b37b7d9" />
<img width="903" height="788" alt="スクリーンショット 2026-03-06 0 30 43" src="https://github.com/user-attachments/assets/4ac384ba-840e-40c9-b8b2-9c3357cd3fb3" />

## 質問(任意)

## その他(任意)