### PR TITLE
JKA-1733 連続ログイン日数取得APIを追加 (Naomichi)

### DIFF
--- a/app/Http/Controllers/Api/Student/LoginController.php
+++ b/app/Http/Controllers/Api/Student/LoginController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api\Student;
+
+use App\Http\Controllers\Controller;
+use App\Model\Student;
+use Illuminate\Http\JsonResponse;
+
+class LoginController extends Controller
+{
+    /**
+     * 連続ログイン日数取得API
+     */
+    public function loginStreak(): JsonResponse
+    {
+        /** @var Student $student */
+        $student = auth()->user();
+
+        return response()->json([
+            'data' => [
+                'login_streak_days' => $student?->getLoginStreakDays(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Student/LoginController.php
+++ b/app/Http/Controllers/Api/Student/LoginController.php
@@ -18,7 +18,7 @@ class LoginController extends Controller
 
         return response()->json([
             'data' => [
-                'login_streak_days' => $student?->getLoginStreakDays(),
+                'login_streak_days' => $student->getLoginStreakDays(),
             ],
         ]);
     }

--- a/app/Http/Controllers/Api/Student/LoginController.php
+++ b/app/Http/Controllers/Api/Student/LoginController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Student;
 
 use App\Http\Controllers\Controller;
 use App\Model\Student;
+use App\Services\Student\LoginStreakService;
 use Illuminate\Http\JsonResponse;
 
 class LoginController extends Controller
@@ -11,14 +12,14 @@ class LoginController extends Controller
     /**
      * 連続ログイン日数取得API
      */
-    public function loginStreak(): JsonResponse
+    public function loginStreak(LoginStreakService $service): JsonResponse
     {
         /** @var Student $student */
         $student = auth()->user();
 
         return response()->json([
             'data' => [
-                'login_streak_days' => $student->getLoginStreakDays(),
+                'login_streak_days' => $service($student),
             ],
         ]);
     }

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -149,8 +149,8 @@ class Student extends Authenticatable
         }
 
         $today = CarbonImmutable::today()->toDateString();
-        
-         if ($loginDates[0] !== $today) {
+
+        if ($loginDates[0] !== $today) {
             return null;
         }
 

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -130,4 +130,42 @@ class Student extends Authenticatable
             'gender' => Gender::class,
         ];
     }
+
+    /**
+     * 連続ログイン日数を取得
+     *
+     * 連続ログインしていない場合は null を返す
+     */
+    public function getLoginStreakDays(): ?int
+    {
+        $loginDates = $this->loginHistories()
+            ->orderByDesc('logged_in_at')
+            ->get(['logged_in_at'])
+            ->pluck('logged_in_at')
+            ->map(fn ($loggedInAt) => $loggedInAt->toDateString())
+            ->unique()
+            ->values();
+
+        if ($loginDates->isEmpty()) {
+            return null;
+        }
+
+        $today = CarbonImmutable::today()->toDateString();
+        
+         if ($loginDates[0] !== $today) {
+            return null;
+        }
+
+        $streakDays = 1;
+        $baseDate = CarbonImmutable::parse($loginDates[0]);
+
+        for ($i = 1; $i < $loginDates->count(); $i++) {
+            if ($loginDates[$i] !== $baseDate->subDays($i)->toDateString()) {
+                break;
+            }
+            $streakDays++;
+        }
+
+        return $streakDays;
+    }
 }

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -139,12 +139,10 @@ class Student extends Authenticatable
     public function getLoginStreakDays(): ?int
     {
         $loginDates = $this->loginHistories()
-            ->orderByDesc('logged_in_at')
-            ->get(['logged_in_at'])
-            ->pluck('logged_in_at')
-            ->map(fn ($loggedInAt) => $loggedInAt->toDateString())
-            ->unique()
-            ->values();
+            ->selectRaw('DATE(logged_in_at) as login_date')
+            ->groupBy('login_date')
+            ->orderByDesc('login_date')
+            ->pluck('login_date');
 
         if ($loginDates->isEmpty()) {
             return null;

--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -130,40 +130,4 @@ class Student extends Authenticatable
             'gender' => Gender::class,
         ];
     }
-
-    /**
-     * 連続ログイン日数を取得
-     *
-     * 連続ログインしていない場合は null を返す
-     */
-    public function getLoginStreakDays(): ?int
-    {
-        $loginDates = $this->loginHistories()
-            ->selectRaw('DATE(logged_in_at) as login_date')
-            ->groupBy('login_date')
-            ->orderByDesc('login_date')
-            ->pluck('login_date');
-
-        if ($loginDates->isEmpty()) {
-            return null;
-        }
-
-        $today = CarbonImmutable::today()->toDateString();
-
-        if ($loginDates[0] !== $today) {
-            return null;
-        }
-
-        $streakDays = 1;
-        $baseDate = CarbonImmutable::parse($loginDates[0]);
-
-        for ($i = 1; $i < $loginDates->count(); $i++) {
-            if ($loginDates[$i] !== $baseDate->subDays($i)->toDateString()) {
-                break;
-            }
-            $streakDays++;
-        }
-
-        return $streakDays;
-    }
 }

--- a/app/Services/Student/LoginStreakService.php
+++ b/app/Services/Student/LoginStreakService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services\Student;
+
+use App\Model\Student;
+use Carbon\CarbonImmutable;
+
+class LoginStreakService
+{
+    /**
+     * 連続ログイン日数を取得
+     */
+    public function __invoke(Student $student): ?int
+    {
+        $loginDates = $student->loginHistories()
+            ->selectRaw('DATE(logged_in_at) as login_date')
+            ->groupBy('login_date')
+            ->orderByDesc('login_date')
+            ->pluck('login_date');
+
+        if ($loginDates->isEmpty()) {
+            return null;
+        }
+
+        $today = CarbonImmutable::today();
+
+        // 今日ログインしていない場合
+        if ($loginDates[0] !== $today->toDateString()) {
+            return null;
+        }
+
+        $streakDays = $loginDates
+            ->values()
+            ->takeWhile(fn (string $date, int $i) => $date === $today->subDays($i)->toDateString()
+            )
+            ->count();
+
+        return $streakDays > 0 ? $streakDays : null;
+    }
+}

--- a/app/Services/Student/LoginStreakService.php
+++ b/app/Services/Student/LoginStreakService.php
@@ -30,11 +30,9 @@ class LoginStreakService
             return null;
         }
 
