### PR TITLE
JKA-1745 講師側 受講状況APIに止まっている箇所を追加

### DIFF
--- a/app/Dto/Instructor/Attendance/StuckLessonDto.php
+++ b/app/Dto/Instructor/Attendance/StuckLessonDto.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Dto\Instructor\Attendance;
+
+readonly class StuckLessonDto
+{
+    public function __construct(
+        public int $id,
+        public string $title,
+    ) {}
+}

--- a/app/Dto/Instructor/Attendance/StuckPointDto.php
+++ b/app/Dto/Instructor/Attendance/StuckPointDto.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Dto\Instructor\Attendance;
+
+use Illuminate\Support\Collection;
+
+readonly class StuckPointDto
+{
+    /**
+     * @param  Collection<int, StuckLessonDto>  $lessons
+     */
+    public function __construct(
+        public int $id,
+        public string $title,
+        public Collection $lessons,
+    ) {}
+}

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -288,7 +288,7 @@ class AttendanceController extends Controller
 
         $result = $service($courseId);
 
-        if ($result === null) {
+        if ($result->isEmpty()) {
             return response()->json([]);
         }
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -11,9 +11,11 @@ use App\Http\Requests\Instructor\Attendance\ShowRequest;
 use App\Http\Requests\Instructor\Attendance\ShowStatusRequest;
 use App\Http\Requests\Instructor\Attendance\StatusRequest;
 use App\Http\Requests\Instructor\Attendance\StoreRequest;
+use App\Http\Requests\Instructor\Attendance\StuckPointsRequest;
 use App\Http\Resources\Instructor\Attendance\ExpiringResource;
 use App\Http\Resources\Instructor\Attendance\FollowUpResource;
 use App\Http\Resources\Instructor\Attendance\StatusResource;
+use App\Http\Resources\Instructor\Attendance\StuckPointsResource;
 use App\Http\Resources\Instructor\AttendanceShowResource;
 use App\Model\Attendance;
 use App\Model\Course;
@@ -23,6 +25,7 @@ use App\Services\Attendance\CalculateDeadlineService;
 use App\Services\Attendance\ExpiringService;
 use App\Services\Attendance\FollowUpService;
 use App\Services\Attendance\StoreService;
+use App\Services\Attendance\StuckPointsService;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -270,5 +273,25 @@ class AttendanceController extends Controller
         $result = $service($request->course_id, $request->thresholds);
 
         return ExpiringResource::collection($result);
+    }
+
+    /**
+     * 受講生の止まっている箇所取得API
+     */
+    public function stuckPoints(StuckPointsRequest $request, StuckPointsService $service): AnonymousResourceCollection|JsonResponse
+    {
+        $courseId = $request->course_id;
+
+        // Policyによる認可チェック
+        $course = Course::findOrFail($courseId);
+        $this->authorize('view', $course);
+
+        $result = $service($courseId);
+
+        if ($result === null) {
+            return response()->json([]);
+        }
+
+        return StuckPointsResource::collection($result);
     }
 }

--- a/app/Http/Requests/Instructor/Attendance/StuckPointsRequest.php
+++ b/app/Http/Requests/Instructor/Attendance/StuckPointsRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Instructor\Attendance;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StuckPointsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'course_id' => ['required', 'integer', 'exists:courses,id,deleted_at,NULL'],
+        ];
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'course_id' => $this->route('course_id'),
+        ]);
+    }
+}

--- a/app/Http/Resources/Instructor/Attendance/StuckLessonsResource.php
+++ b/app/Http/Resources/Instructor/Attendance/StuckLessonsResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\Instructor\Attendance;
+
+use App\Dto\Instructor\Attendance\StuckLessonDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StuckLessonsResource extends JsonResource
+{
+    /** @var StuckLessonDto */
+    public $resource;
+
+    #[\Override]
+    public function toArray(Request $request): array
+    {
+        return [
+            'lesson_id' => $this->resource->id,
+            'lesson_title' => $this->resource->title,
+        ];
+    }
+}

--- a/app/Http/Resources/Instructor/Attendance/StuckPointsResource.php
+++ b/app/Http/Resources/Instructor/Attendance/StuckPointsResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\Instructor\Attendance;
+
+use App\Dto\Instructor\Attendance\StuckPointDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StuckPointsResource extends JsonResource
+{
+    /** @var StuckPointDto */
+    public $resource;
+
+    #[\Override]
+    public function toArray(Request $request): array
+    {
+        return [
+            'chapter_id' => $this->resource->id,
+            'chapter_title' => $this->resource->title,
+            'lessons' => StuckLessonsResource::collection($this->resource->lessons),
+        ];
+    }
+}

--- a/app/Model/Chapter.php
+++ b/app/Model/Chapter.php
@@ -2,6 +2,7 @@
 
 namespace App\Model;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -114,5 +115,13 @@ class Chapter extends Model
     public function getCompletedCountAttribute(): int
     {
         return $this->lessons->flatMap(fn (Lesson $lesson) => $lesson->lessonAttendances->where('status', LessonAttendance::STATUS_COMPLETED_ATTENDANCE))->count();
+    }
+
+    /**
+     * 公開中のチャプターに絞り込む
+     */
+    public function scopePublic(Builder $query): void
+    {
+        $query->where('status', self::STATUS_PUBLIC);
     }
 }

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -22,7 +22,6 @@ final class StuckPointsService
      */
     public function __invoke(int $courseId): Collection
     {
-
         $publicChapters = $this->getPublicChapters($courseId);
         $publicLessons = $this->getPublicLessons($publicChapters);
         $attendances = $this->getActiveAttendances($courseId);
@@ -43,24 +42,24 @@ final class StuckPointsService
             return $this->getFirstLesson($publicChapters, $publicLessons);
         }
 
-        // 最多数のレッスンを取得
+        // 最多数のレッスン群
         $maxCompletedLessons = $completedLessonCounts
             ->where('lesson_attendances_count', $maxCount);
 
         // 最終レッスンの取得
         $lastLesson = $this->getLastLesson($publicChapters, $publicLessons);
 
-        // 受講済みの最多数のレッスンの中で、最終レッスンの有無を確認
-        $maxLastLesson = $maxCompletedLessons->where('id', $lastLesson->id);
-        $maxCompletedLessons = $maxCompletedLessons->where('id', '!=', $lastLesson->id);
-
-        // 受講済み最多数のレッスンが最終レッスンのみの場合、空配列を返す
-        if ($maxLastLesson->isNotEmpty() && $maxCompletedLessons->isEmpty()) {
+        // 受講済み最多数のレッスンが最終レッスンのみの場合は、空コレクションを返す
+        $isOnlyLastLesson = $maxCompletedLessons->count() === 1
+            && $maxCompletedLessons->first()->id === $lastLesson->id;
+        if ($isOnlyLastLesson) {
             return collect();
         }
 
-        // 最終レッスン以外の受講済み最多数のレッスンの次の公開レッスンとチャプターを取得
-        return $this->getNextLesson($maxCompletedLessons, $publicLessons, $publicChapters);
+        // 最終レッスンを除いた最多数のレッスンの次の公開レッスンとチャプターを取得
+        $targetLessons = $maxCompletedLessons->where('id', '!=', $lastLesson->id);
+
+        return $this->getNextLesson($targetLessons, $publicLessons, $publicChapters);
     }
 
     /**
@@ -170,7 +169,7 @@ final class StuckPointsService
         }
 
         // 到達しないはずだが、念のため例外を返す
-        throw new RuntimeException('The first public lesson is not existed.');
+        throw new RuntimeException('The first public lesson does not exist.');
     }
 
     /**
@@ -190,7 +189,7 @@ final class StuckPointsService
         }
 
         // 到達しないはずだが、念のため例外を返す
-        throw new RuntimeException('The last public lesson is not existed.');
+        throw new RuntimeException('The last public lesson does not exist.');
     }
 
     /**
@@ -205,18 +204,17 @@ final class StuckPointsService
     {
         return $maxCompletedLessons
             ->map(function (Lesson $maxCompletedLesson) use ($publicLessons, $publicChapters) {
-                $lesson = $publicLessons->where('id', $maxCompletedLesson->id)->first();
                 $stuckLesson = $publicLessons
-                    ->where('chapter_id', $lesson->chapter_id)
-                    ->where('order', '>', $lesson->order)
+                    ->where('chapter_id', $maxCompletedLesson->chapter_id)
+                    ->where('order', '>', $maxCompletedLesson->order)
                     ->sortBy('order')
                     ->first();
                 if ($stuckLesson) {
                     $stuckChapter = $publicChapters->where('id', $stuckLesson->chapter_id)->first();
                 } else {
-                    $chapter = $publicChapters->where('id', $lesson->chapter_id)->first();
+                    $currentChapter = $publicChapters->where('id', $maxCompletedLesson->chapter_id)->first();
                     $stuckChapter = $publicChapters
-                        ->where('order', '>', $chapter->order)
+                        ->where('order', '>', $currentChapter->order)
                         ->sortBy('order')
                         ->first();
                     $stuckLesson = $publicLessons

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -6,11 +6,10 @@ use App\Dto\Instructor\Attendance\StuckLessonDto;
 use App\Dto\Instructor\Attendance\StuckPointDto;
 use App\Model\Attendance;
 use App\Model\Chapter;
-use App\Model\CourseDeadline;
 use App\Model\Lesson;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use RuntimeException;
 
 final class StuckPointsService
 {
@@ -19,111 +18,193 @@ final class StuckPointsService
     /**
      * 止まっている箇所を取得する
      *
-     * @return Collection<StuckPointDto>|null
+     * @return Collection<StuckPointDto>
      */
