### PR TITLE
JKA-1744講師側 受講状況APIに平均進捗率を追加(Naomichi)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -17,6 +17,7 @@ use App\Http\Resources\Instructor\Attendance\StatusResource;
 use App\Http\Resources\Instructor\AttendanceShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
+use App\Model\Lesson;
 use App\Model\LessonAttendance;
 use App\Services\Attendance\CalculateDeadlineService;
 use App\Services\Attendance\ExpiringService;
@@ -163,12 +164,18 @@ class AttendanceController extends Controller
 
         $studentsCount = $attendances->count();
 
-        $totalLessonsCount = $course->chapters()->withCount('lessons')->get()->sum('lessons_count');
+        $totalLessonsCount = $course->chapters()
+            ->withCount(['lessons' => fn ($query) => $query->public()])
+            ->get()
+            ->sum('lessons_count');
 
         $period = $request->period;
 
-        // 指定期間内に完了したレッスンの個数を取得
+        // 指定期間内に完了した公開レッスンの個数を取得
         $completedLessonsCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->filter(function (LessonAttendance $lessonAttendance) use ($period) {
+            if ($lessonAttendance->lesson->status !== Lesson::STATUS_PUBLIC) {
+                return false;
+            }
             if ($period === LessonAttendance::PERIOD_TODAY) {
                 $updatedAtRequestPeriod = $lessonAttendance->updated_at->isToday();
             } elseif ($period === LessonAttendance::PERIOD_MONTH) {

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -163,7 +163,7 @@ class AttendanceController extends Controller
 
         $studentsCount = $attendances->count();
 
-        $totalLessonsCount = $attendances->first()?->lessonAttendances->count() ?? 0;
+        $totalLessonsCount = $course->chapters()->withCount('lessons')->get()->sum('lessons_count');
 
         $period = $request->period;
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -164,7 +164,7 @@ class AttendanceController extends Controller
         $studentsCount = $attendances->count();
 
         $totalLessonsCount = $attendances->first()?->lessonAttendances->count() ?? 0;
-        
+
         $period = $request->period;
 
         // 指定期間内に完了したレッスンの個数を取得

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -150,7 +150,7 @@ class AttendanceController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
         $courseId = $request->course_id;
         $course = Course::findOrFail($courseId);
-        
+
         if ($course->instructor_id !== $instructorId) {
             // ログインしている講師の講座でない場合はエラーを返す
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
@@ -167,7 +167,7 @@ class AttendanceController extends Controller
             ->withCount('lessons')
             ->get()
             ->sum('lessons_count');
-        
+
         $period = $request->period;
 
         // 指定期間内に完了したレッスンの個数を取得
@@ -179,6 +179,7 @@ class AttendanceController extends Controller
             } else {
                 throw new Exception('Invalid period');
             }
+
             return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $updatedAtRequestPeriod;
         }))->count();
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -150,7 +150,7 @@ class AttendanceController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
         $courseId = $request->course_id;
         $course = Course::findOrFail($courseId);
-
+        
         if ($course->instructor_id !== $instructorId) {
             // ログインしている講師の講座でない場合はエラーを返す
             throw new AuthorizationException('Forbidden, invalid instructor_id.');
@@ -160,6 +160,14 @@ class AttendanceController extends Controller
             'lessonAttendances.lesson.chapter.course',
             'lessonAttendances.lesson.chapter.lessons',
         ])->where('course_id', $courseId)->get();
+
+        $studentsCount = $attendances->count();
+
+        $totalLessonsCount = $course->chapters()
+            ->withCount('lessons')
+            ->get()
+            ->sum('lessons_count');
+        
         $period = $request->period;
 
         // 指定期間内に完了したレッスンの個数を取得
@@ -171,9 +179,12 @@ class AttendanceController extends Controller
             } else {
                 throw new Exception('Invalid period');
             }
-
             return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $updatedAtRequestPeriod;
         }))->count();
+
+        $averageProgressRate = ($studentsCount === 0 || $totalLessonsCount === 0)
+            ? 0
+            : round(($completedLessonsCount / ($studentsCount * $totalLessonsCount)) * 100);
 
         // 指定期間内に完了したチャプターの個数を取得
         $completedChaptersCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))
