### PR TITLE
chore: composer installのprocess-timeoutを600秒に延長

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
+        "process-timeout": 600,
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
## Summary
- `composer.json` の `config.process-timeout` を 600 秒に設定
- デフォルト値（300秒）では `composer install` 中にタイムアウトが発生するケースがあるため延長

## Test plan
- [x] `composer install` が正常に完了することを確認
- [x] `composer validate` でエラーが出ないことを確認