-    public function __invoke(int $courseId): ?Collection
+    public function __invoke(int $courseId): Collection
     {
-        // 当該講座の受講期限を確認
-        $hasCourseDeadline = CourseDeadline::where('course_id', $courseId)
-            ->whereDate('fixed_date', '>=', CarbonImmutable::today())
-            ->exists();
-        // 受講期限が切れている場合は空配列を返す
-        if (! $hasCourseDeadline) {
-            return null;
-        }
 
-        // 公開チャプターを取得
-        $publicChapters = Chapter::where('course_id', $courseId)
-            ->where('status', Chapter::STATUS_PUBLIC)
-            ->get();
-        // 公開チャプターが1件も存在しない場合は空配列を返す
-        if ($publicChapters->isEmpty()) {
-            return null;
-        }
+        $publicChapters = $this->getPublicChapters($courseId);
+        $publicLessons = $this->getPublicLessons($publicChapters);
+        $attendances = $this->getActiveAttendances($courseId);
 
-        // 公開レッスンを取得
-        $publicLessons = Lesson::whereIn('chapter_id', $publicChapters->pluck('id'))
-            ->where('status', Lesson::STATUS_PUBLIC)
-            ->get();
-        // 公開レッスンが1件も存在しない場合は空配列を返す
-        if ($publicLessons->isEmpty()) {
-            return null;
-        }
-
-        // 講座の受講期限が切れていない受講を取得
-        $attendances = Attendance::where('course_id', $courseId)
-            ->whereDate('attendance_deadline', '>=', CarbonImmutable::today())
-            ->get();
-        // 受講生が1人の場合は空配列を返す
-        if ($attendances->pluck('student_id')->unique()
-            ->count() <= self::MINIMUM_STUDENT_COUNT) {
-            return null;
+        // 集計対象の講座、チャプター、レッスンがない場合は、空のコレクションを返す
+        if (! $this->isEligible($publicChapters, $publicLessons, $attendances)) {
+            return collect();
         }
 
         // 受講済みのレッスンを集計
-        $completedLessonCounts = DB::table('lesson_attendances')
-            ->selectRaw('lesson_id, COUNT(*) as count')
-            ->whereIn('attendance_id', $attendances->pluck('id'))
-            ->whereIn('lesson_id', $publicLessons->pluck('id'))
-            ->whereNotNull('completed_at')
-            ->whereNull('deleted_at')
-            ->groupBy('lesson_id')
-            ->get()
-            ->map(fn ($stuckPoint) => [
-                'lesson_id' => (int) $stuckPoint->lesson_id,
-                'count' => (int) $stuckPoint->count,
-            ]);
+        $completedLessonCounts = $this->countCompletedLessons($attendances, $publicLessons);
 
-        $maxCount = $completedLessonCounts->max('count');
+        // 受講済みの人数が最多のレッスンを取得
+        $maxCount = $completedLessonCounts->max('lesson_attendances_count');
+        $maxCompletedLessons = $completedLessonCounts
+            ->where('lesson_attendances_count', '>', self::MINIMUM_STUDENT_COUNT)
+            ->where('lesson_attendances_count', $maxCount);
 
         // 受講済みのレッスンがない、または、受講済みの最多数が1人の場合は
         // 受講可能な最初の公開レッスンとチャプターを返す
-        if ($completedLessonCounts->isEmpty() || (int) $maxCount === self::MINIMUM_STUDENT_COUNT) {
-            $chapters = $publicChapters->sortBy('order');
-            foreach ($chapters as $chapter) {
-                $lesson = $publicLessons->where('chapter_id', $chapter->id)->sortBy('order')->first();
-                if ($lesson) {
-                    return collect([
-                        new StuckPointDto(
-                            id: $chapter->id,
-                            title: $chapter->title,
-                            lessons: collect([
-                                new StuckLessonDto(
-                                    id: $lesson->id,
-                                    title: $lesson->title,
-                                ),
-                            ]),
-                        ),
-                    ]);
-                }
-            }
+        if ($maxCompletedLessons->isEmpty()) {
+            return $this->getFirstLesson($publicChapters, $publicLessons);
         }
 
         // 最終レッスンの取得
-        $chapters = $publicChapters->sortByDesc('order');
-        $lastLesson = null;
-        foreach ($chapters as $chapter) {
-            $lesson = $publicLessons->where('chapter_id', $chapter->id)->sortByDesc('order')->first();
-            if ($lesson) {
-                $lastLesson = $lesson;
-                break;
-            }
-        }
+        $lastLesson = $this->getLastLesson($publicChapters, $publicLessons);
 
-        // 受講済みの最多数のレッスンを取得し、最終レッスンの有無を確認
-        $maxCompletedLessonCounts = $completedLessonCounts->where('count', $maxCount);
-        $maxLastLesson = $maxCompletedLessonCounts->where('lesson_id', $lastLesson->id);
-        $maxCompletedLessons = $maxCompletedLessonCounts->where('lesson_id', '!=', $lastLesson->id);
+        // 受講済みの最多数のレッスンの中で、最終レッスンの有無を確認
+        $maxLastLesson = $maxCompletedLessons->where('id', $lastLesson->id);
+        $maxCompletedLessons = $maxCompletedLessons->where('id', '!=', $lastLesson->id);
 
         // 受講済み最多数のレッスンが最終レッスンのみの場合、空配列を返す
         if ($maxLastLesson->isNotEmpty() && $maxCompletedLessons->isEmpty()) {
-            return null;
+            return collect();
         }
 
         // 最終レッスン以外の受講済み最多数のレッスンの次の公開レッスンとチャプターを取得
+        return $this->getNextLesson($maxCompletedLessons, $publicLessons, $publicChapters);
+    }
+
+    /**
+     * 公開チャプターを取得
+     *
+     * @return Collection<Chapter>
+     */
+    private function getPublicChapters(int $courseId): Collection
+    {
+        return Chapter::where('course_id', $courseId)
+            ->where('status', Chapter::STATUS_PUBLIC)
+            ->get();
+    }
+
+    /**
+     * 公開レッスンを取得
+     *
+     * @param  Collection<Chapter>  $publicChapters
+     * @return Collection<Lesson>
+     */
+    private function getPublicLessons(Collection $publicChapters): Collection
+    {
+        return Lesson::whereIn('chapter_id', $publicChapters->pluck('id'))
+            ->where('status', Lesson::STATUS_PUBLIC)
+            ->get();
+    }
+
+    /**
+     * 講座の受講期限が切れていない受講を取得
+     *
+     * @return Collection<Attendance>
+     */
+    private function getActiveAttendances(int $courseId): Collection
+    {
+        return Attendance::where('course_id', $courseId)
+            ->where(function ($q) {
+                $q->whereDate('attendance_deadline', '>=', CarbonImmutable::today())
+                    ->orWhereNull('attendance_deadline'); // 無期限受講も含める
+            })
+            ->get();
+    }
+
+    /**
+     * 集計対象として有効かを判定
+     *
+     * @param  Collection<Chapter>  $publicChapters
+     * @param  Collection<Lesson>  $publicLessons
+     * @param  Collection<Attendance>  $attendances
+     */
+    private function isEligible(Collection $publicChapters, Collection $publicLessons, Collection $attendances): bool
+    {
+        if ($publicChapters->isEmpty() || $publicLessons->isEmpty()) {
+            return false;
+        }
+        return $attendances->pluck('student_id')
+            ->unique()
+            ->count() > self::MINIMUM_STUDENT_COUNT;
+    }
+
+    /**
+     * 受講済みレッスン数を集計
+     *
+     * @param  Collection<Attendance>  $attendances
+     * @param  Collection<Lesson>  $publicLessons
+     * @return Collection<int, Lesson>
+     */
+    private function countCompletedLessons(Collection $attendances, Collection $publicLessons): Collection
+    {
+        return Lesson::query()
+            ->whereIn('id', $publicLessons->pluck('id'))
+            ->withCount(['lessonAttendances' => fn ($q) => $q
+                ->whereIn('attendance_id', $attendances->pluck('id'))
+                ->whereNotNull('completed_at')
+            ])
+            ->get();
+    }
+
+    /**
+     * 受講可能な最初の公開レッスンとチャプターを取得
+     *
+     * @param  Collection<Chapter>  $publicChapters
+     * @param  Collection<Lesson>  $publicLessons
+     * @return Collection<StuckPointDto>
+     */
+    private function getFirstLesson(Collection $publicChapters, Collection $publicLessons): Collection
+    {
+        $chapters = $publicChapters->sortBy('order');
+        foreach ($chapters as $chapter) {
+            $lesson = $publicLessons->where('chapter_id', $chapter->id)
+                ->sortBy('order')
+                ->first();
+            if ($lesson) {
+                return collect([
+                    new StuckPointDto(
+                        id: $chapter->id,
+                        title: $chapter->title,
+                        lessons: collect([
+                            new StuckLessonDto(
+                                id: $lesson->id,
+                                title: $lesson->title,
+                            ),
+                        ]),
+                    ),
+                ]);
+            }
+        }
+
+        // 到達しないはずだが、念のため例外を返す
+        throw new RuntimeException('The first public lesson is not existed.');
+    }
+
+    /**
+     * 受講可能な最終の公開レッスンを取得
+     *
+     * @param  Collection<Chapter>  $publicChapters
+     * @param  Collection<Lesson>  $publicLessons
+     */
+    private function getLastLesson(Collection $publicChapters, Collection $publicLessons): Lesson
+    {
+        $chapters = $publicChapters->sortByDesc('order');
+        foreach ($chapters as $chapter) {
+            $lesson = $publicLessons->where('chapter_id', $chapter->id)->sortByDesc('order')->first();
+            if ($lesson) {
+                return $lesson;
+            }
+        }
+
+        // 到達しないはずだが、念のため例外を返す
+        throw new RuntimeException('The last public lesson is not existed.');
+    }
+
+    /**
+     * 次に受講すべき公開レッスンとチャプターを取得
+     *
+     * @param  Collection<Lesson>  $maxCompletedLessons
+     * @param  Collection<Lesson>  $publicLessons
+     * @param  Collection<Chapter>  $publicChapters
+     * @return Collection<StuckPointDto>
+     */
+    private function getNextLesson(Collection $maxCompletedLessons, Collection $publicLessons, Collection $publicChapters): Collection
+    {
         return $maxCompletedLessons
-            ->map(function (array $maxCompletedLesson) use ($publicLessons, $publicChapters) {
-                $lesson = $publicLessons->where('id', $maxCompletedLesson['lesson_id'])->first();
+            ->map(function (Lesson $maxCompletedLesson) use ($publicLessons, $publicChapters) {
+                $lesson = $publicLessons->where('id', $maxCompletedLesson->id)->first();
                 $stuckLesson = $publicLessons
                     ->where('chapter_id', $lesson->chapter_id)
                     ->where('order', '>', $lesson->order)
@@ -142,7 +223,6 @@ final class StuckPointsService
                         ->sortBy('order')
                         ->first();
                 }
-
                 return new StuckPointDto(
                     id: $stuckChapter->id,
                     title: $stuckChapter->title,
@@ -154,11 +234,21 @@ final class StuckPointsService
                     ]),
                 );
             })
-            // 重複チャプターをまとめる
+            ->pipe(fn (Collection $stuckPoints) => $this->mergeDuplicatedChapters($stuckPoints));
+    }
+
+    /**
+     * 重複するチャプターをまとめる
+     *
+     * @param  Collection<StuckPointDto>  $stuckPoints
+     * @return Collection<StuckPointDto>
+     */
+    private function mergeDuplicatedChapters(Collection $stuckPoints): Collection
+    {
+        return $stuckPoints
             ->groupBy('id')
             ->map(function ($items) {
                 $first = $items->first();
-
                 return new StuckPointDto(
                     id: $first->id,
                     title: $first->title,

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -13,7 +13,7 @@ use RuntimeException;
 
 final class StuckPointsService
 {
-    private const int MINIMUM_STUDENT_COUNT = 1;
+    private const int MINIMUM_REQUIRED_STUDENTS = 2;
 
     /**
      * 止まっている箇所を取得する
@@ -37,15 +37,15 @@ final class StuckPointsService
 
         // 受講済みの人数が最多のレッスンを取得
         $maxCount = $completedLessonCounts->max('lesson_attendances_count');
-        $maxCompletedLessons = $completedLessonCounts
-            ->where('lesson_attendances_count', '>', self::MINIMUM_STUDENT_COUNT)
-            ->where('lesson_attendances_count', $maxCount);
-
-        // 受講済みのレッスンがない、または、受講済みの最多数が1人の場合は
-        // 受講可能な最初の公開レッスンとチャプターを返す
-        if ($maxCompletedLessons->isEmpty()) {
+        
+        // 最多数が必要受講生数未満の場合は、受講可能な最初の公開レッスンとチャプターを返す
+        if ($maxCount < self::MINIMUM_REQUIRED_STUDENTS) {
             return $this->getFirstLesson($publicChapters, $publicLessons);
         }
+        
+        // 最多数のレッスンを取得
+        $maxCompletedLessons = $completedLessonCounts
+            ->where('lesson_attendances_count', $maxCount);
 
         // 最終レッスンの取得
         $lastLesson = $this->getLastLesson($publicChapters, $publicLessons);
@@ -71,7 +71,7 @@ final class StuckPointsService
     private function getPublicChapters(int $courseId): Collection
     {
         return Chapter::where('course_id', $courseId)
-            ->where('status', Chapter::STATUS_PUBLIC)
+            ->public()
             ->get();
     }
 
@@ -84,7 +84,7 @@ final class StuckPointsService
     private function getPublicLessons(Collection $publicChapters): Collection
     {
         return Lesson::whereIn('chapter_id', $publicChapters->pluck('id'))
-            ->where('status', Lesson::STATUS_PUBLIC)
+            ->public()
             ->get();
     }
 
@@ -118,7 +118,7 @@ final class StuckPointsService
 
         return $attendances->pluck('student_id')
             ->unique()
-            ->count() > self::MINIMUM_STUDENT_COUNT;
+            ->count() >= self::MINIMUM_REQUIRED_STUDENTS;
     }
 
     /**

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -37,12 +37,12 @@ final class StuckPointsService
 
         // 受講済みの人数が最多のレッスンを取得
         $maxCount = $completedLessonCounts->max('lesson_attendances_count');
-        
+
         // 最多数が必要受講生数未満の場合は、受講可能な最初の公開レッスンとチャプターを返す
         if ($maxCount < self::MINIMUM_REQUIRED_STUDENTS) {
             return $this->getFirstLesson($publicChapters, $publicLessons);
         }
-        
+
         // 最多数のレッスンを取得
         $maxCompletedLessons = $completedLessonCounts
             ->where('lesson_attendances_count', $maxCount);

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -115,6 +115,7 @@ final class StuckPointsService
         if ($publicChapters->isEmpty() || $publicLessons->isEmpty()) {
             return false;
         }
+
         return $attendances->pluck('student_id')
             ->unique()
             ->count() > self::MINIMUM_STUDENT_COUNT;
@@ -133,7 +134,7 @@ final class StuckPointsService
             ->whereIn('id', $publicLessons->pluck('id'))
             ->withCount(['lessonAttendances' => fn ($q) => $q
                 ->whereIn('attendance_id', $attendances->pluck('id'))
-                ->whereNotNull('completed_at')
+                ->whereNotNull('completed_at'),
             ])
             ->get();
     }
@@ -223,6 +224,7 @@ final class StuckPointsService
                         ->sortBy('order')
                         ->first();
                 }
+
                 return new StuckPointDto(
                     id: $stuckChapter->id,
                     title: $stuckChapter->title,
@@ -249,6 +251,7 @@ final class StuckPointsService
             ->groupBy('id')
             ->map(function ($items) {
                 $first = $items->first();
+
                 return new StuckPointDto(
                     id: $first->id,
                     title: $first->title,

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Services\Attendance;
+
+use App\Dto\Instructor\Attendance\StuckLessonDto;
+use App\Dto\Instructor\Attendance\StuckPointDto;
+use App\Model\Attendance;
+use App\Model\Chapter;
+use App\Model\CourseDeadline;
+use App\Model\Lesson;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class StuckPointsService
+{
+    private const MINIMUM_STUDENT_COUNT = 1;
+
+    /**
+     * 止まっている箇所を取得する
+     *
+     * @param int $courseId
+     * @return Collection<StuckPointDto>|null 
+     */
+    public function __invoke(int $courseId): ?Collection
+    {
+        // 当該講座の受講期限を確認
+        $hasCourseDeadline = CourseDeadline::where('course_id', $courseId)
+            ->whereDate('fixed_date', '>=', CarbonImmutable::today())
+            ->exists();
+        // 受講期限が切れている場合は空配列を返す
+        if (! $hasCourseDeadline) {
+            return null;
+        }
+
+        // 公開チャプターを取得
+        $publicChapters = Chapter::where('course_id', $courseId)
+            ->where('status', Chapter::STATUS_PUBLIC)
+            ->get();
+        // 公開チャプターが1件も存在しない場合は空配列を返す
+        if ($publicChapters->isEmpty()) {
+            return null;
+        }
+
+        // 公開レッスンを取得
+        $publicLessons = Lesson::whereIn('chapter_id', $publicChapters->pluck('id'))
+            ->where('status', Lesson::STATUS_PUBLIC)
+            ->get();
+        // 公開レッスンが1件も存在しない場合は空配列を返す
+        if ($publicLessons->isEmpty()) {
+            return null;
+        }
+
+        // 講座の受講期限が切れていない受講を取得
+        $attendances = Attendance::where('course_id', $courseId)
+            ->whereDate('attendance_deadline', '>=', CarbonImmutable::today())
+            ->get();
+        // 受講生が1人の場合は空配列を返す
+        if ($attendances->pluck('student_id')->unique()
+                ->count() <= self::MINIMUM_STUDENT_COUNT) {
+            return null;
+        }
+
+        // 受講済みのレッスンを集計
+        $stuckPoints = DB::table('lesson_attendances')
+            ->selectRaw('lesson_id, COUNT(*) as count')
+            ->whereIn('attendance_id', $attendances->pluck('id'))
+            ->whereIn('lesson_id', $publicLessons->pluck('id'))
+            ->whereNotNull('completed_at')
+            ->whereNull('deleted_at')
+            ->groupBy('lesson_id')
+            ->get()
+            ->map(fn ($stuckPoint) => [
+                'lesson_id' => (int) $stuckPoint->lesson_id,
+                'count' => (int) $stuckPoint->count,
+            ]);
+
+        $maxCount = $stuckPoints->max('count');
+
+        // 受講済みのレッスンがない、または、受講済みの最多数が1人の場合は
+        // 受講可能な最初の公開レッスンとチャプターを返す
+        if ($stuckPoints->isEmpty() || (int) $maxCount === self::MINIMUM_STUDENT_COUNT) {
+            $chapters = $publicChapters->sortBy('order');
+            foreach ($chapters as $chapter) {
+                $lesson = $publicLessons->where('chapter_id', $chapter->id)->sortBy('order')->first();
+                if ($lesson) {
+                    return collect([
+                        new StuckPointDto(
+                            id: $chapter->id,
+                            title: $chapter->title,
+                            lessons: collect([
+                                new StuckLessonDto(
+                                    id: $lesson->id,
+                                    title: $lesson->title,
+                                ),
+                            ]),
+                        ),
+                    ]);
+                }
+            }
+        }
+
+        // 最終レッスンの取得
+        $chapters = $publicChapters->sortByDesc('order');
+        $lastLesson = null;
+        foreach ($chapters as $chapter) {
+            $lesson = $publicLessons->where('chapter_id', $chapter->id)->sortByDesc('order')->first();
+            if ($lesson) {
+                $lastLesson = $lesson;
+                break;
+            }
+        }
+
+        // 受講済みの最多数のレッスンを取得し、最終レッスンの有無を確認
+        $maxStuckPoints = $stuckPoints->where('count', $maxCount);
+        $maxLastLesson = $maxStuckPoints->where('lesson_id', $lastLesson->id);
+        $maxStuckLessons = $maxStuckPoints->where('lesson_id', '!=', $lastLesson->id);
+
+        // 受講済み最多数のレッスンが最終レッスンのみの場合、空配列を返す
+        if ($maxLastLesson->isNotEmpty() && $maxStuckLessons->isEmpty()) {
+            return null;
+        }
+
+        // 最終レッスン以外の受講済み最多数のレッスンとチャプターを取得（ループ処理）
+        $publicLessonsById = $publicLessons->keyBy('id');
+        $publicChaptersById = $publicChapters->keyBy('id');
+        return $maxStuckLessons
+            ->map(function (array $maxStuckLesson) use ($publicLessonsById, $publicChaptersById) {
+                $lesson = $publicLessonsById->get($maxStuckLesson['lesson_id']);
+                $chapter = $publicChaptersById->get($lesson->chapter_id);
+                return new StuckPointDto(
+                    id: $chapter->id,
+                    title: $chapter->title,
+                    lessons: collect([
+                        new StuckLessonDto(
+                            id: $lesson->id,
+                            title: $lesson->title,
+                        ),
+                    ]),
+                );
+            })
+            // 重複チャプターをまとめる
+            ->groupBy('id')
+            ->map(function ($items) {
+                $first = $items->first();
+                return new StuckPointDto(
+                    id: $first->id,
+                    title: $first->title,
+                    lessons: $items->flatMap(fn ($i) => $i->lessons),
+                );
+            })
+            ->values();
+    }
+}

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -14,13 +14,12 @@ use Illuminate\Support\Facades\DB;
 
 final class StuckPointsService
 {
-    private const MINIMUM_STUDENT_COUNT = 1;
+    private const int MINIMUM_STUDENT_COUNT = 1;
 
     /**
      * 止まっている箇所を取得する
      *
-     * @param int $courseId
-     * @return Collection<StuckPointDto>|null 
+     * @return Collection<StuckPointDto>|null
      */
     public function __invoke(int $courseId): ?Collection
     {

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -62,7 +62,7 @@ final class StuckPointsService
         }
 
         // 受講済みのレッスンを集計
-        $stuckPoints = DB::table('lesson_attendances')
+        $completedLessonCounts = DB::table('lesson_attendances')
             ->selectRaw('lesson_id, COUNT(*) as count')
             ->whereIn('attendance_id', $attendances->pluck('id'))
             ->whereIn('lesson_id', $publicLessons->pluck('id'))
@@ -75,11 +75,11 @@ final class StuckPointsService
                 'count' => (int) $stuckPoint->count,
             ]);
 
-        $maxCount = $stuckPoints->max('count');
+        $maxCount = $completedLessonCounts->max('count');
 
         // 受講済みのレッスンがない、または、受講済みの最多数が1人の場合は
         // 受講可能な最初の公開レッスンとチャプターを返す
-        if ($stuckPoints->isEmpty() || (int) $maxCount === self::MINIMUM_STUDENT_COUNT) {
+        if ($completedLessonCounts->isEmpty() || (int) $maxCount === self::MINIMUM_STUDENT_COUNT) {
             $chapters = $publicChapters->sortBy('order');
             foreach ($chapters as $chapter) {
                 $lesson = $publicLessons->where('chapter_id', $chapter->id)->sortBy('order')->first();
@@ -112,29 +112,44 @@ final class StuckPointsService
         }
 
         // 受講済みの最多数のレッスンを取得し、最終レッスンの有無を確認
-        $maxStuckPoints = $stuckPoints->where('count', $maxCount);
-        $maxLastLesson = $maxStuckPoints->where('lesson_id', $lastLesson->id);
-        $maxStuckLessons = $maxStuckPoints->where('lesson_id', '!=', $lastLesson->id);
+        $maxCompletedLessonCounts = $completedLessonCounts->where('count', $maxCount);
+        $maxLastLesson = $maxCompletedLessonCounts->where('lesson_id', $lastLesson->id);
+        $maxCompletedLessons = $maxCompletedLessonCounts->where('lesson_id', '!=', $lastLesson->id);
 
         // 受講済み最多数のレッスンが最終レッスンのみの場合、空配列を返す
-        if ($maxLastLesson->isNotEmpty() && $maxStuckLessons->isEmpty()) {
+        if ($maxLastLesson->isNotEmpty() && $maxCompletedLessons->isEmpty()) {
             return null;
         }
 
-        // 最終レッスン以外の受講済み最多数のレッスンとチャプターを取得（ループ処理）
-        $publicLessonsById = $publicLessons->keyBy('id');
-        $publicChaptersById = $publicChapters->keyBy('id');
-        return $maxStuckLessons
-            ->map(function (array $maxStuckLesson) use ($publicLessonsById, $publicChaptersById) {
-                $lesson = $publicLessonsById->get($maxStuckLesson['lesson_id']);
-                $chapter = $publicChaptersById->get($lesson->chapter_id);
+        // 最終レッスン以外の受講済み最多数のレッスンの次の公開レッスンとチャプターを取得
+        return $maxCompletedLessons
+            ->map(function (array $maxCompletedLesson) use ($publicLessons, $publicChapters,) {
+                $lesson = $publicLessons->where('id', $maxCompletedLesson['lesson_id'])->first();
+                $stuckLesson = $publicLessons
+                    ->where('chapter_id', $lesson->chapter_id)
+                    ->where('order', '>', $lesson->order)
+                    ->sortBy('order')
+                    ->first();
+                if ($stuckLesson) {
+                    $stuckChapter = $publicChapters->where('id', $stuckLesson->chapter_id)->first();
+                } else {
+                    $chapter = $publicChapters->where('id', $lesson->chapter_id)->first();
+                    $stuckChapter = $publicChapters
+                        ->where('order', '>', $chapter->order)
+                        ->sortBy('order')
+                        ->first();
+                    $stuckLesson = $publicLessons
+                        ->where('chapter_id', $stuckChapter->id)
+                        ->sortBy('order')
+                        ->first();
+                }
                 return new StuckPointDto(
-                    id: $chapter->id,
-                    title: $chapter->title,
+                    id: $stuckChapter->id,
+                    title: $stuckChapter->title,
                     lessons: collect([
                         new StuckLessonDto(
-                            id: $lesson->id,
-                            title: $lesson->title,
+                            id: $stuckLesson->id,
+                            title: $stuckLesson->title,
                         ),
                     ]),
                 );

--- a/app/Services/Attendance/StuckPointsService.php
+++ b/app/Services/Attendance/StuckPointsService.php
@@ -56,7 +56,7 @@ final class StuckPointsService
             ->get();
         // 受講生が1人の場合は空配列を返す
         if ($attendances->pluck('student_id')->unique()
-                ->count() <= self::MINIMUM_STUDENT_COUNT) {
+            ->count() <= self::MINIMUM_STUDENT_COUNT) {
             return null;
         }
 
@@ -122,7 +122,7 @@ final class StuckPointsService
 
         // 最終レッスン以外の受講済み最多数のレッスンの次の公開レッスンとチャプターを取得
         return $maxCompletedLessons
-            ->map(function (array $maxCompletedLesson) use ($publicLessons, $publicChapters,) {
+            ->map(function (array $maxCompletedLesson) use ($publicLessons, $publicChapters) {
                 $lesson = $publicLessons->where('id', $maxCompletedLesson['lesson_id'])->first();
                 $stuckLesson = $publicLessons
                     ->where('chapter_id', $lesson->chapter_id)
@@ -142,6 +142,7 @@ final class StuckPointsService
                         ->sortBy('order')
                         ->first();
                 }
+
                 return new StuckPointDto(
                     id: $stuckChapter->id,
                     title: $stuckChapter->title,
@@ -157,6 +158,7 @@ final class StuckPointsService
             ->groupBy('id')
             ->map(function ($items) {
                 $first = $items->first();
+
                 return new StuckPointDto(
                     id: $first->id,
                     title: $first->title,

--- a/routes/api.php
+++ b/routes/api.php
@@ -141,6 +141,7 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function () {
                         Route::prefix('status')->group(function () {
                             Route::get('{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'showStatus'])->name('show-status');
                         });
+                        Route::get('stuck-points', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'stuckPoints'])->name('stuck-points');
                         Route::get('{period}', [App\Http\Controllers\Api\Instructor\AttendanceController::class, 'loginRate'])->name('login-rate');
                     });
                 });

--- a/tests/Feature/Api/Instructor/Attendance/StuckPointsTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/StuckPointsTest.php
@@ -5,9 +5,9 @@ namespace Tests\Feature\Api\Instructor\Attendance;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;
-use App\Model\CourseDeadline;
 use App\Model\Instructor;
 use App\Model\Lesson;
+use App\Model\LessonAttendance;
 use App\Model\Student;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -17,24 +17,21 @@ class StuckPointsTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_権限のない講師_失敗(): void
+    #[\Override]
+    protected function setUp(): void
     {
-        // Arrange
-        $ownerInstructor = Instructor::factory()->create();
-        $course = Course::factory()->create(['instructor_id' => $ownerInstructor->id]);
-        $otherInstructor = Instructor::factory()->create();
-        $this->actingAs($otherInstructor, 'instructor');
-
-        // Act
-        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
-            'course_id' => $course->id,
-        ]));
-
-        // Assert
-        $response->assertStatus(403);
+        parent::setUp();
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-01'));
     }
 
-    public function test_空配列を返す_成功(): void  // 受講期限がない場合を想定
+    #[\Override]
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_受講登録がない場合_空配列を返す(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
@@ -51,41 +48,35 @@ class StuckPointsTest extends TestCase
         $response->assertExactJson([]);
     }
 
-    public function test_受講生の止まっている箇所を返す_成功(): void    // 完了済みレッスンがない場合を想定（最初の公開レッスンを返す）
+    public function test_受講済みのレッスンがない場合_最初の公開レッスンを返す(): void
     {
         // Arrange
-        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-01'));
-
         $instructor = Instructor::factory()->create();
         $course = Course::factory()->create(['instructor_id' => $instructor->id]);
-        $this->actingAs($instructor, 'instructor');
-
-        CourseDeadline::factory()->create([
-            'course_id' => $course->id,
-            'fixed_date' => CarbonImmutable::parse('2026-05-31'),
-        ]);
-
         $chapter = Chapter::factory()->create([
             'course_id' => $course->id,
             'order' => 1,
+            'title' => 'チャプター1',
         ]);
-
         $firstLesson = Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'order' => 1,
+            'title' => 'レッスン1',
         ]);
         Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'order' => 2,
         ]);
+        $this->actingAs($instructor, 'instructor');
 
+        // 受講生2人を期限内で登録
         $student1 = Student::factory()->create();
-        $student2 = Student::factory()->create();
         Attendance::factory()->create([
             'course_id' => $course->id,
             'student_id' => $student1->id,
             'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
         ]);
+        $student2 = Student::factory()->create();
         Attendance::factory()->create([
             'course_id' => $course->id,
             'student_id' => $student2->id,
@@ -99,10 +90,101 @@ class StuckPointsTest extends TestCase
 
         // Assert
         $response->assertStatus(200);
-        $response->assertJsonPath('data.0.chapter_id', $chapter->id);
-        $response->assertJsonPath('data.0.chapter_title', $chapter->title);
-        $response->assertJsonPath('data.0.lessons.0.lesson_id', $firstLesson->id);
-        $response->assertJsonPath('data.0.lessons.0.lesson_title', $firstLesson->title);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment([
+            'chapter_id' => $chapter->id,
+            'chapter_title' => 'チャプター1',
+        ]);
+        $response->assertJsonFragment([
+            'lesson_id' => $firstLesson->id,
+            'lesson_title' => 'レッスン1',
+        ]);
+    }
+
+    public function test_受講済み最多数のレッスンが最終レッスン以外の場合_次のレッスンを返す(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 1,
+            'title' => 'チャプター1',
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 1,
+        ]);
+        $targetLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 2,
+        ]);
+        $nextLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 3,
+            'title' => '次のレッスン',
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // 受講生2人がともに targetLesson まで完了
+        $student1 = Student::factory()->create();
+        $attendance1 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        $attendance2 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $targetLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-02'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $targetLesson->id,
+            'attendance_id' => $attendance2->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-03'),
+        ]);
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => $course->id,
+        ]));
+
+        // Assert — targetLesson の次の nextLesson が返る
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonFragment([
+            'chapter_id' => $chapter->id,
+            'chapter_title' => 'チャプター1',
+        ]);
+        $response->assertJsonFragment([
+            'lesson_id' => $nextLesson->id,
+            'lesson_title' => '次のレッスン',
+        ]);
+    }
+
+    public function test_権限のない講師_失敗(): void
+    {
+        // Arrange
+        $ownerInstructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $ownerInstructor->id]);
+        $otherInstructor = Instructor::factory()->create();
+        $this->actingAs($otherInstructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => $course->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(403);
     }
 
     public function test_バリデーションエラー_講座idが文字列(): void

