### PR TITLE
JKA-1695 マネージャー側 講師-講座情報一覧取得APIへのトータル受講中受講生の数追加(えんどう)

### DIFF
--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -14,11 +14,11 @@ use App\Http\Resources\Manager\InstructorIndexResource;
 use App\Http\Resources\Manager\InstructorShowResource;
 use App\Http\Resources\Manager\InstructorTotalCurrentAttendanceCountResource;
 use App\Mail\AuthenticationConfirmationMail;
-use App\Model\Attendance;
 use App\Model\Instructor;
 use App\Model\TemporaryInstructor;
 use App\Services\Auth\CredentialGeneratorService;
 use App\Services\Instructor\StoreService;
+use App\Services\Instructor\TotalCurrentAttendanceCountService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Builder;
@@ -94,25 +94,17 @@ class InstructorController extends Controller
     /**
      * 講師-トータル受講中受講生数取得API
      */
-    public function totalCurrentAttendanceCount(TotalCurrentAttendanceCountRequest $request): InstructorTotalCurrentAttendanceCountResource {
-        $managerId = Auth::guard('instructor')->user()->id;
+    public function totalCurrentAttendanceCount(
+        TotalCurrentAttendanceCountRequest $request, 
+        TotalCurrentAttendanceCountService $service
+    ): InstructorTotalCurrentAttendanceCountResource {
 
-        /** @var Instructor $manager */
-        $manager = Instructor::with('managings')->findOrFail($managerId);
+        /** @var Instructor $instructor */
+        $instructor = Instructor::findOrFail($request->instructor_id);
 
-        $instructorIds = $manager->managings->pluck('id')->toArray();
-        $instructorIds[] = $manager->id;
+        $this->authorize('view', $instructor);
 
-        // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
-        if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
-
-        $totalCurrentAttendanceCount = Attendance::whereNull('completed_at')
-            ->whereHas('course', function ($query) use ($request) {
-                $query->where('instructor_id', $request->instructor_id);
-            })
-            ->count();
+        $totalCurrentAttendanceCount = $service($instructor->id);
 
         return new InstructorTotalCurrentAttendanceCountResource([
             'total_current_attendance_count' => $totalCurrentAttendanceCount,

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -95,7 +95,7 @@ class InstructorController extends Controller
      * 講師-トータル受講中受講生数取得API
      */
     public function totalCurrentAttendanceCount(
-        TotalCurrentAttendanceCountRequest $request, 
+        TotalCurrentAttendanceCountRequest $request,
         TotalCurrentAttendanceCountService $service
     ): InstructorTotalCurrentAttendanceCountResource {
 

--- a/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
+++ b/app/Http/Controllers/Api/Manager/Instructor/InstructorController.php
@@ -8,10 +8,13 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Instructor\IndexRequest;
 use App\Http\Requests\Manager\Instructor\ShowRequest;
 use App\Http\Requests\Manager\Instructor\StoreRequest;
+use App\Http\Requests\Manager\Instructor\TotalCurrentAttendanceCountRequest;
 use App\Http\Requests\Manager\Instructor\UpdateRequest;
 use App\Http\Resources\Manager\InstructorIndexResource;
 use App\Http\Resources\Manager\InstructorShowResource;
+use App\Http\Resources\Manager\InstructorTotalCurrentAttendanceCountResource;
 use App\Mail\AuthenticationConfirmationMail;
+use App\Model\Attendance;
 use App\Model\Instructor;
 use App\Model\TemporaryInstructor;
 use App\Services\Auth\CredentialGeneratorService;
@@ -86,6 +89,34 @@ class InstructorController extends Controller
         $this->authorize('view', $instructor);
 
         return new InstructorShowResource($instructor);
+    }
+
+    /**
+     * 講師-トータル受講中受講生数取得API
+     */
+    public function totalCurrentAttendanceCount(TotalCurrentAttendanceCountRequest $request): InstructorTotalCurrentAttendanceCountResource {
+        $managerId = Auth::guard('instructor')->user()->id;
+
+        /** @var Instructor $manager */
+        $manager = Instructor::with('managings')->findOrFail($managerId);
+
+        $instructorIds = $manager->managings->pluck('id')->toArray();
+        $instructorIds[] = $manager->id;
+
+        // 指定した講師IDが自分と配下の講師IDと一致しない場合は許可しない
+        if (! in_array((int) $request->instructor_id, $instructorIds, true)) {
+            throw new AuthorizationException('Forbidden, invalid instructor_id.');
+        }
+
+        $totalCurrentAttendanceCount = Attendance::whereNull('completed_at')
+            ->whereHas('course', function ($query) use ($request) {
+                $query->where('instructor_id', $request->instructor_id);
+            })
+            ->count();
+
+        return new InstructorTotalCurrentAttendanceCountResource([
+            'total_current_attendance_count' => $totalCurrentAttendanceCount,
+        ]);
     }
 
     /**

--- a/app/Http/Requests/Manager/Instructor/TotalCurrentAttendanceCountRequest.php
+++ b/app/Http/Requests/Manager/Instructor/TotalCurrentAttendanceCountRequest.php
@@ -13,11 +13,9 @@ class TotalCurrentAttendanceCountRequest extends FormRequest
             'instructor_id' => $this->route('instructor_id'),
         ]);
     }
-    
+
     /**
      * Determine if the user is authorized to make this request.
-     * 
-     * @return bool
      */
     public function authorize(): bool
     {
@@ -26,8 +24,6 @@ class TotalCurrentAttendanceCountRequest extends FormRequest
 
     /**
      * Get the validation rules that apply to the request.
-     *
-     * @return array
      */
     public function rules(): array
     {

--- a/app/Http/Requests/Manager/Instructor/TotalCurrentAttendanceCountRequest.php
+++ b/app/Http/Requests/Manager/Instructor/TotalCurrentAttendanceCountRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Manager\Instructor;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TotalCurrentAttendanceCountRequest extends FormRequest
+{
+    #[\Override]
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'instructor_id' => $this->route('instructor_id'),
+        ]);
+    }
+    
+    /**
+     * Determine if the user is authorized to make this request.
+     * 
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'instructor_id' => ['required', 'integer', 'exists:instructors,id,deleted_at,NULL'],
+        ];
+    }
+}

--- a/app/Http/Resources/Manager/InstructorTotalCurrentAttendanceCountResource.php
+++ b/app/Http/Resources/Manager/InstructorTotalCurrentAttendanceCountResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\Manager;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InstructorTotalCurrentAttendanceCountResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'total_current_attendance_count' => $this->resource['total_current_attendance_count'],
+        ];
+    }
+}

--- a/app/Http/Resources/Manager/InstructorTotalCurrentAttendanceCountResource.php
+++ b/app/Http/Resources/Manager/InstructorTotalCurrentAttendanceCountResource.php
@@ -10,9 +10,9 @@ class InstructorTotalCurrentAttendanceCountResource extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return array<string, mixed>
      */
+    #[\Override]
     public function toArray(Request $request): array
     {
         return [

--- a/app/Services/Instructor/TotalCurrentAttendanceCountService.php
+++ b/app/Services/Instructor/TotalCurrentAttendanceCountService.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services\Instructor;
+
+use App\Model\Attendance;
+
+class TotalCurrentAttendanceCountService
+{
+    public function __invoke(int $instructorId): int
+    {
+        return Attendance::whereNull('completed_at')
+            ->whereHas('course', function ($query) use ($instructorId) {
+                $query->where('instructor_id', $instructorId);
+            })
+            ->count();
+    }
+}
+

--- a/app/Services/Instructor/TotalCurrentAttendanceCountService.php
+++ b/app/Services/Instructor/TotalCurrentAttendanceCountService.php
@@ -15,4 +15,3 @@ class TotalCurrentAttendanceCountService
             ->count();
     }
 }
-

--- a/routes/api.php
+++ b/routes/api.php
@@ -211,7 +211,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'show'])->name('show');
                         Route::post('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'update'])->name('update');
                         Route::get('total-current-attendance-count',
-                        [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'totalCurrentAttendanceCount'])->name('total-current-attendance-count');
+                            [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'totalCurrentAttendanceCount'])->name('total-current-attendance-count');
                         Route::prefix('course')->name('course.')->group(function () {
                             Route::get('index', [App\Http\Controllers\Api\Manager\Instructor\CourseController::class, 'index'])->name('index');
                         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -210,6 +210,8 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                     Route::prefix('{instructor_id}')->group(function () {
                         Route::get('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'show'])->name('show');
                         Route::post('/', [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'update'])->name('update');
+                        Route::get('total-current-attendance-count',
+                        [App\Http\Controllers\Api\Manager\Instructor\InstructorController::class, 'totalCurrentAttendanceCount'])->name('total-current-attendance-count');
                         Route::prefix('course')->name('course.')->group(function () {
                             Route::get('index', [App\Http\Controllers\Api\Manager\Instructor\CourseController::class, 'index'])->name('index');
                         });

--- a/tests/Feature/Api/Manager/Instructor/TotalCurrentAttendanceCountTest.php
+++ b/tests/Feature/Api/Manager/Instructor/TotalCurrentAttendanceCountTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Instructor;
+
+use App\Model\Attendance;
+use App\Model\Course;
+use App\Model\Instructor;
+use App\Model\ManageInstructor;
+use App\Model\Student;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TotalCurrentAttendanceCountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_トータル受講中受講生数取得_成功(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $subordinate = Instructor::factory()->create(['type' => 'instructor']);
+        ManageInstructor::factory()->create([
+            'manager_id' => $manager->id,
+            'instructor_id' => $subordinate->id,
+        ]);
+
+        $course1 = Course::factory()->create(['instructor_id' => $subordinate->id]);
+        $course2 = Course::factory()->create(['instructor_id' => $subordinate->id]);
+
+        // 受講中（completed_at = null）の受講レコードを3件
+        Attendance::factory()->create([
+            'student_id' => Student::factory(),
+            'course_id' => $course1->id,
+            'completed_at' => null,
+        ]);
+        Attendance::factory()->create([
+            'student_id' => Student::factory(),
+            'course_id' => $course1->id,
+            'completed_at' => null,
+        ]);
+        Attendance::factory()->create([
+            'student_id' => Student::factory(),
+            'course_id' => $course2->id,
+            'completed_at' => null,
+        ]);
+
+        // 完了済みの受講レコード（カウント対象外）
+        Attendance::factory()->create([
+            'student_id' => Student::factory(),
+            'course_id' => $course1->id,
+            'completed_at' => CarbonImmutable::now(),
+        ]);
+
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('manager.instructor.total-current-attendance-count', [
+            'instructor_id' => $subordinate->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'total_current_attendance_count' => 3,
+            ],
+        ]);
+    }
+
+    public function test_トータル受講中受講生数取得_他講師の受講はカウントされない(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $subordinate = Instructor::factory()->create(['type' => 'instructor']);
+        $otherInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        ManageInstructor::factory()->create([
+            'manager_id' => $manager->id,
+            'instructor_id' => $subordinate->id,
+        ]);
+
+        $subordinateCourse = Course::factory()->create(['instructor_id' => $subordinate->id]);
+        $otherCourse = Course::factory()->create(['instructor_id' => $otherInstructor->id]);
+
+        Attendance::factory()->create([
+            'student_id' => Student::factory(),
+            'course_id' => $subordinateCourse->id,
+            'completed_at' => null,
+        ]);
+        // 別講師の講座への受講はカウント対象外
+        Attendance::factory()->create([
+            'student_id' => Student::factory(),
+            'course_id' => $otherCourse->id,
+            'completed_at' => null,
+        ]);
+
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('manager.instructor.total-current-attendance-count', [
+            'instructor_id' => $subordinate->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.total_current_attendance_count', 1);
+    }
+
+    public function test_権限がない_トータル受講中受講生数取得_失敗(): void
+    {
+        // Arrange — 配下ではない講師の情報を取得しようとする
+        $manager = Instructor::factory()->create();
+        $otherInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('manager.instructor.total-current-attendance-count', [
+            'instructor_id' => $otherInstructor->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
+    public function test_マネージャーではない_失敗(): void
+    {
+        // Arrange — マネージャーではない講師
+        $nonManager = Instructor::factory()->create(['type' => 'instructor']);
+        $otherInstructor = Instructor::factory()->create();
+        $this->actingAs($nonManager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('manager.instructor.total-current-attendance-count', [
+            'instructor_id' => $otherInstructor->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    public function test_存在しない講師_id_失敗(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $this->actingAs($manager, 'instructor');
+
+        // Act — 存在しないinstructor_idを指定
+        $response = $this->getJson(route('manager.instructor.total-current-attendance-count', [
+            'instructor_id' => 99999,
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Issue
JKA-1695  マネージャー側 講師-講座情報一覧取得APIへのトータル受講中受講生の数追加
(JKA-1739~JKA-1741)

## 対応内容
・ロジック（コントローラー）の作成（既存のapp/Http/Controllers/Api/Manager/Instructor/InstructorController.phpを使用)
・新たにTotalCurrentAttendanceCountServiceを新規作成し、
　コントローラーにあった講座カウントロジックを移動
・既存のinstructorPolicyのviewメソッドを活用し、
　コントローラーの認可処理をpolicyに一任させる様に変更

・フォームリクエストの作成(instructor_idにバリデーション設定)

・レスポンス整形のリソースファイル作成(total_current_attendance_count専用のリソースを作成)

## 確認方法
postmanで[http://localhost:8080/api/v1/manager/instructor/{instructor_id}/total-current-attendance-countを叩き、](http://localhost:8080/api/v1/manager/instructor/%7Binstructor_id%7D/total-current-attendance-count%E3%82%92%E5%8F%A9%E3%81%8D%E3%80%81)
レスポンスに
例）
{
"data": {
"total_current_attendance_count": 3
}
}
が返ることを確認

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)