### PR TITLE
要フォロー受講生APIの新規作成（丸山）

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Attendance\DeleteRequest;
+use App\Http\Requests\Instructor\Attendance\FollowUpRequest;
 use App\Http\Requests\Instructor\Attendance\LoginRateRequest;
 use App\Http\Requests\Instructor\Attendance\ShowRequest;
 use App\Http\Requests\Instructor\Attendance\ShowStatusRequest;
@@ -16,6 +17,7 @@ use App\Model\Course;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Attendance\CalculateDeadlineService;
+use App\Services\Attendance\FollowUpService;
 use Carbon\CarbonImmutable;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -258,5 +260,18 @@ class AttendanceController extends Controller
         $this->authorize('view', $attendance->course);
 
         return new StatusResource($attendance);
+    }
+
+    /**
+     * 要フォロー受講生API
+     */
+    public function followUp(FollowUpRequest $request, FollowUpService $service): JsonResponse
+    {
+        $course = Course::findOrFail($request->course_id);
+        $this->authorize('view', $course);
+
+        $followUpStudents = $service->getFollowUpStudents($request->course_id, $request->days);
+
+        return response()->json($followUpStudents);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\Instructor\Attendance\ShowRequest;
 use App\Http\Requests\Instructor\Attendance\ShowStatusRequest;
 use App\Http\Requests\Instructor\Attendance\StatusRequest;
 use App\Http\Requests\Instructor\Attendance\StoreRequest;
+use App\Http\Resources\Instructor\Attendance\FollowUpResource;
 use App\Http\Resources\Instructor\Attendance\StatusResource;
 use App\Http\Resources\Instructor\AttendanceShowResource;
 use App\Model\Attendance;
@@ -270,8 +271,10 @@ class AttendanceController extends Controller
         $course = Course::findOrFail($request->course_id);
         $this->authorize('view', $course);
 
-        $followUpStudents = $service->getFollowUpStudents($request->course_id, $request->days);
+        $students = $service($request->course_id, $request->days);
 
-        return response()->json($followUpStudents);
+        return response()->json([
+            'students' => FollowUpResource::collection($students),
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -23,6 +23,7 @@ use Carbon\CarbonImmutable;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -266,15 +267,13 @@ class AttendanceController extends Controller
     /**
      * 要フォロー受講生API
      */
-    public function followUp(FollowUpRequest $request, FollowUpService $service): JsonResponse
+    public function followUp(FollowUpRequest $request, FollowUpService $service): AnonymousResourceCollection
     {
         $course = Course::findOrFail($request->course_id);
         $this->authorize('view', $course);
 
         $students = $service($request->course_id, $request->days);
 
-        return response()->json([
-            'students' => FollowUpResource::collection($students),
-        ]);
+        return FollowUpResource::collection($students);
     }
 }

--- a/app/Http/Requests/Instructor/Attendance/FollowUpRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/FollowUpRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Attendance;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FollowUpRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+            'days'      => ['required', 'integer', 'min:1'],
+        ];
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Requests/Instructor/Attendance/FollowUpRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/FollowUpRequest.php
@@ -23,7 +23,7 @@ class FollowUpRequest extends FormRequest
     {
         return [
             'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
-            'days'      => ['required', 'integer', 'min:1'],
+            'days' => ['required', 'integer', 'min:1'],
         ];
     }
 

--- a/app/Http/Resources/Instructor/Attendance/FollowUpResource.php
+++ b/app/Http/Resources/Instructor/Attendance/FollowUpResource.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Resources\Instructor\Attendance;
 
-use Illuminate\Http\Request;
 use Carbon\CarbonImmutable;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class FollowUpResource extends JsonResource
@@ -13,15 +13,16 @@ class FollowUpResource extends JsonResource
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function toArray(Request $request): array
     {
         $lastLogin = $this->latest_login_at;
 
         return [
-            'student_id'       => $this->id,
-            'name'             => $this->last_name . ' ' . $this->first_name,
-            'email'            => $this->email,
-            'last_login_at'    => $lastLogin
+            'student_id' => $this->id,
+            'name' => $this->last_name.' '.$this->first_name,
+            'email' => $this->email,
+            'last_login_at' => $lastLogin
                 ? CarbonImmutable::parse($lastLogin)->toIso8601String()
                 : null,
             'days_since_login' => $lastLogin

--- a/app/Http/Resources/Instructor/Attendance/FollowUpResource.php
+++ b/app/Http/Resources/Instructor/Attendance/FollowUpResource.php
@@ -2,12 +2,16 @@
 
 namespace App\Http\Resources\Instructor\Attendance;
 
+use App\Model\Student;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class FollowUpResource extends JsonResource
 {
+    /** @var Student */
+    public $resource;
+
     /**
      * Transform the resource into an array.
      *
@@ -16,17 +20,15 @@ class FollowUpResource extends JsonResource
     #[\Override]
     public function toArray(Request $request): array
     {
-        $lastLogin = $this->latest_login_at;
-
         return [
-            'student_id' => $this->id,
-            'name' => $this->last_name.' '.$this->first_name,
-            'email' => $this->email,
-            'last_login_at' => $lastLogin
-                ? CarbonImmutable::parse($lastLogin)->toIso8601String()
+            'student_id' => $this->resource->id,
+            'name' => $this->resource->last_name.' '.$this->resource->first_name,
+            'email' => $this->resource->email,
+            'last_login_at' => $this->resource->latest_login_at
+                ? CarbonImmutable::parse($this->resource->latest_login_at)->toDateTimeString()
                 : null,
-            'days_since_login' => $lastLogin
-                ? (int) CarbonImmutable::parse($lastLogin)->diffInDays(CarbonImmutable::now())
+            'days_since_login' => $this->resource->latest_login_at
+                ? (int) CarbonImmutable::parse($this->resource->latest_login_at)->diffInDays(CarbonImmutable::now())
                 : null,
         ];
     }

--- a/app/Http/Resources/Instructor/Attendance/FollowUpResource.php
+++ b/app/Http/Resources/Instructor/Attendance/FollowUpResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources\Instructor\Attendance;
+
+use Illuminate\Http\Request;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class FollowUpResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $lastLogin = $this->latest_login_at;
+
+        return [
+            'student_id'       => $this->id,
+            'name'             => $this->last_name . ' ' . $this->first_name,
+            'email'            => $this->email,
+            'last_login_at'    => $lastLogin
+                ? CarbonImmutable::parse($lastLogin)->toIso8601String()
+                : null,
+            'days_since_login' => $lastLogin
+                ? (int) CarbonImmutable::parse($lastLogin)->diffInDays(CarbonImmutable::now())
+                : null,
+        ];
+    }
+}

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -7,6 +7,9 @@ use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
+/**
+ * @property CarbonImmutable|null $latest_login_at
+ */
 class Student extends Authenticatable
 {
     use HasFactory;

--- a/app/Services/Attendance/FollowUpService.php
+++ b/app/Services/Attendance/FollowUpService.php
@@ -4,7 +4,8 @@ namespace App\Services\Attendance;
 
 use App\Model\Student;
 use App\Model\StudentLoginHistory;
-use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 final class FollowUpService
 {
@@ -13,13 +14,10 @@ final class FollowUpService
      *
      * @param int $course_id 講座ID
      * @param int $days 最終ログインからの日数
-     * @return array フォローが必要な受講生のリスト
      */
-    public function getFollowUpStudents(int $course_id, int $days): array
+    public function __invoke(int $course_id, int $days): Collection
     {
-        $now = CarbonImmutable::now();
-
-        $students = Student::whereHas('attendances', fn($q) => $q->where('course_id', $course_id))
+        return Student::whereHas('attendances', fn($q) => $q->where('course_id', $course_id))
             ->select([
                 'students.id',
                 'students.last_name',
@@ -32,30 +30,17 @@ final class FollowUpService
                     ->latest('logged_in_at')
                     ->limit(1),
             ])
-            ->get()
-            ->map(function ($student) use ($now) {
-                $lastLogin = $student->latest_login_at;
-                $daysSince = $lastLogin
-                    ? (int) CarbonImmutable::parse($lastLogin)->diffInDays($now)
-                    : PHP_INT_MAX;
-
-                return [
-                    'student_id'       => $student->id,
-                    'name'             => $student->last_name . ' ' . $student->first_name,
-                    'email'            => $student->email,
-                    'last_login_at'    => $lastLogin
-                        ? CarbonImmutable::parse($lastLogin)->toIso8601String()
-                        : null,
-                    'days_since_login' => $daysSince,
-                ];
+            ->having(
+                DB::raw('DATEDIFF(NOW(), (SELECT MAX(logged_in_at) FROM student_login_histories WHERE student_id = students.id))'),
+                '>=',
+                $days
+            )
+            ->orWhereNotExists(function ($query) {
+                $query->select(DB::raw(1))
+                    ->from('student_login_histories')
+                    ->whereColumn('student_id', 'students.id');
             })
-            ->filter(fn($s) => $s['days_since_login'] >= $days)
-            ->sortByDesc('days_since_login')
-            ->map(fn($s) => array_merge($s, [
-                'days_since_login' => $s['days_since_login'] === PHP_INT_MAX ? null : $s['days_since_login'], // 最後にnullへ変換
-            ]))
-            ->values();
-
-        return ['students' => $students];
+            ->orderByRaw('latest_login_at IS NULL DESC, latest_login_at ASC')
+            ->get();
     }
 }

--- a/app/Services/Attendance/FollowUpService.php
+++ b/app/Services/Attendance/FollowUpService.php
@@ -4,16 +4,16 @@ namespace App\Services\Attendance;
 
 use App\Model\Student;
 use App\Model\StudentLoginHistory;
-use Illuminate\Support\Collection;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
 
 final class FollowUpService
 {
     /**
      * 要フォロー受講生を取得する
      *
-     * @param int $course_id 講座ID
-     * @param int $days 最終ログインからの日数
+     * @param  int  $course_id  講座ID
+     * @param  int  $days  最終ログインからの日数
      */
     public function __invoke(int $course_id, int $days): Collection
     {

--- a/app/Services/Attendance/FollowUpService.php
+++ b/app/Services/Attendance/FollowUpService.php
@@ -5,7 +5,7 @@ namespace App\Services\Attendance;
 use App\Model\Student;
 use App\Model\StudentLoginHistory;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Carbon\CarbonImmutable;
 
 final class FollowUpService
 {
@@ -17,7 +17,9 @@ final class FollowUpService
      */
     public function __invoke(int $course_id, int $days): Collection
     {
-        return Student::whereHas('attendances', fn($q) => $q->where('course_id', $course_id))
+        $threshold = CarbonImmutable::now()->subDays($days);
+
+        return Student::whereHas('attendances', fn ($q) => $q->where('course_id', $course_id))
             ->select([
                 'students.id',
                 'students.last_name',
@@ -30,11 +32,7 @@ final class FollowUpService
                     ->latest('logged_in_at')
                     ->limit(1),
             ])
-            ->having(
-                DB::raw('IFNULL(DATEDIFF(NOW(), (SELECT MAX(logged_in_at) FROM student_login_histories WHERE student_id = students.id)), 99999)'),
-                '>=',
-                $days
-            )
+            ->whereDoesntHave('loginHistories', fn ($q) => $q->where('logged_in_at', '>', $threshold))
             ->orderByRaw('latest_login_at IS NULL DESC, latest_login_at ASC')
             ->get();
     }

--- a/app/Services/Attendance/FollowUpService.php
+++ b/app/Services/Attendance/FollowUpService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Attendance;
+
+use App\Model\Student;
+use App\Model\StudentLoginHistory;
+use Carbon\CarbonImmutable;
+
+final class FollowUpService
+{
+    /**
+     * 要フォロー受講生を取得する
+     *
+     * @param int $course_id 講座ID
+     * @param int $days 最終ログインからの日数
+     * @return array フォローが必要な受講生のリスト
+     */
+    public function getFollowUpStudents(int $course_id, int $days): array
+    {
+        $now = CarbonImmutable::now();
+
+        $students = Student::whereHas('attendances', fn($q) => $q->where('course_id', $course_id))
+            ->select([
+                'students.id',
+                'students.last_name',
+                'students.first_name',
+                'students.email',
+            ])
+            ->addSelect([
+                'latest_login_at' => StudentLoginHistory::select('logged_in_at')
+                    ->whereColumn('student_id', 'students.id')
+                    ->latest('logged_in_at')
+                    ->limit(1),
+            ])
+            ->get()
+            ->map(function ($student) use ($now) {
+                $lastLogin = $student->latest_login_at;
+                $daysSince = $lastLogin
+                    ? (int) CarbonImmutable::parse($lastLogin)->diffInDays($now)
+                    : PHP_INT_MAX;
+
+                return [
+                    'student_id'       => $student->id,
+                    'name'             => $student->last_name . ' ' . $student->first_name,
+                    'email'            => $student->email,
+                    'last_login_at'    => $lastLogin
+                        ? CarbonImmutable::parse($lastLogin)->toIso8601String()
+                        : null,
+                    'days_since_login' => $daysSince,
+                ];
+            })
+            ->filter(fn($s) => $s['days_since_login'] >= $days)
+            ->sortByDesc('days_since_login')
+            ->map(fn($s) => array_merge($s, [
+                'days_since_login' => $s['days_since_login'] === PHP_INT_MAX ? null : $s['days_since_login'], // 最後にnullへ変換
+            ]))
+            ->values();
+
+        return ['students' => $students];
+    }
+}

--- a/app/Services/Attendance/FollowUpService.php
+++ b/app/Services/Attendance/FollowUpService.php
@@ -31,15 +31,10 @@ final class FollowUpService
                     ->limit(1),
             ])
             ->having(
-                DB::raw('DATEDIFF(NOW(), (SELECT MAX(logged_in_at) FROM student_login_histories WHERE student_id = students.id))'),
+                DB::raw('IFNULL(DATEDIFF(NOW(), (SELECT MAX(logged_in_at) FROM student_login_histories WHERE student_id = students.id)), 99999)'),
                 '>=',
                 $days
             )
-            ->orWhereNotExists(function ($query) {
-                $query->select(DB::raw(1))
-                    ->from('student_login_histories')
-                    ->whereColumn('student_id', 'students.id');
-            })
             ->orderByRaw('latest_login_at IS NULL DESC, latest_login_at ASC')
             ->get();
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -134,6 +134,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
 
                     // 講師-講座-受講
                     Route::prefix('attendance')->name('course.attendance.')->group(function () {
+                        Route::get('follow-up', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'followUp'])->name('follow-up');
                         Route::prefix('status')->group(function () {
                             Route::get('{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'showStatus'])->name('show-status');
                         });

--- a/tests/Feature/Api/Instructor/Attendance/FollowUpTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/FollowUpTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Attendance;
+use App\Model\Course;
+use App\Model\Instructor;
+use App\Model\Student;
+use App\Model\StudentLoginHistory;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FollowUpTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_10日以上ログインがない受講生を取得_成功(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // 15日前にログインした受講生（対象）
+        $studentOld = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentOld->id, 'course_id' => $course->id]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $studentOld->id,
+            'logged_in_at' => CarbonImmutable::now()->subDays(15),
+        ]);
+
+        // 5日前にログインした受講生（対象外）
+        $studentRecent = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentRecent->id, 'course_id' => $course->id]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $studentRecent->id,
+            'logged_in_at' => CarbonImmutable::now()->subDays(5),
+        ]);
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 10,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment(['student_id' => $studentOld->id]);
+        $response->assertJsonMissing(['student_id' => $studentRecent->id]);
+    }
+
+    public function test_一度もログインがない受講生が含まれる(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // 一度もログインしていない受講生（対象）
+        $studentNeverLoggedIn = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentNeverLoggedIn->id, 'course_id' => $course->id]);
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 10,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment([
+            'student_id' => $studentNeverLoggedIn->id,
+            'last_login_at' => null,
+            'days_since_login' => null,
+        ]);
+    }
+
+    public function test_他講座の受講生は含まれない(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $otherCourse = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // 自分の講座の受講生（対象）
+        $studentInCourse = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentInCourse->id, 'course_id' => $course->id]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $studentInCourse->id,
+            'logged_in_at' => CarbonImmutable::now()->subDays(20),
+        ]);
+
+        // 別の講座の受講生（対象外）— ログイン履歴なし
+        $studentInOtherCourse = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentInOtherCourse->id, 'course_id' => $otherCourse->id]);
+
+        // どの講座にも受講していない生徒（対象外）— ログイン履歴なし
+        $studentNoCourse = Student::factory()->create();
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 10,
+        ]));
+
+        // Assert — 自分の講座の受講生のみ返る
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment(['student_id' => $studentInCourse->id]);
+        $response->assertJsonMissing(['student_id' => $studentInOtherCourse->id]);
+        $response->assertJsonMissing(['student_id' => $studentNoCourse->id]);
+    }
+
+    public function test_一度もログインがない他講座の受講生は含まれない(): void
+    {
+        // Arrange
+        // ※ 現行実装の orWhereNotExists バグを検出するテスト
+        // orWhereNotExists が OR 条件のため、whereHas の講座絞り込みが無効化され
+        // ログイン履歴のない全生徒が返ってしまう問題
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // 対象講座にログイン履歴なしの受講生（対象）
+        $studentInCourse = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentInCourse->id, 'course_id' => $course->id]);
+
+        // 別講座にログイン履歴なしの受講生（対象外）
+        $otherCourse = Course::factory()->create();
+        $studentInOtherCourse = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentInOtherCourse->id, 'course_id' => $otherCourse->id]);
+
+        // どの講座にも属さずログイン履歴なしの受講生（対象外）
+        $studentNoCourse = Student::factory()->create();
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 10,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment(['student_id' => $studentInCourse->id]);
+        // ↓ 現行実装では orWhereNotExists のバグにより、これらが含まれてしまう可能性がある
+        $response->assertJsonMissing(['student_id' => $studentInOtherCourse->id]);
+        $response->assertJsonMissing(['student_id' => $studentNoCourse->id]);
+    }
+
+    public function test_180日以上ログインがない受講生を取得_成功(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // 200日前にログインした受講生（対象）
+        $studentOld = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentOld->id, 'course_id' => $course->id]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $studentOld->id,
+            'logged_in_at' => CarbonImmutable::now()->subDays(200),
+        ]);
+
+        // 100日前にログインした受講生（対象外）
+        $studentMid = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentMid->id, 'course_id' => $course->id]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $studentMid->id,
+            'logged_in_at' => CarbonImmutable::now()->subDays(100),
+        ]);
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 180,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment(['student_id' => $studentOld->id]);
+        $response->assertJsonMissing(['student_id' => $studentMid->id]);
+    }
+
+    public function test_未ログイン受講生が先頭に表示される(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // 30日前にログインした受講生
+        $studentOld = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentOld->id, 'course_id' => $course->id]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $studentOld->id,
+            'logged_in_at' => CarbonImmutable::now()->subDays(30),
+        ]);
+
+        // 一度もログインしていない受講生
+        $studentNever = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $studentNever->id, 'course_id' => $course->id]);
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 10,
+        ]));
+
+        // Assert — 未ログイン受講生が先頭
+        $response->assertStatus(200);
+        $students = $response->json('data');
+        $this->assertCount(2, $students);
+        $this->assertEquals($studentNever->id, $students[0]['student_id']);
+        $this->assertEquals($studentOld->id, $students[1]['student_id']);
+    }
+
+    public function test_権限のない講師_失敗(): void
+    {
+        // Arrange
+        $ownerInstructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $ownerInstructor->id]);
+        $otherInstructor = Instructor::factory()->create();
+        $this->actingAs($otherInstructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 10,
+        ]));
+
+        // Assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー_daysが未指定(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['days']);
+    }
+
+    public function test_バリデーションエラー_daysが0以下(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => $course->id,
+            'days' => 0,
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['days']);
+    }
+
+    public function test_バリデーションエラー_存在しない講座_id(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.follow-up', [
+            'course_id' => 99999,
+            'days' => 10,
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['course_id']);
+    }
+}