--- a/tests/Feature/Api/Instructor/Attendance/StuckPointsTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/StuckPointsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Attendance;
+use App\Model\Chapter;
+use App\Model\Course;
+use App\Model\CourseDeadline;
+use App\Model\Instructor;
+use App\Model\Lesson;
+use App\Model\Student;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StuckPointsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_権限のない講師_失敗(): void
+    {
+        // Arrange
+        $ownerInstructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $ownerInstructor->id]);
+        $otherInstructor = Instructor::factory()->create();
+        $this->actingAs($otherInstructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => $course->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(403);
+    }
+
+    public function test_空配列を返す_成功(): void  // 受講期限がない場合を想定
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => $course->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertExactJson([]);
+    }
+
+    public function test_受講生の止まっている箇所を返す_成功(): void    // 完了済みレッスンがない場合を想定（最初の公開レッスンを返す）
+    {
+        // Arrange
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-01'));
+
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        CourseDeadline::factory()->create([
+            'course_id' => $course->id,
+            'fixed_date' => CarbonImmutable::parse('2026-05-31'),
+        ]);
+
+        $chapter = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 1,
+        ]);
+
+        $firstLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 1,
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 2,
+        ]);
+
+        $student1 = Student::factory()->create();
+        $student2 = Student::factory()->create();
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => $course->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.chapter_id', $chapter->id);
+        $response->assertJsonPath('data.0.chapter_title', $chapter->title);
+        $response->assertJsonPath('data.0.lessons.0.lesson_id', $firstLesson->id);
+        $response->assertJsonPath('data.0.lessons.0.lesson_title', $firstLesson->title);
+    }
+
+    public function test_バリデーションエラー_講座idが文字列(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => 'aaa',
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['course_id']);
+    }
+
+    public function test_バリデーションエラー_存在しない講座id(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => 99999,
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['course_id']);
+    }
+
+    public function test_バリデーションエラー_論理削除された講座id(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $course->delete();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.course.attendance.stuck-points', [
+            'course_id' => $course->id,
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['course_id']);
+    }
+}