@@ -207,6 +218,7 @@ class AttendanceController extends Controller
         return response()->json([
             'completed_lessons_count' => $completedLessonsCount,
             'completed_chapters_count' => $completedChaptersCount,
+            'average_progress_rate' => $averageProgressRate,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -163,11 +163,8 @@ class AttendanceController extends Controller
 
         $studentsCount = $attendances->count();
 
-        $totalLessonsCount = $course->chapters()
-            ->withCount('lessons')
-            ->get()
-            ->sum('lessons_count');
-
+        $totalLessonsCount = $attendances->first()?->lessonAttendances->count() ?? 0;
+        
         $period = $request->period;
 
         // 指定期間内に完了したレッスンの個数を取得
@@ -183,9 +180,12 @@ class AttendanceController extends Controller
             return $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE && $updatedAtRequestPeriod;
         }))->count();
 
-        $averageProgressRate = ($studentsCount === 0 || $totalLessonsCount === 0)
-            ? 0
-            : round(($completedLessonsCount / ($studentsCount * $totalLessonsCount)) * 100);
+        // 指定期間内に完了したレッスン数をもとに平均進捗率を取得
+        $averageProgressRate = Attendance::calcAverageProgressRate(
+            $completedLessonsCount,
+            $studentsCount,
+            $totalLessonsCount,
+        );
 
         // 指定期間内に完了したチャプターの個数を取得
         $completedChaptersCount = $attendances->flatMap(fn (Attendance $attendance) => $attendance->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -86,6 +86,9 @@ class Attendance extends Model
         return floor($percent);
     }
 
+    /**
+     * 平均進捗率計算
+     */
     public static function calcAverageProgressRate(int $completedLessonsCount, int $studentsCount, int $totalLessonsCount): float
     {
         if ($studentsCount === 0 || $totalLessonsCount === 0) {

--- a/app/Model/Attendance.php
+++ b/app/Model/Attendance.php
@@ -86,6 +86,17 @@ class Attendance extends Model
         return floor($percent);
     }
 
+    public static function calcAverageProgressRate(int $completedLessonsCount, int $studentsCount, int $totalLessonsCount): float
+    {
+        if ($studentsCount === 0 || $totalLessonsCount === 0) {
+            return 0;
+        }
+
+        $percent = ($completedLessonsCount / ($studentsCount * $totalLessonsCount)) * 100;
+
+        return floor($percent);
+    }
+
     public static function hasActiveStudents(int $courseId): bool
     {
         return self::where('course_id', $courseId)->exists();

--- a/app/Model/Lesson.php
+++ b/app/Model/Lesson.php
@@ -2,6 +2,7 @@
 
 namespace App\Model;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -72,5 +73,13 @@ class Lesson extends Model
     public function getCompletedLessonsCountAttribute()
     {
         return $this->lessonAttendances->filter(fn (LessonAttendance $lessonAttendance) => $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE)->count();
+    }
+
+    /**
+     * 公開済みのレッスンに絞り込む
+     */
+    public function scopePublic(Builder $query): void
+    {
+        $query->where('status', self::STATUS_PUBLIC);
     }
 }

--- a/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
@@ -88,7 +88,7 @@ class ShowStatusTest extends TestCase
         $response->assertStatus(403);
     }
 
-    public function test_受講生がいない場合_average_progress_rateは0(): void
+    public function test_受講生がいない場合_平均進捗率は0(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
@@ -108,7 +108,7 @@ class ShowStatusTest extends TestCase
         $response->assertJson(['average_progress_rate' => 0]);
     }
 