### PR DESCRIPTION
## Issue
・https://gut-familie.atlassian.net/browse/JKA-1718
## 対応内容
### 追加ファイル
- app/Http/Requests/Instructor/Attendance/FollowUpRequest.php
- app/Services/Attendance/FollowUpService.php

### 変更ファイル
- routes/api.php にルートを追加
- app/Http/Controllers/Api/Instructor/AttendanceController.php に followUp メソッドを追加

### 実装の詳細

- クエリパラメータ days で「何日以上ログインがないか」を指定できる設計にしました
- 一度もログインがない受講生は last_login_at: null / days_since_login: null で返し、表示順は先頭になります
- 認可は既存の CoursePolicy@view を使用し、他講師の講座へのアクセスを制限しています
- student_login_histories テーブルをサブクエリで結合することでN+1問題を回避しています
## 確認方法　Postman
403エラーがちゃんと機能しているのを確認
- 10日以上ログインしていない場合
<img width="584" height="939" alt="a4ba6d95dd0f9a11e5018ac9f6fd2213" src="https://github.com/user-attachments/assets/1b55cb42-152d-40c1-b907-49034eac707d" />

- 180日以上ログインしていない場合
<img width="632" height="623" alt="b01afed2f25c72c9b0d56cde102a2197" src="https://github.com/user-attachments/assets/21e94c04-0fe2-4b98-aabf-a7bd54c4f9bd" />

- 一度もログインがない場合
<img width="745" height="585" alt="0dae60dbff3d2289b23d56883e934a1e" src="https://github.com/user-attachments/assets/d97a12ed-f60b-41f0-82c0-963449147218" />