--- a/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
+++ b/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Service\Attendance;
 
 use App\Dto\Instructor\Attendance\StuckLessonDto;
 use App\Dto\Instructor\Attendance\StuckPointDto;
-use App\Enums\Course\DeadlineTypeEnum;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;
@@ -39,11 +38,27 @@ class StuckPointsServiceTest extends TestCase
     public function test_公開チャプターが1件も存在しない場合_空コレクションを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
         Chapter::factory()->create([
             'course_id' => $course->id,
             'status' => Chapter::STATUS_PRIVATE,
         ]);
+
+        // 受講生2人を期限内で登録
+        $student1 = Student::factory()->create();
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+
         $service = new StuckPointsService;
 
         // Act
@@ -52,19 +67,34 @@ class StuckPointsServiceTest extends TestCase
         // Assert
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
+
     }
 
     public function test_公開レッスンが1件も存在しない場合_空コレクションを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
-        $chapter = Chapter::factory()->create([
-            'course_id' => $course->id,
-        ]);
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id]);
         Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'status' => Lesson::STATUS_PRIVATE,
         ]);
+
+        // 受講生2人を期限内で登録
+        $student1 = Student::factory()->create();
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+
         $service = new StuckPointsService;
 
         // Act
@@ -73,20 +103,31 @@ class StuckPointsServiceTest extends TestCase
         // Assert
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
+
     }
 
     public function test_受講期限が切れている場合_空コレクションを返す(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
-        $course = Course::factory()->create([
-            'instructor_id' => $instructor->id,
-            'deadline_type' => DeadlineTypeEnum::FIXED_DATE,
-        ]);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id, 'order' => 1]);
+        Lesson::factory()->create(['chapter_id' => $chapter->id, 'order' => 1]);
+
+        // 期限切れの受講生2人
+        $student1 = Student::factory()->create();
         Attendance::factory()->create([
             'course_id' => $course->id,
+            'student_id' => $student1->id,
             'attendance_deadline' => CarbonImmutable::parse('2026-04-30'),
         ]);
