### PR TITLE
JKA-1708    2.空の配列を返すルーターとコントローラの作成（えんどう)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -223,6 +223,16 @@ class CourseController extends Controller
     }
 
     /**
+     * 受講定員一括変更API
+     */
+    public function putCapacity(): JsonResponse
+    {
+        return response()->json([
+            'result' => true,
+        ]);
+    }
+
+    /**
      * 講座一括削除API
      */
     public function bulkDelete(BulkDeleteRequest $request, DeleteService $service): JsonResponse

--- a/routes/api.php
+++ b/routes/api.php
@@ -76,6 +76,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::get('index', [App\Http\Controllers\Api\Instructor\CourseController::class, 'index'])->name('index');
                     Route::post('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'store'])->name('store');
                     Route::put('status', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putStatus'])->name('put-status');
+                    Route::put('capacity', [App\Http\Controllers\Api\Instructor\CourseController::class, 'putCapacity'])->name('put-capacity');
                     Route::delete('/', [App\Http\Controllers\Api\Instructor\CourseController::class, 'bulkDelete'])->name('bulk-delete');
                     Route::get('tag/index', [App\Http\Controllers\Api\Instructor\Course\TagController::class, 'index'])->name('tag.index');
                     Route::patch('deadline', [App\Http\Controllers\Api\Instructor\CourseDeadlineController::class, 'bulkUpdate'])->name('deadline.bulk-update');


### PR DESCRIPTION
## Issue
JKA-1708

## 対応内容
空の配列を返すルーターとコントローラの作成
・api.phpに新たなルーティングを実装
・app/Http/Controllers/Api/Instructor/CourseController.phpに空の配列が返るputCapacityメソッドを実装

## 確認方法
postmanでPUT http://localhost:8085/api/v1/instructor/course/capacity
を叩き、レスポンスに
`{
    "result": true
}`
が返ることを確認