### PR TITLE
JKA-1732 講師側 講座詳細APIへ受講期限まで何日かを追加する(すさ)

### DIFF
--- a/app/Http/Resources/Base/Instructor/AttendanceResource.php
+++ b/app/Http/Resources/Base/Instructor/AttendanceResource.php
@@ -19,9 +19,12 @@ class AttendanceResource extends JsonResource
     #[\Override]
     public function toArray($request)
     {
+        $deadline = $this->resource->attendance_deadline;
+
         return [
             'attendance_id' => $this->resource->id,
-            'attendance_deadline' => $this->resource->attendance_deadline?->format('Y-m-d') ?? null,
+            'attendance_deadline' => $deadline?->format('Y-m-d'),
+            'days_until_deadline' => $this->resource->getDaysUntilDeadlineLabel(),
         ];
     }
 }

--- a/app/Http/Resources/Base/Instructor/AttendanceResource.php
+++ b/app/Http/Resources/Base/Instructor/AttendanceResource.php
@@ -24,7 +24,7 @@ class AttendanceResource extends JsonResource
         return [
             'attendance_id' => $this->resource->id,
             'attendance_deadline' => $deadline?->format('Y-m-d'),
-            'days_until_deadline' => $this->resource->getDaysUntilDeadlineLabel(),
+            'days_until_deadline' => $this->resource->getDaysUntilDeadline(),
         ];
     }
 }

--- a/app/Http/Resources/Base/Instructor/AttendanceResource.php
+++ b/app/Http/Resources/Base/Instructor/AttendanceResource.php
@@ -19,11 +19,9 @@ class AttendanceResource extends JsonResource
     #[\Override]
     public function toArray($request)
     {
-        $deadline = $this->resource->attendance_deadline;
-
         return [
             'attendance_id' => $this->resource->id,
-            'attendance_deadline' => $deadline?->format('Y-m-d'),
+            'attendance_deadline' => $this->resource->attendance_deadline?->format('Y-m-d'),
             'days_until_deadline' => $this->resource->getDaysUntilDeadline(),
         ];
     }

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -160,6 +160,6 @@ class Attendance extends Model
             return null;
         }
 
-        return (int) CarbonImmutable::today()->diffInDays($this->attendance_deadline);
+        return max(0, (int) CarbonImmutable::today()->diffInDays($this->attendance_deadline, false));
     }
 }

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -150,4 +150,30 @@ class Attendance extends Model
     {
         return $this->attendance_deadline !== null && CarbonImmutable::now()->gte($this->attendance_deadline_end);
     }
+
+    /**
+     * 受講期限まで何日かを返す。期限なしなら null。
+     */
+    public function getDaysUntilDeadlineLabel(): ?string
+    {
+        if ($this->attendance_deadline === null) {
+            return null;
+        }
+
+        $today = CarbonImmutable::today();
+        $totalDays = $today->diffInDays($this->attendance_deadline);
+
+        if ($totalDays <= 30) {
+            return "{$totalDays}日";
+        }
+
+        $months = (int) $today->diffInMonths($this->attendance_deadline);
+        $remainingDays = $today->addMonths($months)->diffInDays($this->attendance_deadline);
+
+        if ($remainingDays === 0) {
+            return "{$months}ヶ月";
+        }
+
+        return "{$months}ヶ月と{$remainingDays}日";
+    }
 }

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -152,28 +152,14 @@ class Attendance extends Model
     }
 
     /**
-     * 受講期限まで何日かを返す。期限なしなら null。
+     * 受講期限まで何日かを返す。期限なし・期限切れなら null。
      */
-    public function getDaysUntilDeadlineLabel(): ?string
+    public function getDaysUntilDeadline(): ?int
     {
-        if ($this->attendance_deadline === null) {
+        if ($this->attendance_deadline === null || $this->isExpired()) {
             return null;
         }
 
-        $today = CarbonImmutable::today();
-        $totalDays = $today->diffInDays($this->attendance_deadline);
-
-        if ($totalDays <= 30) {
-            return "{$totalDays}日";
-        }
-
-        $months = (int) $today->diffInMonths($this->attendance_deadline);
-        $remainingDays = $today->addMonths($months)->diffInDays($this->attendance_deadline);
-
-        if ($remainingDays === 0) {
-            return "{$months}ヶ月";
-        }
-
-        return "{$months}ヶ月と{$remainingDays}日";
+        return (int) CarbonImmutable::today()->diffInDays($this->attendance_deadline);
     }
 }

--- a/tests/Feature/Api/Instructor/Attendance/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowTest.php
@@ -37,6 +37,7 @@ class ShowTest extends TestCase
             'data' => [
                 'attendance_id',
                 'attendance_deadline',
+                'days_until_deadline',
                 'course' => [
                     'course_id',
                     'title',
@@ -77,6 +78,7 @@ class ShowTest extends TestCase
             'data' => [
                 'attendance_id',
                 'attendance_deadline',
+                'days_until_deadline',
                 'course' => [
                     'course_id',
                     'title',
@@ -112,6 +114,7 @@ class ShowTest extends TestCase
             'data' => [
                 'attendance_id',
                 'attendance_deadline',
+                'days_until_deadline',
                 'course' => [
                     'course_id',
                     'title',


### PR DESCRIPTION
## Issue
- https://gut-familie.atlassian.net/browse/JKA-1732
## 対応内容
- app/Model/Attendance.php に getDaysUntilDeadlineLabel() メソッドを追加し、受講期限までの残り日数を文字列で返すロジックを実装
- app/Http/Resources/Base/Instructor/AttendanceResource.php に days_until_deadline を追加し、期限なしの場合は null、30日以下は「15日」、31日以上は「11ヶ月と25日」の形式で返すように変更
## 確認方法
期限なし
<img width="1439" height="746" alt="スクリーンショット 2026-03-26 2 35 53" src="https://github.com/user-attachments/assets/d859b3b7-947b-4f77-8197-593f0e65ed3c" />

30日以下
<img width="1439" height="746" alt="スクリーンショット 2026-03-26 2 38 41" src="https://github.com/user-attachments/assets/8ecfba91-955e-41f3-928d-9e044877f331" />

31日以上
<img width="1439" height="746" alt="スクリーンショット 2026-03-26 2 34 45" src="https://github.com/user-attachments/assets/03771e1d-b588-4364-96a8-9048832fd08e" />

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)