+        $student2 = Student::factory()->create();
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-04-30'),
+        ]);
+
         $service = new StuckPointsService;
 
         // Act
@@ -95,20 +136,25 @@ class StuckPointsServiceTest extends TestCase
         // Assert
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
+
     }
 
     public function test_受講生が1人の場合_空コレクションを返す(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
-        $course = Course::factory()->create([
-            'instructor_id' => $instructor->id,
-            'deadline_type' => DeadlineTypeEnum::FIXED_DATE,
-        ]);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id, 'order' => 1]);
+        Lesson::factory()->create(['chapter_id' => $chapter->id, 'order' => 1]);
+
+        // 受講生1人のみ
+        $student = Student::factory()->create();
         Attendance::factory()->create([
             'course_id' => $course->id,
+            'student_id' => $student->id,
             'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
         ]);
+
         $service = new StuckPointsService;
 
         // Act
@@ -117,26 +163,28 @@ class StuckPointsServiceTest extends TestCase
         // Assert
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
+
     }
 
     public function test_受講済みのレッスンがない場合_最初の公開レッスンを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
-
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
         $chapter1 = Chapter::factory()->create([
             'course_id' => $course->id,
             'order' => 1,
+            'title' => 'チャプター1',
         ]);
         $firstLesson = Lesson::factory()->create([
             'chapter_id' => $chapter1->id,
             'order' => 1,
+            'title' => '最初のレッスン',
         ]);
         Lesson::factory()->create([
             'chapter_id' => $chapter1->id,
             'order' => 2,
         ]);
-
         $chapter2 = Chapter::factory()->create([
             'course_id' => $course->id,
             'order' => 2,
@@ -146,8 +194,19 @@ class StuckPointsServiceTest extends TestCase
             'order' => 1,
         ]);
 