-        $streakDays = $loginDates
+        return $loginDates
             ->values()
             ->takeWhile(fn (CarbonImmutable $date, int $i) => $date->isSameDay($today->subDays($i)))
             ->count();
-
-        return $streakDays;
     }
 }

--- a/app/Services/Student/LoginStreakService.php
+++ b/app/Services/Student/LoginStreakService.php
@@ -16,7 +16,8 @@ class LoginStreakService
             ->selectRaw('DATE(logged_in_at) as login_date')
             ->groupBy('login_date')
             ->orderByDesc('login_date')
-            ->pluck('login_date');
+            ->pluck('login_date')
+            ->map(fn (string $date) => CarbonImmutable::parse($date));
 
         if ($loginDates->isEmpty()) {
             return null;
@@ -25,16 +26,15 @@ class LoginStreakService
         $today = CarbonImmutable::today();
 
         // 今日ログインしていない場合
-        if ($loginDates[0] !== $today->toDateString()) {
+        if (! $loginDates[0]->isSameDay($today)) {
             return null;
         }
 
         $streakDays = $loginDates
             ->values()
-            ->takeWhile(fn (string $date, int $i) => $date === $today->subDays($i)->toDateString()
-            )
+            ->takeWhile(fn (CarbonImmutable $date, int $i) => $date->isSameDay($today->subDays($i)))
             ->count();
 
-        return $streakDays > 0 ? $streakDays : null;
+        return $streakDays;
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
             Route::get('/', [App\Http\Controllers\Api\Student\StudentController::class, 'show'])->name('show');
             Route::post('update', [App\Http\Controllers\Api\Student\StudentController::class, 'update'])->name('update');
             Route::get('learning-history', [App\Http\Controllers\Api\Student\LearningHistoryController::class, 'index'])->name('learning-history.index');
+            Route::get('login-streak', [App\Http\Controllers\Api\Student\LoginController::class, 'loginStreak'])->name('login-streak');
         });
 
         // 受講生-受講