-    public function test_レッスンが0件の場合_average_progress_rateは0(): void
+    public function test_レッスンが0件の場合_平均進捗率は0(): void
     {
         // Arrange — 講座にチャプター/レッスンが無く、受講生のみ存在
         $instructor = Instructor::factory()->create();

--- a/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
@@ -2,8 +2,13 @@
 
 namespace Tests\Feature\Api\Instructor\Attendance;
 
+use App\Model\Attendance;
+use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Lesson;
+use App\Model\LessonAttendance;
+use App\Model\Student;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -81,5 +86,95 @@ class ShowStatusTest extends TestCase
 
         // Assert
         $response->assertStatus(403);
+    }
+
+    public function test_受講生がいない場合_average_progress_rateは0(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id]);
+        Lesson::factory()->create(['chapter_id' => $chapter->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.show-status', [
+            'course_id' => $course->id,
+            'period' => 'today',
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(['average_progress_rate' => 0]);
+    }
+
+    public function test_レッスンが0件の場合_average_progress_rateは0(): void
+    {
+        // Arrange — 講座にチャプター/レッスンが無く、受講生のみ存在
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $student = Student::factory()->create();
+        Attendance::factory()->create(['student_id' => $student->id, 'course_id' => $course->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.show-status', [
+            'course_id' => $course->id,
+            'period' => 'today',
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(['average_progress_rate' => 0]);
+    }
+
+    public function test_平均進捗率の計算が正しい(): void
+    {
+        // Arrange — 受講生2名 × レッスン4本、当日完了が5件 → floor(5 / (2 * 4) * 100) = 62
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id]);
+        $lessons = Lesson::factory()->count(4)->create(['chapter_id' => $chapter->id]);
+
+        $studentA = Student::factory()->create();
+        $attendanceA = Attendance::factory()->create(['student_id' => $studentA->id, 'course_id' => $course->id]);
+        $studentB = Student::factory()->create();
+        $attendanceB = Attendance::factory()->create(['student_id' => $studentB->id, 'course_id' => $course->id]);
+
+        // 受講生A: 4レッスンのうち3件を完了
+        foreach ($lessons as $i => $lesson) {
+            LessonAttendance::factory()->create([
+                'attendance_id' => $attendanceA->id,
+                'lesson_id' => $lesson->id,
+                'status' => $i < 3
+                    ? LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+                    : LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+            ]);
+        }
+        // 受講生B: 4レッスンのうち2件を完了
+        foreach ($lessons as $i => $lesson) {
+            LessonAttendance::factory()->create([
+                'attendance_id' => $attendanceB->id,
+                'lesson_id' => $lesson->id,
+                'status' => $i < 2
+                    ? LessonAttendance::STATUS_COMPLETED_ATTENDANCE
+                    : LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+            ]);
+        }
+
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.show-status', [
+            'course_id' => $course->id,
+            'period' => 'today',
+        ]));
+
+        // Assert — completed: 5 / (students: 2 × lessons: 4) × 100 = 62.5 → floor → 62
+        $response->assertStatus(200);
+        $response->assertJson([
+            'completed_lessons_count' => 5,
+            'average_progress_rate' => 62,
+        ]);
     }
 }

--- a/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowStatusTest.php
@@ -128,6 +128,59 @@ class ShowStatusTest extends TestCase
         $response->assertJson(['average_progress_rate' => 0]);
     }
 
+    public function test_非公開レッスンは平均進捗率の計算に含まれない(): void
+    {
+        // Arrange — 公開2本 + 非公開2本、受講生1名が公開レッスン2本を完了
+        // 母数 = 公開Lesson 2本 × 受講生1名 = 2、完了 = 2 → 100%
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id]);
+
+        $publicLessons = Lesson::factory()->count(2)->create([
+            'chapter_id' => $chapter->id,
+            'status' => Lesson::STATUS_PUBLIC,
+        ]);
+        $privateLessons = Lesson::factory()->count(2)->create([
+            'chapter_id' => $chapter->id,
+            'status' => Lesson::STATUS_PRIVATE,
+        ]);
+
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create(['student_id' => $student->id, 'course_id' => $course->id]);
+
+        // 公開Lesson 2件を完了
+        foreach ($publicLessons as $lesson) {
+            LessonAttendance::factory()->create([
+                'attendance_id' => $attendance->id,
+                'lesson_id' => $lesson->id,
+                'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            ]);
+        }
+        // 非公開Lesson はステータス遷移しないものの、レコード自体は存在する想定
+        foreach ($privateLessons as $lesson) {
+            LessonAttendance::factory()->create([
+                'attendance_id' => $attendance->id,
+                'lesson_id' => $lesson->id,
+                'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+            ]);
+        }
+
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.show-status', [
+            'course_id' => $course->id,
+            'period' => 'today',
+        ]));
+
+        // Assert — 非公開Lessonは母数・分子から除外され、completed: 2 / (1 × 2) × 100 = 100
+        $response->assertStatus(200);
+        $response->assertJson([
+            'completed_lessons_count' => 2,
+            'average_progress_rate' => 100,
+        ]);
+    }
+
     public function test_平均進捗率の計算が正しい(): void
     {
         // Arrange — 受講生2名 × レッスン4本、当日完了が5件 → floor(5 / (2 * 4) * 100) = 62


### PR DESCRIPTION
## Issue
・講師側 受講状況APIに平均進捗率を追加
## 対応内容
・`completed_lessons_count` をもとに平均進捗率を算出  
　→平均進捗率 =  対象講座の全受講生の完了レッスン数合計 ÷（全受講生数 × 対象講座が持つ全レッスン数）× 100
・レスポンスに `average_progress_rate` を追加  
・受講生数または対象講座のレッスン数が0件の場合  
　→ `0` を返却
## 確認方法

・講師でログイン
・GET /api/v1/instructor/course/{course_id}/attendance/status/{period}を実行  
・レスポンスに `average_progress_rate` が返ることをPostmanで確認
## スクショ(任意)
<img width="874" height="671" alt="image" src="https://github.com/user-attachments/assets/d0ae649a-1004-4061-abb7-5d9b7c5de333" />
