### PR TITLE
JKA-1753講師側 講座作成APIの初期状態を draft に変更(Naomichi)

### DIFF
--- a/app/Services/Course/StoreService.php
+++ b/app/Services/Course/StoreService.php
@@ -38,7 +38,7 @@ class StoreService
             'instructor_id' => $instructorId,
             'title' => $title,
             'image' => $filePath,
-            'status' => CourseStatusEnum::PRIVATE->value,
+            'status' => CourseStatusEnum::DRAFT->value,
             'deadline_type' => $deadlineType->value,
             'capacity' => $capacity,
         ]);

--- a/tests/Feature/Api/Instructor/Course/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Course/StoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Instructor\Course;
 
+use App\Enums\Course\StatusEnum as CourseStatusEnum;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Tag;
@@ -33,6 +34,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
         ]);
         $course = Course::where('title', 'テスト講座')->first();
         $this->assertDatabaseHas('course_tag', [
@@ -65,6 +67,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
         ]);
         $course = Course::where('title', 'テスト講座')->first();
         $this->assertDatabaseHas('course_tag', [
@@ -98,6 +101,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
         ]);
         $course = Course::where('title', 'テスト講座')->first();
         $this->assertDatabaseHas('course_tag', [
@@ -155,6 +159,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
             'capacity' => 30,
         ]);
     }
@@ -179,6 +184,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
             'capacity' => null,
         ]);
     }

--- a/tests/Feature/Api/Manager/Course/StoreTest.php
+++ b/tests/Feature/Api/Manager/Course/StoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Manager\Course;
 
+use App\Enums\Course\StatusEnum as CourseStatusEnum;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\Tag;
@@ -34,6 +35,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
         ]);
 
         $course = Course::where('title', 'テスト講座')->first();
@@ -69,6 +71,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
         ]);
 
         $course = Course::where('title', 'テスト講座')->first();
@@ -105,6 +108,7 @@ class StoreTest extends TestCase
         $response->assertStatus(200);
         $this->assertDatabaseHas('courses', [
             'title' => 'テスト講座',
+            'status' => CourseStatusEnum::DRAFT->value,
         ]);
 
         $course = Course::where('title', 'テスト講座')->first();


### PR DESCRIPTION
## Issue
・講師側 講座作成APIの初期状態を draft に変更
## 対応内容
- 講師側・マネージャー側の講座作成APIが共通利用している StoreService.php を修正
- 講座作成時の status を CourseStatusEnum::DRAFT->value に変更
## 確認方法
- Postmanにて以下APIが 200 OK で返却されることを確認

`POST /api/v1/manager/course`
- レスポンスの status が draft であることを確認

`POST /api/v1/instructor/course`
- 講座作成が成功することを確認
- DB の courses.status が draft であることを確認

## スクショ(任意)
`POST /api/v1/manager/course`
<img width="871" height="683" alt="image" src="https://github.com/user-attachments/assets/fff68457-0e1c-4d87-9fa7-7638fff4e4be" />

`POST /api/v1/instructor/course`
<img width="859" height="561" alt="image" src="https://github.com/user-attachments/assets/3d8e3f85-194d-4169-8aa5-3ed01f7bb118" />

- DB の courses.status が draft であることを確認
i<img width="1199" height="470" alt="image" src="https://github.com/user-attachments/assets/bc88c057-f0a5-450a-8c88-a2dd56031552" />

## その他(任意)
・タスク内のパスでは /courses となっていますが、確認は /course を使用しています。
・Postman の image パラメータには既存画像がなかったため、確認用のテスト画像を使用しています。
・ instructor 側 API のレスポンスは {"result": true} のみで status が返却されなかったため、DB(courses.status) を確認し draft であることを確認しています。