--- a/tests/Feature/Api/Student/LoginStreak/IndexTest.php
+++ b/tests/Feature/Api/Student/LoginStreak/IndexTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Feature\Api\Student\LoginStreak;
+
+use App\Model\Student;
+use App\Model\StudentLoginHistory;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_連続ログイン日数取得_今日のみログイン_成功(): void
+    {
+        // Arrange
+        $now = CarbonImmutable::create(2026, 4, 17);
+        CarbonImmutable::setTestNow($now);
+
+        $student = Student::factory()->create();
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now,
+        ]);
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => ['login_streak_days'],
+        ]);
+        $response->assertJsonPath('data.login_streak_days', 1);
+
+        CarbonImmutable::setTestNow();
+    }
+
+    public function test_連続ログイン日数取得_複数日連続ログイン_成功(): void
+    {
+        // Arrange
+        $now = CarbonImmutable::create(2026, 4, 17);
+        CarbonImmutable::setTestNow($now);
+
+        $student = Student::factory()->create();
+        // 今日から5日連続でログイン
+        foreach (range(0, 4) as $i) {
+            StudentLoginHistory::factory()->create([
+                'student_id' => $student->id,
+                'logged_in_at' => $now->subDays($i),
+            ]);
+        }
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.login_streak_days', 5);
+
+        CarbonImmutable::setTestNow();
+    }
+
+    public function test_連続ログイン日数取得_今日未ログイン_null返却(): void
+    {
+        // Arrange
+        $now = CarbonImmutable::create(2026, 4, 17);
+        CarbonImmutable::setTestNow($now);
+
+        $student = Student::factory()->create();
+        // 昨日以前のログインはあるが、今日のログインはない
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->subDay(),
+        ]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->subDays(2),
+        ]);
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.login_streak_days', null);
+
+        CarbonImmutable::setTestNow();
+    }
+
+    public function test_連続ログイン日数取得_ログイン履歴なし_null返却(): void
+    {
+        // Arrange
+        $student = Student::factory()->create();
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.login_streak_days', null);
+    }
+
+    public function test_連続ログイン日数取得_連続が途切れた場合_途切れる前までカウント(): void
+    {
+        // Arrange
+        $now = CarbonImmutable::create(2026, 4, 17);
+        CarbonImmutable::setTestNow($now);
+
+        $student = Student::factory()->create();
+        // 今日・昨日はログインあり、2日前は飛ばして3日前・4日前にログインあり
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now,
+        ]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->subDay(),
+        ]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->subDays(3),
+        ]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->subDays(4),
+        ]);
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.login_streak_days', 2);
+
+        CarbonImmutable::setTestNow();
+    }
+
+    public function test_連続ログイン日数取得_同日に複数回ログインしても1日としてカウント(): void
+    {
+        // Arrange
+        $now = CarbonImmutable::create(2026, 4, 17, 20, 0, 0);
+        CarbonImmutable::setTestNow($now);
+
+        $student = Student::factory()->create();
+        // 今日の中で複数回ログイン
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->setTime(8, 0, 0),
+        ]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->setTime(12, 0, 0),
+        ]);
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->setTime(20, 0, 0),
+        ]);
+        // 昨日も1回ログイン
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now->subDay(),
+        ]);
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.login_streak_days', 2);
+
+        CarbonImmutable::setTestNow();
+    }
+
+    public function test_連続ログイン日数取得_他の受講生のログイン履歴は影響しない(): void
+    {
+        // Arrange
+        $now = CarbonImmutable::create(2026, 4, 17);
+        CarbonImmutable::setTestNow($now);
+
+        $student = Student::factory()->create();
+        $otherStudent = Student::factory()->create();
+
+        // 対象受講生は今日のみログイン
+        StudentLoginHistory::factory()->create([
+            'student_id' => $student->id,
+            'logged_in_at' => $now,
+        ]);
+        // 他の受講生は連続5日ログイン（影響してはいけない）
+        foreach (range(0, 4) as $i) {
+            StudentLoginHistory::factory()->create([
+                'student_id' => $otherStudent->id,
+                'logged_in_at' => $now->subDays($i),
+            ]);
+        }
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.login_streak_days', 1);
+
+        CarbonImmutable::setTestNow();
+    }
+
+    public function test_未認証_連続ログイン日数取得_失敗(): void
+    {
+        // Act
+        $response = $this->getJson(route('student.login-streak'));
+
+        // Assert
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Issue
・JKA-1733　受講生側で、現在の連続ログイン日数を返却する新しいAPIを作成する
## 対応内容
・受講生側の連続ログイン日数取得APIを新規作成
・Student モデルに getLoginStreakDays() を追加し、student_login_histories から連続ログイン日数を算出するロジックを実装
・本日未ログインの場合は null を返すよう対応
・365日以上連続ログインしている場合でも、日数の数値をそのまま返却するよう対応
## 確認方法
StudentLoginHistorySeeder を用いて以下のデータを作成し確認を行った。

・今日ログインしている場合（student_id=1）
login_streak_days が 1 で返却されることを確認
<img width="845" height="551" alt="image" src="https://github.com/user-attachments/assets/7d135e19-3dc9-46e5-9d8d-ab4b4ae065e1" />


・連続ログインしていない場合（student_id=2）
login_streak_days が null で返却されることを確認
<img width="909" height="598" alt="image" src="https://github.com/user-attachments/assets/14556605-75c7-43ba-b6d9-12be7ee7d2c6" />

・366日連続ログインしている場合（student_id=3）
login_streak_days が 366 で返却されることを確認
<img width="750" height="517" alt="image" src="https://github.com/user-attachments/assets/bfd37d55-2d07-4f42-a9df-29b503f84227" />