-        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
-
+        // 受講生2人がレッスン未完了
+        $student1 = Student::factory()->create();
+        $attendance1 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        $attendance2 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
         LessonAttendance::factory()->create([
             'lesson_id' => $firstLesson->id,
             'attendance_id' => $attendance1->id,
@@ -166,60 +225,105 @@ class StuckPointsServiceTest extends TestCase
         // Act
         $result = $service($course->id);
 
-        // Assert
-        $this->assertSingleStuckPoint($result, $chapter1, $firstLesson);
+        // Assert — 最初のチャプターの最初のレッスンが返る
+        $this->assertCount(1, $result);
+        /** @var StuckPointDto $stuckPoint */
+        $stuckPoint = $result->first();
+        $this->assertInstanceOf(StuckPointDto::class, $stuckPoint);
+        $this->assertSame($chapter1->id, $stuckPoint->id);
+        $this->assertSame('チャプター1', $stuckPoint->title);
+        $this->assertCount(1, $stuckPoint->lessons);
+        /** @var StuckLessonDto $stuckLesson */
+        $stuckLesson = $stuckPoint->lessons->first();
+        $this->assertInstanceOf(StuckLessonDto::class, $stuckLesson);
+        $this->assertSame($firstLesson->id, $stuckLesson->id);
+        $this->assertSame('最初のレッスン', $stuckLesson->title);
+
     }
 
     public function test_最多数が必要受講生数未満の場合_最初の公開レッスンを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
-
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
         $chapter = Chapter::factory()->create([
             'course_id' => $course->id,
             'order' => 1,
+            'title' => 'チャプター1',
         ]);
         $firstLesson = Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'order' => 1,
+            'title' => '最初のレッスン',
         ]);
-        Lesson::factory()->create([
+        $secondLesson = Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'order' => 2,
         ]);
 
-        $this->createTwoAttendances($course);
+        // 受講生2人。1人だけ secondLesson を完了（最多1人 < MINIMUM_REQUIRED_STUDENTS=2）
+        $student1 = Student::factory()->create();
+        $attendance1 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $secondLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-02'),
+        ]);
 
         $service = new StuckPointsService;
 
         // Act
         $result = $service($course->id);
 
-        // Assert
-        $this->assertSingleStuckPoint($result, $chapter, $firstLesson);
+        // Assert — 最初のチャプターの最初のレッスンが返る
+        $this->assertCount(1, $result);
+        /** @var StuckPointDto $stuckPoint */
+        $stuckPoint = $result->first();
+        $this->assertSame($chapter->id, $stuckPoint->id);
+        $this->assertSame('チャプター1', $stuckPoint->title);
+        /** @var StuckLessonDto $stuckLesson */
+        $stuckLesson = $stuckPoint->lessons->first();
+        $this->assertSame($firstLesson->id, $stuckLesson->id);
+        $this->assertSame('最初のレッスン', $stuckLesson->title);
+
     }
 
     public function test_受講済み最多数のレッスンが最終レッスンのみの場合_空コレクションを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
-
-        $chapter = Chapter::factory()->create([
-            'course_id' => $course->id,
-            'order' => 1,
-        ]);
-
-        Lesson::factory()->create([
-            'chapter_id' => $chapter->id,
-            'order' => 1,
-        ]);
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id, 'order' => 1]);
+        Lesson::factory()->create(['chapter_id' => $chapter->id, 'order' => 1]);
         $lastLesson = Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'order' => 2,
         ]);
 
-        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
-
+        // 受講生2人がともに最終レッスンのみ完了
+        $student1 = Student::factory()->create();
+        $attendance1 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        $attendance2 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
         LessonAttendance::factory()->create([
             'lesson_id' => $lastLesson->id,
             'attendance_id' => $attendance1->id,
@@ -241,21 +345,20 @@ class StuckPointsServiceTest extends TestCase
         // Assert
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
+
     }
 
     public function test_受講済み最多数のレッスンが最終レッスン以外の場合_同一チャプターの次のレッスンを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
-
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
         $chapter = Chapter::factory()->create([
             'course_id' => $course->id,
             'order' => 1,
+            'title' => 'チャプター1',
         ]);
-        Lesson::factory()->create([
-            'chapter_id' => $chapter->id,
-            'order' => 1,
-        ]);
+        Lesson::factory()->create(['chapter_id' => $chapter->id, 'order' => 1]);
         $targetLesson = Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'order' => 2,
@@ -263,10 +366,22 @@ class StuckPointsServiceTest extends TestCase
         $lastLesson = Lesson::factory()->create([
             'chapter_id' => $chapter->id,
             'order' => 3,
+            'title' => '最終レッスン',
         ]);
 
-        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
-
+        // 受講生2人がともに targetLesson まで完了、1人は最終レッスンも完了
+        $student1 = Student::factory()->create();
+        $attendance1 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        $attendance2 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
         LessonAttendance::factory()->create([
             'lesson_id' => $targetLesson->id,
             'attendance_id' => $attendance1->id,
@@ -291,44 +406,58 @@ class StuckPointsServiceTest extends TestCase
         // Act
         $result = $service($course->id);
 
-        // Assert
-        $this->assertSingleStuckPoint($result, $chapter, $lastLesson);
+        // Assert — targetLesson の次の lastLesson が返る
+        $this->assertCount(1, $result);
+        /** @var StuckPointDto $stuckPoint */
+        $stuckPoint = $result->first();
+        $this->assertSame($chapter->id, $stuckPoint->id);
+        $this->assertSame('チャプター1', $stuckPoint->title);
+        /** @var StuckLessonDto $stuckLesson */
+        $stuckLesson = $stuckPoint->lessons->first();
+        $this->assertSame($lastLesson->id, $stuckLesson->id);
+        $this->assertSame('最終レッスン', $stuckLesson->title);
+
     }
 
     public function test_受講済み最多数のレッスンが最終レッスン以外の場合_次のチャプターの最初のレッスンを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
-
-        $chapter1 = Chapter::factory()->create([
-            'course_id' => $course->id,
-            'order' => 1,
-        ]);
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter1 = Chapter::factory()->create(['course_id' => $course->id, 'order' => 1]);
         $chapter2 = Chapter::factory()->create([
             'course_id' => $course->id,
             'order' => 2,
+            'title' => 'チャプター2',
         ]);
-
-        Lesson::factory()->create([
-            'chapter_id' => $chapter1->id,
-            'order' => 1,
-        ]);
+        Lesson::factory()->create(['chapter_id' => $chapter1->id, 'order' => 1]);
         $chapter1LastLesson = Lesson::factory()->create([
             'chapter_id' => $chapter1->id,
             'order' => 2,
         ]);
-
         $chapter2FirstLesson = Lesson::factory()->create([
             'chapter_id' => $chapter2->id,
             'order' => 1,
+            'title' => 'チャプター2の最初のレッスン',
         ]);
         $courseLastLesson = Lesson::factory()->create([
             'chapter_id' => $chapter2->id,
             'order' => 2,
         ]);
 
-        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
-
+        // 受講生2人がともに chapter1 の最終レッスンまで完了、1人は講座の最終レッスンも完了
+        $student1 = Student::factory()->create();
+        $attendance1 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $student2 = Student::factory()->create();
+        $attendance2 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
         LessonAttendance::factory()->create([
             'lesson_id' => $chapter1LastLesson->id,
             'attendance_id' => $attendance1->id,
@@ -353,54 +482,16 @@ class StuckPointsServiceTest extends TestCase
         // Act
         $result = $service($course->id);
 
-        // Assert
-        $this->assertSingleStuckPoint($result, $chapter2, $chapter2FirstLesson);
-    }
-
-    private function assertSingleStuckPoint(Collection $result, Chapter $expectedChapter, Lesson $expectedLesson): void
-    {
+        // Assert — chapter2 の最初のレッスンが返る
         $this->assertCount(1, $result);
-        $this->assertInstanceOf(StuckPointDto::class, $result->first());
-
+        /** @var StuckPointDto $stuckPoint */
         $stuckPoint = $result->first();
-        $this->assertSame($expectedChapter->id, $stuckPoint->id);
-        $this->assertSame($expectedChapter->title, $stuckPoint->title);
-        $this->assertCount(1, $stuckPoint->lessons);
-        $this->assertInstanceOf(StuckLessonDto::class, $stuckPoint->lessons->first());
-
+        $this->assertSame($chapter2->id, $stuckPoint->id);
+        $this->assertSame('チャプター2', $stuckPoint->title);
+        /** @var StuckLessonDto $stuckLesson */
         $stuckLesson = $stuckPoint->lessons->first();
-        $this->assertSame($expectedLesson->id, $stuckLesson->id);
-        $this->assertSame($expectedLesson->title, $stuckLesson->title);
-    }
+        $this->assertSame($chapter2FirstLesson->id, $stuckLesson->id);
+        $this->assertSame('チャプター2の最初のレッスン', $stuckLesson->title);
 
-    private function createCourseWithDeadline(): Course
-    {
-        $instructor = Instructor::factory()->create();
-        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
-        Attendance::factory()->create([
-            'course_id' => $course->id,
-            'attendance_deadline' => CarbonImmutable::parse('2026-05-31'),
-        ]);
-
-        return $course;
-    }
-
-    private function createTwoAttendances(Course $course): array
-    {
-        $student1 = Student::factory()->create();
-        $student2 = Student::factory()->create();
-
-        $attendance1 = Attendance::factory()->create([
-            'course_id' => $course->id,
-            'student_id' => $student1->id,
-            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
-        ]);
-        $attendance2 = Attendance::factory()->create([
-            'course_id' => $course->id,
-            'student_id' => $student2->id,
-            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
-        ]);
-
-        return [$attendance1, $attendance2];
     }
 }

--- a/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
+++ b/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Tests\Feature\Service\Attendance;
+
+use App\Dto\Instructor\Attendance\StuckLessonDto;
+use App\Dto\Instructor\Attendance\StuckPointDto;
+use App\Enums\Course\DeadlineTypeEnum;
+use App\Model\Attendance;
+use App\Model\Chapter;
+use App\Model\Course;
+use App\Model\CourseDeadline;
+use App\Model\Instructor;
+use App\Model\Lesson;
+use App\Model\LessonAttendance;
+use App\Model\Student;
+use App\Services\Attendance\StuckPointsService;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StuckPointsServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-01'));
+    }
+
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_受講期限が切れている場合_nullを返す(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'deadline_type' => DeadlineTypeEnum::FIXED_DATE,
+        ]);
+        CourseDeadline::factory()->create([
+            'course_id' => $course->id,
+            'fixed_date' => CarbonImmutable::parse('2026-04-30'),
+        ]);
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    public function test_公開チャプターが1件も存在しない場合_nullを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+        Chapter::factory()->create([
+            'course_id' => $course->id,
+            'status' => Chapter::STATUS_PRIVATE,
+        ]);
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    public function test_公開レッスンが1件も存在しない場合_nullを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+        $chapter = Chapter::factory()->create([
+            'course_id' => $course->id,
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'status' => Lesson::STATUS_PRIVATE,
+        ]);
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    public function test_受講生が1人の場合_nullを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+        $chapter = Chapter::factory()->create([
+            'course_id' => $course->id,
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+        ]);
+        Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => Student::factory()->create()->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    public function test_受講済みのレッスンがない場合_最初の公開レッスンのdtoを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+
+        $chapter = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 1,
+        ]);
+        $firstLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 1,
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 2,
+        ]);
+
+        $this->createTwoAttendances($course);
+
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertNotNull($result);
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(StuckPointDto::class, $result->first());
+
+        /** @var StuckPointDto $stuckPoint */
+        $stuckPoint = $result->first();
+        $this->assertSame($chapter->id, $stuckPoint->id);
+        $this->assertSame($chapter->title, $stuckPoint->title);
+        $this->assertCount(1, $stuckPoint->lessons);
+        $this->assertInstanceOf(StuckLessonDto::class, $stuckPoint->lessons->first());
+
+        /** @var StuckLessonDto $stuckLesson */
+        $stuckLesson = $stuckPoint->lessons->first();
+        $this->assertSame($firstLesson->id, $stuckLesson->id);
+        $this->assertSame($firstLesson->title, $stuckLesson->title);
+    }
+
+    public function test_受講済み最多数のレッスンが最終レッスンのみの場合_nullを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+
+        $chapter = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 1,
+        ]);
+
+        Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 1,
+        ]);
+        $lastLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 2,
+        ]);
+
+        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
+
+        LessonAttendance::factory()->create([
+            'lesson_id' => $lastLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-02'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $lastLesson->id,
+            'attendance_id' => $attendance2->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-03'),
+        ]);
+
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    public function test_受講済み最多数のレッスンが最終レッスン以外の場合_受講済み最多数のレッスンのdtoを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+
+        $chapter = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 1,
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 1,
+        ]);
+        $targetLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 2,
+        ]);
+        $lastLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter->id,
+            'order' => 3,
+        ]);
+
+        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
+
+        LessonAttendance::factory()->create([
+            'lesson_id' => $targetLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-02'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $targetLesson->id,
+            'attendance_id' => $attendance2->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-03'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $lastLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-04'),
+        ]);
+
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertNotNull($result);
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(StuckPointDto::class, $result->first());
+
+        /** @var StuckPointDto $stuckPoint */
+        $stuckPoint = $result->first();
+        $this->assertSame($chapter->id, $stuckPoint->id);
+        $this->assertSame($chapter->title, $stuckPoint->title);
+        $this->assertCount(1, $stuckPoint->lessons);
+        $this->assertInstanceOf(StuckLessonDto::class, $stuckPoint->lessons->first());
+
+        /** @var StuckLessonDto $stuckLesson */
+        $stuckLesson = $stuckPoint->lessons->first();
+        $this->assertSame($targetLesson->id, $stuckLesson->id);
+        $this->assertSame($targetLesson->title, $stuckLesson->title);
+    }
+
+    private function createCourseWithDeadline(): Course
+    {
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        CourseDeadline::factory()->create([
+            'course_id' => $course->id,
+            'fixed_date' => CarbonImmutable::parse('2026-05-31'),
+        ]);
+
+        return $course;
+    }
+
+    /**
+     * @return array{0: Attendance, 1: Attendance}
+     */
+    private function createTwoAttendances(Course $course): array
+    {
+        $student1 = Student::factory()->create();
+        $student2 = Student::factory()->create();
+
+        $attendance1 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student1->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+        $attendance2 = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student2->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
+        ]);
+
+        return [$attendance1, $attendance2];
+    }
+}

