### PR TITLE
JKA-1748  2. 受講人数から期限切れを除外する実装(ロジックの作成)(えんどう)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -21,6 +21,7 @@ use App\Model\LessonAttendance;
 use App\Services\Attendance\CalculateDeadlineService;
 use App\Services\Attendance\ExpiringService;
 use App\Services\Attendance\FollowUpService;
+use App\Services\Attendance\ShowService;
 use App\Services\Attendance\StoreService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -58,19 +59,15 @@ class AttendanceController extends Controller
     /**
      * 受講状況取得API
      */
-    public function show(ShowRequest $request): AttendanceShowResource
+    public function show(ShowRequest $request, ShowService $service): AttendanceShowResource
     {
         $attendance = Attendance::with(['course.tags', 'course.courseDeadline'])->findOrFail($request->attendance_id);
 
         $this->authorize('view', [Attendance::class, $attendance]);
 
-        /** @var int */
-        $studentsCount = Attendance::where('course_id', $attendance->course_id)->count();
+        $result = $service($attendance);
 
-        return new AttendanceShowResource([
-            'attendance' => $attendance,
-            'studentsCount' => $studentsCount,
-        ]);
+        return new AttendanceShowResource($result);
     }
 
     /**

--- a/app/Services/Attendance/ShowService.php
+++ b/app/Services/Attendance/ShowService.php
@@ -11,7 +11,7 @@ final class ShowService
      * 受講状況詳細に必要な情報（期限切れを除いた受講人数を含む）を取得する
      *
      * @return array{attendance: Attendance, studentsCount: int}
-     */
+    */
     public function __invoke(Attendance $attendance): array
     {
         $studentsCount = Attendance::where('course_id', $attendance->course_id)

--- a/app/Services/Attendance/ShowService.php
+++ b/app/Services/Attendance/ShowService.php
@@ -5,15 +5,19 @@ namespace App\Services\Attendance;
 use App\Model\Attendance;
 use Carbon\CarbonImmutable;
 
-class ShowService
+final class ShowService
 {
     public function __invoke(Attendance $attendance): array
     {
-        /** @var int */
+        /**
+         * 受講状況詳細に必要な情報（期限切れを除いた受講人数を含む）を取得する
+         *
+         * @return array{attendance: Attendance, studentsCount: int}
+        */
         $studentsCount = Attendance::where('course_id', $attendance->course_id)
             ->where(function ($query) {
                 $query->whereNull('attendance_deadline')
-                    ->orWhere('attendance_deadline', '>=', CarbonImmutable::today()->toDateString());
+                    ->orWhere('attendance_deadline', '>=', CarbonImmutable::today());
             })
             ->count();
 

--- a/app/Services/Attendance/ShowService.php
+++ b/app/Services/Attendance/ShowService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services\Attendance;
+
+use App\Model\Attendance;
+use Carbon\CarbonImmutable;
+
+class ShowService
+{
+    public function __invoke(Attendance $attendance): array
+    {
+        /** @var int */
+        $studentsCount = Attendance::where('course_id', $attendance->course_id)
+            ->where(function ($query) {
+                $query->whereNull('attendance_deadline')
+                    ->orWhere('attendance_deadline', '>=', CarbonImmutable::today()->toDateString());
+            })
+            ->count();
+
+        return [
+            'attendance' => $attendance,
+            'studentsCount' => $studentsCount,
+        ];
+    }
+}

--- a/app/Services/Attendance/ShowService.php
+++ b/app/Services/Attendance/ShowService.php
@@ -11,7 +11,7 @@ final class ShowService
      * 受講状況詳細に必要な情報（期限切れを除いた受講人数を含む）を取得する
      *
      * @return array{attendance: Attendance, studentsCount: int}
-    */
+     */
     public function __invoke(Attendance $attendance): array
     {
         $studentsCount = Attendance::where('course_id', $attendance->course_id)

--- a/app/Services/Attendance/ShowService.php
+++ b/app/Services/Attendance/ShowService.php
@@ -7,13 +7,13 @@ use Carbon\CarbonImmutable;
 
 final class ShowService
 {
+    /**
+     * 受講状況詳細に必要な情報（期限切れを除いた受講人数を含む）を取得する
+     *
+     * @return array{attendance: Attendance, studentsCount: int}
+    */
     public function __invoke(Attendance $attendance): array
     {
-        /**
-         * 受講状況詳細に必要な情報（期限切れを除いた受講人数を含む）を取得する
-         *
-         * @return array{attendance: Attendance, studentsCount: int}
-        */
         $studentsCount = Attendance::where('course_id', $attendance->course_id)
             ->where(function ($query) {
                 $query->whereNull('attendance_deadline')

--- a/tests/Feature/Api/Instructor/Attendance/ShowTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/ShowTest.php
@@ -367,4 +367,97 @@ class ShowTest extends TestCase
         ]);
         $response->assertJsonPath('data.course.course_deadline.fixed_date', '2026-12-31');
     }
+
+    public function test_期限切れの受講者は受講人数から除外される(): void
+    {
+        // Arrange — 期限内の受講者と期限切れの受講者を作成し、期限内の受講で取得
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $activeStudent = Student::factory()->create();
+        $activeAttendance = Attendance::factory()->create([
+            'student_id' => $activeStudent->id,
+            'course_id' => $course->id,
+            'attendance_deadline' => CarbonImmutable::tomorrow(),
+        ]);
+        $expiredStudent = Student::factory()->create();
+        Attendance::factory()->create([
+            'student_id' => $expiredStudent->id,
+            'course_id' => $course->id,
+            'attendance_deadline' => CarbonImmutable::yesterday(),
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $activeAttendance->id]));
+
+        // Assert — 期限切れの受講者は除外されてカウントされる
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'students_count' => 1,
+            ],
+        ]);
+    }
+
+    public function test_当日が期限の受講者は受講人数に含まれる(): void
+    {
+        // Arrange — 当日が期限の受講者と期限内の受講者を作成
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $todayDeadlineStudent = Student::factory()->create();
+        Attendance::factory()->create([
+            'student_id' => $todayDeadlineStudent->id,
+            'course_id' => $course->id,
+            'attendance_deadline' => CarbonImmutable::today(),
+        ]);
+        $futureDeadlineStudent = Student::factory()->create();
+        $futureAttendance = Attendance::factory()->create([
+            'student_id' => $futureDeadlineStudent->id,
+            'course_id' => $course->id,
+            'attendance_deadline' => CarbonImmutable::tomorrow(),
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $futureAttendance->id]));
+
+        // Assert — 当日が期限の受講者も含めてカウントされる（>= の境界）
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'students_count' => 2,
+            ],
+        ]);
+    }
+
+    public function test_受講期限なしの受講者は受講人数に含まれる(): void
+    {
+        // Arrange — 期限なしの受講者と期限内の受講者を作成
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $noDeadlineStudent = Student::factory()->create();
+        Attendance::factory()->create([
+            'student_id' => $noDeadlineStudent->id,
+            'course_id' => $course->id,
+            'attendance_deadline' => null,
+        ]);
+        $activeStudent = Student::factory()->create();
+        $activeAttendance = Attendance::factory()->create([
+            'student_id' => $activeStudent->id,
+            'course_id' => $course->id,
+            'attendance_deadline' => CarbonImmutable::tomorrow(),
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.attendance.show', ['attendance_id' => $activeAttendance->id]));
+
+        // Assert — 期限なしの受講者も含めてカウントされる
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'students_count' => 2,
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
## Issue
JKA-1748

## 対応内容
2. 受講人数から期限切れを除外する実装(ロジックの作成)
・app/Http/Controllers/Api/Instructor/AttendanceController.phpのshowメソッドの
　　$studentsCountのロジックを拡張
・抽出条件に以下を追加
　　 1. 受講期限(attendance_deadline)がnull
 　　2.本日が受講期限日（当日も含む）より前であること
・次タスクも見据えてロジックが拡張していく事からshowServiceに切り出し

## 確認方法
postmanにてhttp://localhost:8085/api/v1/instructor/attendance/{attendance_id}を叩き、
students_count数が条件によって変化することを確認

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)