### PR TITLE
JKA-1687   マネージャー側 講師一覧APIに受講生上限を含める対応(えんどう)

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -63,7 +63,11 @@ class InstructorController extends Controller
                         })
                         ->select(DB::raw('COUNT(DISTINCT attendances.student_id)'));
                 },
+                'courses as fixed_capacity_count' => function (Builder $query) {
+                    $query->whereNotNull('capacity');
+                },
             ])
+            ->withSum('courses as capacity_sum', 'capacity')
             ->orderBy($sortBy, $order)
             ->paginate($perPage, ['*'], 'page', $page);
 

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -55,6 +55,7 @@ class InstructorController extends Controller
         // 講師情報を取得
         $instructors = Instructor::whereIn('id', $instructorIds)
             ->withCount([
+                'courses',
                 'courses as student_count' => function (Builder $query) {
                     $query->join('attendances', 'courses.id', '=', 'attendances.course_id')
                         ->where(function ($query) {
@@ -63,7 +64,7 @@ class InstructorController extends Controller
                         })
                         ->select(DB::raw('COUNT(DISTINCT attendances.student_id)'));
                 },
-                'courses as fixed_capacity_count' => function (Builder $query) {
+                'courses as courses_with_capacity_count' => function (Builder $query) {
                     $query->whereNotNull('capacity');
                 },
             ])

--- a/app/Http/Resources/Manager/InstructorIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorIndexResource.php
@@ -28,6 +28,9 @@ class InstructorIndexResource extends JsonResource
                 'profile_image' => $instructor->profile_image,
                 'course_count' => $instructor->courses()->count(),
                 'student_count' => $instructor->student_count ?? 0,
+                'capacity_count' => $instructor->courses()->count() === ($instructor->fixed_capacity_count ?? 0)
+                ? $instructor->capacity_sum
+                : null,
             ]),
             'pagination' => [
                 'page' => $data->currentPage(),

--- a/app/Http/Resources/Manager/InstructorIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorIndexResource.php
@@ -26,9 +26,9 @@ class InstructorIndexResource extends JsonResource
                 'nick_name' => $instructor->nick_name,
                 'email' => $instructor->email,
                 'profile_image' => $instructor->profile_image,
-                'course_count' => $instructor->courses()->count(),
+                'course_count' => $instructor->courses_count ?? 0,
                 'student_count' => $instructor->student_count ?? 0,
-                'capacity_count' => $instructor->courses()->count() === ($instructor->fixed_capacity_count ?? 0)
+                'capacity_count' => ($instructor->courses_count ?? 0) === ($instructor->courses_with_capacity_count ?? 0)
                 ? $instructor->capacity_sum
                 : null,
             ]),

--- a/app/Http/Resources/Manager/InstructorIndexResource.php
+++ b/app/Http/Resources/Manager/InstructorIndexResource.php
@@ -29,8 +29,8 @@ class InstructorIndexResource extends JsonResource
                 'course_count' => $instructor->courses_count ?? 0,
                 'student_count' => $instructor->student_count ?? 0,
                 'capacity_count' => ($instructor->courses_count ?? 0) === ($instructor->courses_with_capacity_count ?? 0)
-                ? $instructor->capacity_sum
-                : null,
+                    ? $instructor->capacity_sum
+                    : null,
             ]),
             'pagination' => [
                 'page' => $data->currentPage(),

--- a/app/Model/Instructor.php
+++ b/app/Model/Instructor.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
+/**
+ * @property int|null $capacity_sum
+ */
 class Instructor extends Authenticatable
 {
     use HasFactory;


### PR DESCRIPTION
## Issue
JKA-1736~JKA-1738
マネージャー側 講師一覧APIに受講生上限を含める対応

## 対応内容
1. ロジックの修正
・既存のwithCountにnullではなく設定されている定員上限を判定する属性(courses_with__capacity_count)を追加
・クエリ条件を通った定員上限合計を計算するクエリ->withSum(...)を追加

2. レスポンス整形のリソースファイル変更
・講師が持つ講座のうち１つでも講座定員上限が設定されていなければ、
定員上限の合計数はレスポンスとして返さないjiraの内容通り、
　講師の講座数と
　定員上限が設定されている件数を比べ、
　trueであれば定員上限合計(capacity_sum)をcapacity_countとして表示させ、
　falseであればnullがレスポンス表示されるように設定

確認方法

## 確認方法
postmanで
対象講師の講座定員上限が一つでもnullであれば、'capacity_count'はnullがレスポンスに返り、
対象講師の講座定員上限が全て設定されていれば、'capacity_count'は定員上限の合計がレスポンスに返ることを確認

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)