--- a/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
+++ b/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
@@ -8,7 +8,6 @@ use App\Enums\Course\DeadlineTypeEnum;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;
-use App\Model\CourseDeadline;
 use App\Model\Instructor;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
@@ -37,28 +36,7 @@ class StuckPointsServiceTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_受講期限が切れている場合_nullを返す(): void
-    {
-        // Arrange
-        $instructor = Instructor::factory()->create();
-        $course = Course::factory()->create([
-            'instructor_id' => $instructor->id,
-            'deadline_type' => DeadlineTypeEnum::FIXED_DATE,
-        ]);
-        CourseDeadline::factory()->create([
-            'course_id' => $course->id,
-            'fixed_date' => CarbonImmutable::parse('2026-04-30'),
-        ]);
-        $service = new StuckPointsService;
-
-        // Act
-        $result = $service($course->id);
-
-        // Assert
-        $this->assertNull($result);
-    }
-
-    public function test_公開チャプターが1件も存在しない場合_nullを返す(): void
+    public function test_公開チャプターが1件も存在しない場合_空コレクションを返す(): void
     {
         // Arrange
         $course = $this->createCourseWithDeadline();
@@ -72,10 +50,11 @@ class StuckPointsServiceTest extends TestCase
         $result = $service($course->id);
 
         // Assert
-        $this->assertNull($result);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
     }
 
-    public function test_公開レッスンが1件も存在しない場合_nullを返す(): void
+    public function test_公開レッスンが1件も存在しない場合_空コレクションを返す(): void
     {
         // Arrange
         $course = $this->createCourseWithDeadline();
@@ -92,22 +71,42 @@ class StuckPointsServiceTest extends TestCase
         $result = $service($course->id);
 
         // Assert
-        $this->assertNull($result);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
     }
 
-    public function test_受講生が1人の場合_nullを返す(): void
+    public function test_受講期限が切れている場合_空コレクションを返す(): void
     {
         // Arrange
-        $course = $this->createCourseWithDeadline();
-        $chapter = Chapter::factory()->create([
-            'course_id' => $course->id,
-        ]);
-        Lesson::factory()->create([
-            'chapter_id' => $chapter->id,
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'deadline_type' => DeadlineTypeEnum::FIXED_DATE,
         ]);
         Attendance::factory()->create([
             'course_id' => $course->id,
-            'student_id' => Student::factory()->create()->id,
+            'attendance_deadline' => CarbonImmutable::parse('2026-04-30'),
+        ]);
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_受講生が1人の場合_空コレクションを返す(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'deadline_type' => DeadlineTypeEnum::FIXED_DATE,
+        ]);
+        Attendance::factory()->create([
+            'course_id' => $course->id,
             'attendance_deadline' => CarbonImmutable::parse('2026-05-20'),
         ]);
         $service = new StuckPointsService;
@@ -116,7 +115,8 @@ class StuckPointsServiceTest extends TestCase
         $result = $service($course->id);
 
         // Assert
-        $this->assertNull($result);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
     }
 
     public function test_受講済みのレッスンがない場合_最初の公開レッスンを返す(): void
@@ -148,7 +148,7 @@ class StuckPointsServiceTest extends TestCase
         $this->assertSingleStuckPoint($result, $chapter, $firstLesson);
     }
 
-    public function test_受講済み最多数のレッスンが最終レッスンのみの場合_nullを返す(): void
+    public function test_受講済み最多数のレッスンが最終レッスンのみの場合_空コレクションを返す(): void
     {
         // Arrange
         $course = $this->createCourseWithDeadline();
@@ -188,7 +188,8 @@ class StuckPointsServiceTest extends TestCase
         $result = $service($course->id);
 
         // Assert
-        $this->assertNull($result);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
     }
 
     public function test_受講済み最多数のレッスンが最終レッスン以外の場合_同一チャプターの次のレッスンを返す(): void
@@ -305,9 +306,8 @@ class StuckPointsServiceTest extends TestCase
         $this->assertSingleStuckPoint($result, $chapter2, $chapter2FirstLesson);
     }
 
