### PR TITLE
JKA-1716    4. レスポンス整形用リソースファイルの作成または変更(えんどう)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -50,7 +50,9 @@ class NotificationController extends Controller
         $notifications = Notification::with([
             'course' => function ($query) {
                 $query->withCount([
-                    'attendances as current_attendance_count',
+                    'attendances as current_attendance_count' => function ($query) {
+                        $query->whereNull('completed_at');
+                    },
                 ]);
             },
             'course.tags',

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -50,9 +50,7 @@ class NotificationController extends Controller
         $notifications = Notification::with([
             'course' => function ($query) {
                 $query->withCount([
-                    'attendances as current_attendance_count' => function ($query) {
-                        $query->whereNull('completed_at');
-                    },
+                    'attendances as current_attendance_count' 
                 ]);
             },
             'course.tags',

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -50,7 +50,7 @@ class NotificationController extends Controller
         $notifications = Notification::with([
             'course' => function ($query) {
                 $query->withCount([
-                    'attendances as current_attendance_count' 
+                    'attendances as current_attendance_count',
                 ]);
             },
             'course.tags',

--- a/app/Http/Controllers/Api/Instructor/NotificationController.php
+++ b/app/Http/Controllers/Api/Instructor/NotificationController.php
@@ -29,6 +29,7 @@ use App\Services\Notification\UpdateTypeAllService;
 use App\Services\Notification\UpdateTypeService;
 use Exception;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -41,7 +42,7 @@ class NotificationController extends Controller
     /**
      * お知らせ一覧取得API
      */
-    public function index(IndexRequest $request): NotificationIndexResource
+    public function index(IndexRequest $request): AnonymousResourceCollection
     {
         $instructorId = Auth::guard('instructor')->user()->id;
         $perPage = $request->input('per_page', 20);
@@ -61,7 +62,7 @@ class NotificationController extends Controller
             ->where('instructor_id', $instructorId)
             ->paginate($perPage, ['*'], 'page', $page);
 
-        return new NotificationIndexResource($notifications);
+        return NotificationIndexResource::collection($notifications);
     }
 
     /**

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -26,11 +26,20 @@ class NotificationIndexResource extends JsonResource
         $notifications = $this->resource;
 
         return [
-            'notifications' => $notifications->map(fn (Notification $notification) => [
-                ...(new NotificationResource($notification))->toArray($request),
-                'course' => new CourseResource($notification->course),
-                'tags' => TagResource::collection($notification->course->tags),
-            ]),
+            'notifications' => $notifications->map(function (Notification $notification) use ($request) {
+                $course = (new CourseResource($notification->course))->toArray($request);
+
+                $course['current_attendance_count'] = $notification->course->current_attendance_count ?? 0;
+
+                if ($notification->course->capacity === null) {
+                    unset($course['capacity']);
+                }
+                return [
+                    ...(new NotificationResource($notification))->toArray($request),
+                    'course' => $course,
+                    'tags' => TagResource::collection($notification->course->tags),
+                ];
+            }),
             'pagination' => [
                 'page' => $notifications->currentPage(),
                 'total' => $notifications->total(),

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -34,6 +34,7 @@ class NotificationIndexResource extends JsonResource
                 if ($notification->course->capacity === null) {
                     unset($course['capacity']);
                 }
+
                 return [
                     ...(new NotificationResource($notification))->toArray($request),
                     'course' => $course,

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -26,21 +26,14 @@ class NotificationIndexResource extends JsonResource
         $notifications = $this->resource;
 
         return [
-            'notifications' => $notifications->map(function (Notification $notification) use ($request) {
-                $course = (new CourseResource($notification->course))->toArray($request);
-
-                $course['current_attendance_count'] = $notification->course->current_attendance_count ?? 0;
-
-                if ($notification->course->capacity === null) {
-                    unset($course['capacity']);
-                }
-
-                return [
-                    ...(new NotificationResource($notification))->toArray($request),
-                    'course' => $course,
-                    'tags' => TagResource::collection($notification->course->tags),
-                ];
-            }),
+            'notifications' => $notifications->map(fn (Notification $notification) => [
+                ...(new NotificationResource($notification))->toArray($request),
+                'course' => [
+                    ...(new CourseResource($notification->course))->toArray($request),
+                    'current_attendance_count' => $notification->course->current_attendance_count
+                ],
+                'tags' => TagResource::collection($notification->course->tags),
+            ]),
             'pagination' => [
                 'page' => $notifications->currentPage(),
                 'total' => $notifications->total(),

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -30,7 +30,7 @@ class NotificationIndexResource extends JsonResource
                 ...(new NotificationResource($notification))->toArray($request),
                 'course' => [
                     ...(new CourseResource($notification->course))->toArray($request),
-                    'current_attendance_count' => $notification->course->current_attendance_count
+                    'current_attendance_count' => $notification->course->current_attendance_count,
                 ],
                 'tags' => TagResource::collection($notification->course->tags),
             ]),

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -7,11 +7,10 @@ use App\Http\Resources\Base\Instructor\NotificationResource;
 use App\Http\Resources\Base\Instructor\TagResource;
 use App\Model\Notification;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Pagination\LengthAwarePaginator;
 
 class NotificationIndexResource extends JsonResource
 {
-    /** @var LengthAwarePaginator */
+    /** @var Notification */
     public $resource;
 
     /**
@@ -23,23 +22,15 @@ class NotificationIndexResource extends JsonResource
     #[\Override]
     public function toArray($request)
     {
-        $notifications = $this->resource;
-
         return [
-            'notifications' => $notifications->map(fn (Notification $notification) => [
-                ...(new NotificationResource($notification))->toArray($request),
-                'course' => [
-                    ...(new CourseResource($notification->course))->toArray($request),
-                    'current_attendance_count' => $notification->course->capacity !== null
-                        ? ($notification->course->current_attendance_count ?? 0)
-                        : null,
-                ],
-                'tags' => TagResource::collection($notification->course->tags),
-            ]),
-            'pagination' => [
-                'page' => $notifications->currentPage(),
-                'total' => $notifications->total(),
+            ...(new NotificationResource($this->resource))->toArray($request),
+            'course' => [
+                ...(new CourseResource($this->resource->course))->toArray($request),
+                'current_attendance_count' => $this->resource->course->capacity !== null
+                    ? ($this->resource->course->current_attendance_count ?? 0)
+                    : null,
             ],
+            'tags' => TagResource::collection($this->resource->course->tags),
         ];
     }
 }

--- a/app/Http/Resources/Instructor/NotificationIndexResource.php
+++ b/app/Http/Resources/Instructor/NotificationIndexResource.php
@@ -30,7 +30,9 @@ class NotificationIndexResource extends JsonResource
                 ...(new NotificationResource($notification))->toArray($request),
                 'course' => [
                     ...(new CourseResource($notification->course))->toArray($request),
-                    'current_attendance_count' => $notification->course->current_attendance_count,
+                    'current_attendance_count' => $notification->course->capacity !== null
+                        ? ($notification->course->current_attendance_count ?? 0)
+                        : null,
                 ],
                 'tags' => TagResource::collection($notification->course->tags),
             ]),

--- a/app/Model/Course.php
+++ b/app/Model/Course.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property bool $has_active_students
  * @property int $progress_percentage
  * @property int|null $capacity
+ * @property int|null $current_attendance_count
  */
 class Course extends Model
 {

--- a/tests/Feature/Api/Instructor/Notification/IndexTest.php
+++ b/tests/Feature/Api/Instructor/Notification/IndexTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Instructor\Notification;
 
+use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Notification;
@@ -28,5 +29,52 @@ class IndexTest extends TestCase
 
         // Assert
         $response->assertStatus(200);
+    }
+
+    public function test_定員あり講座_受講者数が返却される(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'capacity' => 10,
+        ]);
+        Attendance::factory()->count(3)->create(['course_id' => $course->id]);
+        Notification::factory()->create([
+            'instructor_id' => $instructor->id,
+            'course_id' => $course->id,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.notification.index'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.course.capacity', 10);
+        $response->assertJsonPath('data.0.course.current_attendance_count', 3);
+    }
+
+    public function test_定員なし講座_受講者数がnullで返却される(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'capacity' => null,
+        ]);
+        Notification::factory()->create([
+            'instructor_id' => $instructor->id,
+            'course_id' => $course->id,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.notification.index'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.course.capacity', null);
+        $response->assertJsonPath('data.0.course.current_attendance_count', null);
     }
 }


### PR DESCRIPTION
## Issue
JKA-1716 

## 対応内容
・レスポンス整形用リソースファイルの変更
・ロジックの再修正（前回のレビュー指摘を受けて)

## 確認方法
・リソースファイルを変更後、
capacityが設定されているとき
　capacityが値表示と、current_attendance_countが同時にレスポンスに表示を確認

capacityの設定がないとき
　capacityがnull表示と、current_attendance_countのみレスポンスに表示を確認

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)
・ご指摘頂いた箇所を修正しました。