### PR TITLE
JKA-1709  3.ロジックの作成(えんどう)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Enums\Course\DeadlineTypeEnum;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\Course\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Course\DeleteRequest;
 use App\Http\Requests\Instructor\Course\IndexRequest;
@@ -18,14 +17,15 @@ use App\Model\Course;
 use App\Model\Tag;
 use App\Services\Attendance\CalculateDeadlineService;
 use App\Services\Course\DeleteService;
-use App\Services\Course\PutStatusService;
 use App\Services\Course\PutCapacityService;
+use App\Services\Course\PutStatusService;
 use App\Services\Course\StoreService;
 use App\Services\Course\UpdateService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -217,7 +217,7 @@ class CourseController extends Controller
         $this->authorize('bulkUpdate', [Course::class, $courses]);
 
         // 更新処理
-        $service(courseIds: $courseIds, status: $status);
+        $service(courses: $courses, status: $status);
 
         return response()->json([
             'result' => true,
@@ -234,13 +234,14 @@ class CourseController extends Controller
 
         // 対象講座を取得
         $courses = Course::whereIn('id', $courseIds)
-        ->withCount('attendances')
-        ->get();
+            ->withCount('attendances')
+            ->get();
 
         // 認可チェック（CoursePolicy@bulkUpdate を利用）
         $this->authorize('bulkUpdate', [Course::class, $courses]);
 
-        $service(courses: $courses, capacity: $capacity,);
+        // 更新処理
+        $service(courses: $courses, capacity: $capacity);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Instructor;
 
 use App\Enums\Course\DeadlineTypeEnum;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 use App\Http\Requests\Instructor\Course\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Course\DeleteRequest;
 use App\Http\Requests\Instructor\Course\IndexRequest;
@@ -18,6 +19,7 @@ use App\Model\Tag;
 use App\Services\Attendance\CalculateDeadlineService;
 use App\Services\Course\DeleteService;
 use App\Services\Course\PutStatusService;
+use App\Services\Course\PutCapacityService;
 use App\Services\Course\StoreService;
 use App\Services\Course\UpdateService;
 use Exception;
@@ -223,10 +225,34 @@ class CourseController extends Controller
     }
 
     /**
-     * 受講定員一括変更API
+     * 講座定員一括変更API
      */
-    public function putCapacity(): JsonResponse
+    public function putCapacity(Request $request, PutCapacityService $service): JsonResponse
     {
+        $courseIds = $request->input('courses', []);
+        $capacity = $request->input('capacity');
+
+        // 対象講座を取得
+        $courses = Course::whereIn('id', $courseIds)
+        ->withCount('attendances')
+        ->get();
+
+        // 認可チェック（CoursePolicy@bulkUpdate を利用）
+        $this->authorize('bulkUpdate', [Course::class, $courses]);
+
+        // 定員が現在の受講者数を下回っていないかチェック
+        if ($capacity !== null) {
+            foreach ($courses as $course) {
+                if ($course->attendances_count > $capacity) {
+                    throw ValidationException::withMessages([
+                        'capacity' => '定員は現在の受講者数（'.$course->attendances_count.'人）以上に設定してください。',
+                    ]);
+                }
+            }
+        }
+
+        $service(courseIds: $courseIds, capacity: $capacity,);
+
         return response()->json([
             'result' => true,
         ]);

--- a/app/Http/Controllers/Api/Instructor/CourseController.php
+++ b/app/Http/Controllers/Api/Instructor/CourseController.php
@@ -240,18 +240,7 @@ class CourseController extends Controller
         // 認可チェック（CoursePolicy@bulkUpdate を利用）
         $this->authorize('bulkUpdate', [Course::class, $courses]);
 
-        // 定員が現在の受講者数を下回っていないかチェック
-        if ($capacity !== null) {
-            foreach ($courses as $course) {
-                if ($course->attendances_count > $capacity) {
-                    throw ValidationException::withMessages([
-                        'capacity' => '定員は現在の受講者数（'.$course->attendances_count.'人）以上に設定してください。',
-                    ]);
-                }
-            }
-        }
-
-        $service(courseIds: $courseIds, capacity: $capacity,);
+        $service(courses: $courses, capacity: $capacity,);
 
         return response()->json([
             'result' => true,

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -170,15 +170,15 @@ class CourseController extends Controller
         $managingIds = $instructor->managings->pluck('id')->toArray();
         $managingIds[] = $instructorId;
 
-        // 更新対象の講座IDを抽出
-        $courseIds = Course::whereIn('instructor_id', $managingIds)->pluck('id')->toArray();
+        // 更新対象の講座を取得
+        $courses = Course::whereIn('instructor_id', $managingIds)->get();
 
         // 更新処理
-        $service(courseIds: $courseIds, status: $request->status);
+        $service(courses: $courses, status: $request->status);
 
         return response()->json([
             'result' => 'true',
-            'updated_ids' => $courseIds,
+            'updated_ids' => $courses->pluck('id')->toArray(),
         ]);
     }
 }

--- a/app/Services/Course/PutCapacityService.php
+++ b/app/Services/Course/PutCapacityService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services\Course;
+
+use App\Model\Course;
+
+class PutCapacityService
+{
+    /**
+     * 選択した講座定員を一括更新する
+     *
+     * @param  array<int>  $courseIds
+     * @param  int| null  $capacity
+     */
+    public function __invoke(array $courseIds, ?int $capacity): void
+    {
+        // 講座のステータスを一括更新
+        Course::whereIn('id', $courseIds)->update(['capacity' => $capacity]);
+    }
+}

--- a/app/Services/Course/PutCapacityService.php
+++ b/app/Services/Course/PutCapacityService.php
@@ -3,18 +3,31 @@
 namespace App\Services\Course;
 
 use App\Model\Course;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
 
 class PutCapacityService
 {
     /**
      * 選択した講座定員を一括更新する
      *
-     * @param  array<int>  $courseIds
-     * @param  int| null  $capacity
+     * @param  Collection<int, Course>  $courses
+     * @param  int|null  $capacity
      */
-    public function __invoke(array $courseIds, ?int $capacity): void
+    public function __invoke(Collection $courses, ?int $capacity): void
     {
-        // 講座のステータスを一括更新
-        Course::whereIn('id', $courseIds)->update(['capacity' => $capacity]);
+        // 定員が現在の受講者数を下回っていないかチェック
+        if ($capacity !== null) {
+            foreach ($courses as $course) {
+                if ($course->attendances_count > $capacity) {
+                    throw ValidationException::withMessages([
+                        'capacity' => '定員は現在の受講者数（'.$course->attendances_count.'人）以上に設定してください。',
+                    ]);
+                }
+            }
+        }
+
+        // 講座定員を一括更新
+        Course::whereIn('id', $courses->pluck('id'))->update(['capacity' => $capacity]);
     }
 }

--- a/app/Services/Course/PutCapacityService.php
+++ b/app/Services/Course/PutCapacityService.php
@@ -12,7 +12,6 @@ class PutCapacityService
      * 選択した講座定員を一括更新する
      *
      * @param  Collection<int, Course>  $courses
-     * @param  int|null  $capacity
      */
     public function __invoke(Collection $courses, ?int $capacity): void
     {

--- a/app/Services/Course/PutStatusService.php
+++ b/app/Services/Course/PutStatusService.php
@@ -3,18 +3,19 @@
 namespace App\Services\Course;
 
 use App\Model\Course;
+use Illuminate\Support\Collection;
 
 class PutStatusService
 {
     /**
      * 選択した講座のステータスを更新する
      *
-     * @param  array<int>  $courseIds
+     * @param  Collection<int, Course>  $courses
      * @param  'public'|'private'  $status
      */
-    public function __invoke(array $courseIds, string $status): void
+    public function __invoke(Collection $courses, string $status): void
     {
         // 講座のステータスを一括更新
-        Course::whereIn('id', $courseIds)->update(['status' => $status]);
+        Course::whereIn('id', $courses->pluck('id'))->update(['status' => $status]);
     }
 }


### PR DESCRIPTION
## Issue
JKA-1709

## 対応内容
ロジックの作成（コントローラー、サービスの実装〜既存ポリシーの連携）

## 確認方法
・コントローラーへ対象データの取得〜認可〜講座定員の変更までを実装
・一括更新部分実装はputCapacityServiceを作成して記述
・認可は既存のcoursePolicyのbulkUpdateを使用
・postmanで変更したい講座のid（複数)と、capacityを入力して、
　エラーなくDBが期待通りに更新されたことを確認

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)
・専用リクエストは次の子課題で作成しますので、
　今回はテストの為一旦use Illuminate\Http\Request;宣言を入れて
　動作確認を実行しております。