### PR TITLE
JKA-1755講座一覧・詳細APIの3状態表示対応(Naomichi)

### DIFF
--- a/app/Http/Resources/Base/Instructor/CourseResource.php
+++ b/app/Http/Resources/Base/Instructor/CourseResource.php
@@ -18,7 +18,7 @@ class CourseResource extends JsonResource
             'course_id' => $this->resource->id,
             'title' => $this->resource->title,
             'image' => $this->resource->image,
-            'status' => $this->resource->status,
+            'status' => $this->resource->status->value,
             'capacity' => $this->resource->capacity,
             'deadline_type' => $this->resource->deadline_type,
             'course_deadline' => $this->resource->courseDeadline

--- a/app/Http/Resources/Instructor/CourseIndexResource.php
+++ b/app/Http/Resources/Instructor/CourseIndexResource.php
@@ -25,7 +25,7 @@ class CourseIndexResource extends JsonResource
             'course_id' => $this->resource->id,
             'image' => $this->resource->image,
             'title' => $this->resource->title,
-            'status' => $this->resource->status,
+            'status' => $this->resource->status->value,
             'has_active_students' => (bool) $this->resource->has_active_students,
             'tags' => TagResource::collection($this->resource->tags),
             'course_deadline' => $this->resource->courseDeadline


### PR DESCRIPTION
## Issue
講座一覧・詳細APIの3状態表示対応
## 対応内容
- CourseIndexResource の status を Enum ではなく文字列で返却するよう修正
- Base/Instructor/CourseResource の status を Enum ではなく文字列で返却するよう修正
- status を ->value 経由で返却するよう統一
- draft / public / private がレスポンスで文字列として返るよう対応

## 確認方法
- status が Enum ではなく文字列として返ること
- draft 状態の講座が一覧API・詳細APIで取得できること
- 以下APIで status が"draft" / "public" / "private" 文字列で返却されることを確認：
講師側一覧　
`GET /api/v1/instructor/course/index`
講師側詳細　
`GET /api/v1/instructor/course/{course_id}`
manager側一覧　
`GET /api/v1/manager/course/index`
manager側詳細　
`GET /api/v1/manager/course/{course_id}`

## スクショ(任意)
- 講師側一覧 
<img width="862" height="673" alt="image" src="https://github.com/user-attachments/assets/2d1d49a6-761d-4f5b-a601-ed8386f3f722" />

- 講師側詳細
<img width="865" height="598" alt="image" src="https://github.com/user-attachments/assets/67e090ba-3397-4d3b-8f4f-694c54de4bd5" />

- manager側一覧
<img width="873" height="634" alt="image" src="https://github.com/user-attachments/assets/7f3a7cfa-fa4a-4cca-9872-c36c9a39207e" />

- manager側詳細
<img width="862" height="594" alt="image" src="https://github.com/user-attachments/assets/cbef7890-b045-432c-9922-46d1e11f58bb" />


## その他(任意)
- 前回のタスク同様タスク内のパスでは /courses となっていますが、確認は /course を使用しています。