-    private function assertSingleStuckPoint(?Collection $result, Chapter $expectedChapter, Lesson $expectedLesson): void
+    private function assertSingleStuckPoint(Collection $result, Chapter $expectedChapter, Lesson $expectedLesson): void
     {
-        $this->assertNotNull($result);
         $this->assertCount(1, $result);
         $this->assertInstanceOf(StuckPointDto::class, $result->first());
 
@@ -326,9 +326,9 @@ class StuckPointsServiceTest extends TestCase
     {
         $instructor = Instructor::factory()->create();
         $course = Course::factory()->create(['instructor_id' => $instructor->id]);
-        CourseDeadline::factory()->create([
+        Attendance::factory()->create([
             'course_id' => $course->id,
-            'fixed_date' => CarbonImmutable::parse('2026-05-31'),
+            'attendance_deadline' => CarbonImmutable::parse('2026-05-31'),
         ]);
 
         return $course;

--- a/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
+++ b/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
@@ -16,6 +16,7 @@ use App\Model\Student;
 use App\Services\Attendance\StuckPointsService;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
 use Tests\TestCase;
 
 class StuckPointsServiceTest extends TestCase
@@ -116,7 +117,7 @@ class StuckPointsServiceTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function test_受講済みのレッスンがない場合_最初の公開レッスンのdtoを返す(): void
+    public function test_受講済みのレッスンがない場合_最初の公開レッスンを返す(): void
     {
         // Arrange
         $course = $this->createCourseWithDeadline();
@@ -142,21 +143,7 @@ class StuckPointsServiceTest extends TestCase
         $result = $service($course->id);
 
         // Assert
-        $this->assertNotNull($result);
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf(StuckPointDto::class, $result->first());
-
-        /** @var StuckPointDto $stuckPoint */
-        $stuckPoint = $result->first();
-        $this->assertSame($chapter->id, $stuckPoint->id);
-        $this->assertSame($chapter->title, $stuckPoint->title);
-        $this->assertCount(1, $stuckPoint->lessons);
-        $this->assertInstanceOf(StuckLessonDto::class, $stuckPoint->lessons->first());
-
-        /** @var StuckLessonDto $stuckLesson */
-        $stuckLesson = $stuckPoint->lessons->first();
-        $this->assertSame($firstLesson->id, $stuckLesson->id);
-        $this->assertSame($firstLesson->title, $stuckLesson->title);
+        $this->assertSingleStuckPoint($result, $chapter, $firstLesson);
     }
 
     public function test_受講済み最多数のレッスンが最終レッスンのみの場合_nullを返す(): void
@@ -202,7 +189,7 @@ class StuckPointsServiceTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function test_受講済み最多数のレッスンが最終レッスン以外の場合_受講済み最多数のレッスンのdtoを返す(): void
+    public function test_受講済み最多数のレッスンが最終レッスン以外の場合_同一チャプターの次のレッスンを返す(): void
     {
         // Arrange
         $course = $this->createCourseWithDeadline();
@@ -251,21 +238,86 @@ class StuckPointsServiceTest extends TestCase
         $result = $service($course->id);
 
         // Assert
+        $this->assertSingleStuckPoint($result, $chapter, $lastLesson);
+    }
+
+    public function test_受講済み最多数のレッスンが最終レッスン以外の場合_次のチャプターの最初のレッスンを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+
+        $chapter1 = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 1,
+        ]);
+        $chapter2 = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 2,
+        ]);
+
+        Lesson::factory()->create([
+            'chapter_id' => $chapter1->id,
+            'order' => 1,
+        ]);
+        $chapter1LastLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter1->id,
+            'order' => 2,
+        ]);
+
+        $chapter2FirstLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter2->id,
+            'order' => 1,
+        ]);
+        $courseLastLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter2->id,
+            'order' => 2,
+        ]);
+
+        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
+
+        LessonAttendance::factory()->create([
+            'lesson_id' => $chapter1LastLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-02'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $chapter1LastLesson->id,
+            'attendance_id' => $attendance2->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-03'),
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $courseLastLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_COMPLETED_ATTENDANCE,
+            'completed_at' => CarbonImmutable::parse('2026-05-04'),
+        ]);
+
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertSingleStuckPoint($result, $chapter2, $chapter2FirstLesson);
+    }
+
+    private function assertSingleStuckPoint(?Collection $result, Chapter $expectedChapter, Lesson $expectedLesson): void
+    {
         $this->assertNotNull($result);
         $this->assertCount(1, $result);
         $this->assertInstanceOf(StuckPointDto::class, $result->first());
 
-        /** @var StuckPointDto $stuckPoint */
         $stuckPoint = $result->first();
-        $this->assertSame($chapter->id, $stuckPoint->id);
-        $this->assertSame($chapter->title, $stuckPoint->title);
+        $this->assertSame($expectedChapter->id, $stuckPoint->id);
+        $this->assertSame($expectedChapter->title, $stuckPoint->title);
         $this->assertCount(1, $stuckPoint->lessons);
         $this->assertInstanceOf(StuckLessonDto::class, $stuckPoint->lessons->first());
 
-        /** @var StuckLessonDto $stuckLesson */
         $stuckLesson = $stuckPoint->lessons->first();
-        $this->assertSame($targetLesson->id, $stuckLesson->id);
-        $this->assertSame($targetLesson->title, $stuckLesson->title);
+        $this->assertSame($expectedLesson->id, $stuckLesson->id);
+        $this->assertSame($expectedLesson->title, $stuckLesson->title);
     }
 
     private function createCourseWithDeadline(): Course
@@ -280,9 +332,6 @@ class StuckPointsServiceTest extends TestCase
         return $course;
     }
 
-    /**
-     * @return array{0: Attendance, 1: Attendance}
-     */
     private function createTwoAttendances(Course $course): array
     {
         $student1 = Student::factory()->create();

--- a/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
+++ b/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
@@ -124,6 +124,57 @@ class StuckPointsServiceTest extends TestCase
         // Arrange
         $course = $this->createCourseWithDeadline();
 
+        $chapter1 = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 1,
+        ]);
+        $firstLesson = Lesson::factory()->create([
+            'chapter_id' => $chapter1->id,
+            'order' => 1,
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter1->id,
+            'order' => 2,
+        ]);
+
+        $chapter2 = Chapter::factory()->create([
+            'course_id' => $course->id,
+            'order' => 2,
+        ]);
+        Lesson::factory()->create([
+            'chapter_id' => $chapter2->id,
+            'order' => 1,
+        ]);
+
+        [$attendance1, $attendance2] = $this->createTwoAttendances($course);
+
+        LessonAttendance::factory()->create([
+            'lesson_id' => $firstLesson->id,
+            'attendance_id' => $attendance1->id,
+            'status' => LessonAttendance::STATUS_IN_ATTENDANCE,
+            'completed_at' => null,
+        ]);
+        LessonAttendance::factory()->create([
+            'lesson_id' => $firstLesson->id,
+            'attendance_id' => $attendance2->id,
+            'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
+            'completed_at' => null,
+        ]);
+
+        $service = new StuckPointsService;
+
+        // Act
+        $result = $service($course->id);
+
+        // Assert
+        $this->assertSingleStuckPoint($result, $chapter1, $firstLesson);
+    }
+    
+    public function test_最多数が必要受講生数未満の場合_最初の公開レッスンを返す(): void
+    {
+        // Arrange
+        $course = $this->createCourseWithDeadline();
+
         $chapter = Chapter::factory()->create([
             'course_id' => $course->id,
             'order' => 1,

--- a/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
+++ b/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
@@ -23,12 +23,14 @@ class StuckPointsServiceTest extends TestCase
 {
     use RefreshDatabase;
 
+    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
         CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-01'));
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         CarbonImmutable::setTestNow();

--- a/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
+++ b/tests/Feature/Service/Attendance/StuckPointsServiceTest.php
@@ -169,7 +169,7 @@ class StuckPointsServiceTest extends TestCase
         // Assert
         $this->assertSingleStuckPoint($result, $chapter1, $firstLesson);
     }
-    
+
     public function test_最多数が必要受講生数未満の場合_最初の公開レッスンを返す(): void
     {
         // Arrange


### PR DESCRIPTION
## Issue
講師側 受講状況APIに止まっている箇所（チャプター名・レッスン名）を追加

## 対応内容
講師側APIとして、 ~/instructor/course/{course_id}/attendance/stuck-pointsを追加

処理内容
「止まっている箇所」（＝完了人数が最も多いレッスン）の「次のレッスン」を取得する
①集計対象のレッスンを抽出
　下記に当てはまる場合は対象から除外し、空で返す
　・講座の受講期限が切れている
　・講座配下のチャプター・レッスンが公開でない
　・講座の受講人数が0か1
②対象レッスンについて、完了人数を集計
　完了が0人or最多人数が1人の場合は、最初の公開チャプターかつ最初の公開レッスンを返す
③完了人数が最多のレッスンを取得
　完了人数最多レッスン＝最終の公開チャプターかつ最終の公開レッスンの場合、他に完了レッスンがなければ、空で返す
　それ以外は、最多レッスンの次のレッスン及びそのチャプターを返す

【更新】
- routes\api.php：stuck-pointsのルートを追加
- app\Http\Controllers\Api\Instructor\AttendanceController.php：stuck-pointsのメソッドを追加

【新規】
- app\Http\Requests\Instructor\Attendance\StuckPointsRequest.php：リスエスト（course_idのバリデーション設定）
- app\Http\Resources\Instructor\Attendance\StuckPointsResource.php：レスポンス
- app\Http\Resources\Instructor\Attendance\StuckLessonsResource.php：StuckPointsResourceの子要素
- app\Dto\Instructor\Attendance\StuckPointDto.php：止まっているチャプターを一時保管
- app\Dto\Instructor\Attendance\StuckLessonDto.php：止まっているレッスンを一時保管
- app\Services\Attendance\StuckPointsService.php：stuck-pointsのメソッドのロジックを記述
- tests\Feature\Api\Instructor\Attendance\StuckPointsTest.php：コントローラークラスのユニットテストを作成
- tests\Feature\Service\Attendance\StuckPointsServiceTest.php：サービスクラスのユニットテストを作成

## 確認方法
Postmanにて下記URLでリクエストを送信し、[]が返ってくることを確認。
`GET　http://localhost:8080/api/v1/instructor/course/1/attendance/stuck-points`
※レスポンスが[]のパターンしか確認できなかったので、ユニットテストで全パターン確認済み。

## 関連資料(任意)
なし

## スクショ(任意)
Postmanで動作確認時のスクショ
<img width="977" height="447" alt="image" src="https://github.com/user-attachments/assets/e3af57f8-c6e4-4f18-a3fe-4f6dc0af48f7" />

ユニットテスト（コントローラークラス）実行結果のスクショ
<img width="1222" height="320" alt="image" src="https://github.com/user-attachments/assets/4cbe34b0-8e6d-4d0b-bb06-d170e4b627aa" />

ユニットテスト（サービスクラス）実行結果のスクショ
<img width="1210" height="362" alt="image" src="https://github.com/user-attachments/assets/ee921e96-2a62-4422-91ed-68199f16d11f" />

## 質問(任意)
DTOの使い時は？
今回型変換のために使ってみましたが、不要かもと思いました。

## その他(任意)
効率良い書き方がいまいちわからない・・・