### PR TITLE
JKA-1754 講座ステータス更新APIの状態遷移バリデーション

### DIFF
--- a/app/Enums/Course/StatusEnum.php
+++ b/app/Enums/Course/StatusEnum.php
@@ -7,4 +7,12 @@ enum StatusEnum: string
     case DRAFT = 'draft';
     case PUBLIC = 'public';
     case PRIVATE = 'private';
+
+    public static function switchableStatuses(): array
+    {
+        return [
+            self::PUBLIC->value,
+            self::PRIVATE->value,
+        ];
+    }
 }

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Manager;
 
 use App\Enums\Course\DeadlineTypeEnum;
+use App\Enums\Course\StatusEnum;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manager\Course\IndexRequest;
 use App\Http\Requests\Manager\Course\ShowRequest;
@@ -171,7 +172,9 @@ class CourseController extends Controller
         $managingIds[] = $instructorId;
 
         // 更新対象の講座を取得
-        $courses = Course::whereIn('instructor_id', $managingIds)->get();
+        $courses = Course::whereIn('instructor_id', $managingIds)
+            ->whereIn('status', [StatusEnum::PUBLIC->value, StatusEnum::PRIVATE->value])
+            ->get();
 
         // 更新処理
         $service(courses: $courses, status: $request->status);

--- a/app/Http/Controllers/Api/Manager/CourseController.php
+++ b/app/Http/Controllers/Api/Manager/CourseController.php
@@ -173,7 +173,7 @@ class CourseController extends Controller
 
         // 更新対象の講座を取得
         $courses = Course::whereIn('instructor_id', $managingIds)
-            ->whereIn('status', [StatusEnum::PUBLIC->value, StatusEnum::PRIVATE->value])
+            ->whereIn('status', StatusEnum::switchableStatuses())
             ->get();
 
         // 更新処理

--- a/app/Http/Requests/Instructor/Course/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Course/PutStatusRequest.php
@@ -3,8 +3,8 @@
 namespace App\Http\Requests\Instructor\Course;
 
 use App\Enums\Course\StatusEnum;
-use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PutStatusRequest extends FormRequest
 {

--- a/app/Http/Requests/Instructor/Course/PutStatusRequest.php
+++ b/app/Http/Requests/Instructor/Course/PutStatusRequest.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Requests\Instructor\Course;
 
-use App\Rules\CourseStatusRule;
+use App\Enums\Course\StatusEnum;
+use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class PutStatusRequest extends FormRequest
@@ -27,7 +28,7 @@ class PutStatusRequest extends FormRequest
         return [
             'courses' => ['required', 'array', 'min:1'],
             'courses.*' => ['integer', 'exists:courses,id,deleted_at,NULL'],
-            'status' => ['required', 'string', new CourseStatusRule],
+            'status' => ['required', 'string', Rule::in(StatusEnum::switchableStatuses())],
         ];
     }
 }

--- a/app/Http/Requests/Manager/Course/StatusRequest.php
+++ b/app/Http/Requests/Manager/Course/StatusRequest.php
@@ -3,8 +3,8 @@
 namespace App\Http\Requests\Manager\Course;
 
 use App\Enums\Course\StatusEnum;
-use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StatusRequest extends FormRequest
 {

--- a/app/Http/Requests/Manager/Course/StatusRequest.php
+++ b/app/Http/Requests/Manager/Course/StatusRequest.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Requests\Manager\Course;
 
-use App\Rules\CourseStatusRule;
+use App\Enums\Course\StatusEnum;
+use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StatusRequest extends FormRequest
@@ -25,7 +26,7 @@ class StatusRequest extends FormRequest
     public function rules()
     {
         return [
-            'status' => ['required', 'string', new CourseStatusRule],
+            'status' => ['required', 'string', Rule::in(StatusEnum::switchableStatuses())],
         ];
     }
 }

--- a/app/Rules/CourseStatusRule.php
+++ b/app/Rules/CourseStatusRule.php
@@ -15,7 +15,7 @@ class CourseStatusRule implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (
-            !in_array($value, [
+            ! in_array($value, [
                 StatusEnum::PUBLIC->value,
                 StatusEnum::PRIVATE->value,
             ], true)

--- a/app/Rules/CourseStatusRule.php
+++ b/app/Rules/CourseStatusRule.php
@@ -14,9 +14,14 @@ class CourseStatusRule implements ValidationRule
     #[\Override]
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (StatusEnum::tryFrom($value) === null) {
+        if (
+            !in_array($value, [
+                StatusEnum::PUBLIC->value,
+                StatusEnum::PRIVATE->value,
+            ], true)
+        ) {
             // エラーを返す
-            $fail('The :attribute must be a valid status.');
+            $fail('The :attribute must be public or private.');
         }
     }
 }

--- a/app/Services/Course/PutStatusService.php
+++ b/app/Services/Course/PutStatusService.php
@@ -4,8 +4,8 @@ namespace App\Services\Course;
 
 use App\Enums\Course\StatusEnum;
 use App\Model\Course;
-use Illuminate\Validation\ValidationException;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
 
 class PutStatusService
 {

--- a/app/Services/Course/PutStatusService.php
+++ b/app/Services/Course/PutStatusService.php
@@ -2,7 +2,9 @@
 
 namespace App\Services\Course;
 
+use App\Enums\Course\StatusEnum;
 use App\Model\Course;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Support\Collection;
 
 class PutStatusService
@@ -15,7 +17,40 @@ class PutStatusService
      */
     public function __invoke(Collection $courses, string $status): void
     {
+
+        // 許容する組み合わせを検証する
+        $this->validateStatusCombination($courses, $status);
+
         // 講座のステータスを一括更新
         Course::whereIn('id', $courses->pluck('id'))->update(['status' => $status]);
+    }
+
+    /**
+     * 許容する組み合わせを検証する
+     *
+     * @param  Collection<int, Course>  $courses
+     * @param  'public'|'private'  $status
+     */
+    private function validateStatusCombination(Collection $courses, string $status): void
+    {
+        // 対象のステータスをEnumに変換
+        $target = StatusEnum::from($status);
+
+        foreach ($courses as $course) {
+            $current = $course->status;
+
+            // 許容する組み合わせの検証
+            $allowed = ($current === StatusEnum::DRAFT && $target === StatusEnum::PUBLIC)
+                || ($current === StatusEnum::PUBLIC && $target === StatusEnum::PRIVATE)
+                || ($current === StatusEnum::PRIVATE && $target === StatusEnum::PUBLIC)
+                || ($current === StatusEnum::PUBLIC && $target === StatusEnum::PUBLIC)
+                || ($current === StatusEnum::PRIVATE && $target === StatusEnum::PRIVATE);
+
+            if (! $allowed) {
+                throw ValidationException::withMessages([
+                    'status' => $current->value.'は、'.$target->value.'に変更できません。',
+                ]);
+            }
+        }
     }
 }

--- a/tests/Feature/Api/Instructor/Course/PutStatusTest.php
+++ b/tests/Feature/Api/Instructor/Course/PutStatusTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Api\Instructor\Course;
 
-use App\Model\Attendance;
 use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Api/Instructor/Course/PutStatusTest.php
+++ b/tests/Feature/Api/Instructor/Course/PutStatusTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\Api\Instructor\Course;
 
+use App\Enums\Course\StatusEnum;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\ManageInstructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -11,20 +13,58 @@ class PutStatusTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_講座ステータス一括更新_成功(): void
+    public function test_講師で自分の講座のステータスを一括更新_成功(): void
     {
         // Arrange
-        $instructor = Instructor::factory()->create();
-        $course = Course::factory()->create([
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course1 = Course::factory()->create([
             'instructor_id' => $instructor->id,
-            'status' => 'public',
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+        $course2 = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
         $this->actingAs($instructor, 'instructor');
 
         // Act
         $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course1->id, $course2->id],
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(['result' => true]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $course1->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $course2->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+    }
+
+    public function test_マネージャーで配下の講師の講座を一括更新_成功(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $subordinate = Instructor::factory()->create(['type' => 'instructor']);
+        ManageInstructor::factory()->create([
+            'manager_id' => $manager->id,
+            'instructor_id' => $subordinate->id,
+        ]);
+        $course = Course::factory()->create([
+            'instructor_id' => $subordinate->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
             'courses' => [$course->id],
-            'status' => 'public',
+            'status' => StatusEnum::PRIVATE->value,
         ]);
 
         // Assert
@@ -32,33 +72,136 @@ class PutStatusTest extends TestCase
         $response->assertJson(['result' => true]);
         $this->assertDatabaseHas('courses', [
             'id' => $course->id,
-            'status' => 'public',
+            'status' => StatusEnum::PRIVATE->value,
         ]);
     }
 
-    public function test_権限がない講師が講座ステータス一括更新_失敗(): void
+    public function test_状態遷移バリデーションエラー_下書きから非公開へ更新できない(): void
     {
         // Arrange
-        $instructor = Instructor::factory()->create();
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
         $course = Course::factory()->create([
             'instructor_id' => $instructor->id,
-            'status' => 'public',
+            'status' => StatusEnum::DRAFT->value,
         ]);
-        $otherInstructor = Instructor::factory()->create();
-        $this->actingAs($otherInstructor, 'instructor');
+        $this->actingAs($instructor, 'instructor');
 
         // Act
         $response = $this->putJson(route('instructor.course.put-status'), [
             'courses' => [$course->id],
-            'status' => 'public',
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+        $this->assertDatabaseHas('courses', [
+            'id' => $course->id,
+            'status' => StatusEnum::DRAFT->value,
+        ]);
+    }
+
+    public function test_権限がないマネージャーの場合更新できない(): void
+    {
+        // Arrange — 配下にない講師の講座
+        $manager = Instructor::factory()->create();
+        $otherInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create([
+            'instructor_id' => $otherInstructor->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course->id],
+            'status' => StatusEnum::PRIVATE->value,
         ]);
 
         // Assert
         $response->assertStatus(403);
-        $response->assertJson(['message' => 'This action is unauthorized.']);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $course->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
     }
 
-    public function test_講座idが空配列_バリデーションエラー(): void
+    public function test_権限がない講師の場合更新できない(): void
+    {
+        // Arrange — 別の講師の講座
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $otherInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create([
+            'instructor_id' => $otherInstructor->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course->id],
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+    }
+
+    public function test_一部に権限がない講座を含む場合更新できない(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $ownCourse = Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $otherInstructor = Instructor::factory()->create();
+        $otherCourse = Course::factory()->create([
+            'instructor_id' => $otherInstructor->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$ownCourse->id, $otherCourse->id],
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'This action is unauthorized.',
+        ]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $ownCourse->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+    }
+
+    public function test_バリデーションエラー_coursesが未送信(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['courses']);
+    }
+
+    public function test_バリデーションエラー_coursesが空配列(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
@@ -67,7 +210,7 @@ class PutStatusTest extends TestCase
         // Act
         $response = $this->putJson(route('instructor.course.put-status'), [
             'courses' => [],
-            'status' => 'public',
+            'status' => StatusEnum::PUBLIC->value,
         ]);
 
         // Assert
@@ -75,7 +218,41 @@ class PutStatusTest extends TestCase
         $response->assertJsonValidationErrors(['courses']);
     }
 
-    public function test_存在しない講座id_バリデーションエラー(): void
+    public function test_バリデーションエラー_coursesが配列でない(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => 'abc',
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['courses']);
+    }
+
+    public function test_バリデーションエラー_courses要素が整数でない(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => ['abc'],
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['courses.0']);
+    }
+
+    public function test_バリデーションエラー_存在しない_i_dを含む(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
@@ -84,7 +261,7 @@ class PutStatusTest extends TestCase
         // Act
         $response = $this->putJson(route('instructor.course.put-status'), [
             'courses' => [99999],
-            'status' => 'public',
+            'status' => StatusEnum::PUBLIC->value,
         ]);
 
         // Assert
@@ -92,16 +269,83 @@ class PutStatusTest extends TestCase
         $response->assertJsonValidationErrors(['courses.0']);
     }
 
-    public function test_ステータスがdraft_バリデーションエラー(): void
+    public function test_バリデーションエラー_削除済みの_i_dを含む(): void
     {
         // Arrange
         $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $course->delete();
         $this->actingAs($instructor, 'instructor');
 
         // Act
         $response = $this->putJson(route('instructor.course.put-status'), [
-            'courses' => [1],
-            'status' => 'draft',
+            'courses' => [$course->id],
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['courses.0']);
+    }
+
+    public function test_バリデーションエラー_statusが未送信(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course->id],
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_バリデーションエラー_statusが文字列でない(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course->id],
+            'status' => 123,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_バリデーションエラー_statusが下書き(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course->id],
+            'status' => StatusEnum::DRAFT->value,
         ]);
 
         // Assert

--- a/tests/Feature/Api/Instructor/Course/PutStatusTest.php
+++ b/tests/Feature/Api/Instructor/Course/PutStatusTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Course;
+
+use App\Model\Attendance;
+use App\Model\Course;
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_講座ステータス一括更新_成功(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => 'public',
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course->id],
+            'status' => 'public',
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(['result' => true]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $course->id,
+            'status' => 'public',
+        ]);
+    }
+
+    public function test_権限がない講師が講座ステータス一括更新_失敗(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => 'public',
+        ]);
+        $otherInstructor = Instructor::factory()->create();
+        $this->actingAs($otherInstructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [$course->id],
+            'status' => 'public',
+        ]);
+
+        // Assert
+        $response->assertStatus(403);
+        $response->assertJson(['message' => 'This action is unauthorized.']);
+    }
+
+    public function test_講座idが空配列_バリデーションエラー(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [],
+            'status' => 'public',
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['courses']);
+    }
+
+    public function test_存在しない講座id_バリデーションエラー(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [99999],
+            'status' => 'public',
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['courses.0']);
+    }
+
+    public function test_ステータスがdraft_バリデーションエラー(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('instructor.course.put-status'), [
+            'courses' => [1],
+            'status' => 'draft',
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+    }
+}

--- a/tests/Feature/Api/Manager/Course/PutStatusTest.php
+++ b/tests/Feature/Api/Manager/Course/PutStatusTest.php
@@ -25,7 +25,7 @@ class PutStatusTest extends TestCase
             'instructor_id' => $manager->id,
             'status' => CourseStatusEnum::PRIVATE->value,
         ]);
-        $course3 = Course::factory()->create([
+        Course::factory()->create([
             'instructor_id' => $manager->id,
             'status' => CourseStatusEnum::DRAFT->value,
         ]);

--- a/tests/Feature/Api/Manager/Course/PutStatusTest.php
+++ b/tests/Feature/Api/Manager/Course/PutStatusTest.php
@@ -88,7 +88,7 @@ class PutStatusTest extends TestCase
             'id' => $subordinateCourse->id,
             'status' => CourseStatusEnum::PRIVATE->value,
         ]);
-    }    
+    }
 
     public function test_権限がないマネージャーが講座ステータス一括更新_失敗(): void
     {

--- a/tests/Feature/Api/Manager/Course/PutStatusTest.php
+++ b/tests/Feature/Api/Manager/Course/PutStatusTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Api\Manager\Course;
 
-use App\Enums\Course\StatusEnum as CourseStatusEnum;
+use App\Enums\Course\StatusEnum;
 use App\Model\Course;
 use App\Model\Instructor;
 use App\Model\ManageInstructor;
@@ -13,68 +13,64 @@ class PutStatusTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_複数講座ステータス一括更新_成功(): void
+    public function test_マネージャーで自分の複数講座のステータスを一括更新_成功(): void
     {
         // Arrange
         $manager = Instructor::factory()->create();
         $course1 = Course::factory()->create([
             'instructor_id' => $manager->id,
-            'status' => CourseStatusEnum::PUBLIC->value,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
         $course2 = Course::factory()->create([
             'instructor_id' => $manager->id,
-            'status' => CourseStatusEnum::PRIVATE->value,
-        ]);
-        Course::factory()->create([
-            'instructor_id' => $manager->id,
-            'status' => CourseStatusEnum::DRAFT->value,
+            'status' => StatusEnum::PRIVATE->value,
         ]);
         $this->actingAs($manager, 'instructor');
 
         // Act
         $response = $this->putJson(route('manager.course.put-status'), [
-            'status' => 'public',
+            'status' => StatusEnum::PUBLIC->value,
         ]);
 
         // Assert
         $response->assertStatus(200);
-        $response->assertJson(['result' => true]);
+        $response->assertJson(['result' => 'true']);
         $this->assertEqualsCanonicalizing(
             [$course1->id, $course2->id],
             $response->json('updated_ids')
         );
         $this->assertDatabaseHas('courses', [
             'id' => $course1->id,
-            'status' => CourseStatusEnum::PUBLIC->value,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
         $this->assertDatabaseHas('courses', [
             'id' => $course2->id,
-            'status' => CourseStatusEnum::PUBLIC->value,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
     }
 
-    public function test_配下講師の講座も一括更新される_成功(): void
+    public function test_マネージャーで配下の講師の講座も一括更新_成功(): void
     {
         // Arrange
         $manager = Instructor::factory()->create();
-        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $subordinate = Instructor::factory()->create(['type' => 'instructor']);
         ManageInstructor::factory()->create([
             'manager_id' => $manager->id,
-            'instructor_id' => $instructor->id,
+            'instructor_id' => $subordinate->id,
         ]);
         $managerCourse = Course::factory()->create([
             'instructor_id' => $manager->id,
-            'status' => CourseStatusEnum::PUBLIC->value,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
         $subordinateCourse = Course::factory()->create([
-            'instructor_id' => $instructor->id,
-            'status' => CourseStatusEnum::PUBLIC->value,
+            'instructor_id' => $subordinate->id,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
         $this->actingAs($manager, 'instructor');
 
         // Act
         $response = $this->putJson(route('manager.course.put-status'), [
-            'status' => 'private',
+            'status' => StatusEnum::PRIVATE->value,
         ]);
 
         // Assert
@@ -85,28 +81,68 @@ class PutStatusTest extends TestCase
             $response->json('updated_ids')
         );
         $this->assertDatabaseHas('courses', [
+            'id' => $managerCourse->id,
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+        $this->assertDatabaseHas('courses', [
             'id' => $subordinateCourse->id,
-            'status' => CourseStatusEnum::PRIVATE->value,
+            'status' => StatusEnum::PRIVATE->value,
         ]);
     }
 
-    public function test_権限がないマネージャーが講座ステータス一括更新_失敗(): void
+    public function test_下書きの講座は一括更新の対象外(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $publicCourse = Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => StatusEnum::PUBLIC->value,
+        ]);
+        $draftCourse = Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => StatusEnum::DRAFT->value,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(['result' => 'true']);
+        $this->assertEqualsCanonicalizing(
+            [$publicCourse->id],
+            $response->json('updated_ids')
+        );
+        $this->assertDatabaseHas('courses', [
+            'id' => $publicCourse->id,
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $draftCourse->id,
+            'status' => StatusEnum::DRAFT->value,
+        ]);
+    }
+
+    public function test_スコープ外の講座は一括更新の対象外(): void
     {
         // Arrange
         $ownerManager = Instructor::factory()->create();
         $otherManager = Instructor::factory()->create();
         $ownerCourse = Course::factory()->create([
             'instructor_id' => $ownerManager->id,
-            'status' => CourseStatusEnum::PUBLIC->value,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
         $this->actingAs($otherManager, 'instructor');
 
         // Act
         $response = $this->putJson(route('manager.course.put-status'), [
-            'status' => 'private',
+            'status' => StatusEnum::PRIVATE->value,
         ]);
 
-        // Assert — スコープ外の講座は対象外のため403ではなく200
+        // Assert
         $response->assertStatus(200);
         $response->assertJson([
             'result' => 'true',
@@ -114,18 +150,32 @@ class PutStatusTest extends TestCase
         ]);
         $this->assertDatabaseHas('courses', [
             'id' => $ownerCourse->id,
-            'status' => CourseStatusEnum::PUBLIC->value,
+            'status' => StatusEnum::PUBLIC->value,
         ]);
     }
 
-    public function test_ステータスが未送信_バリデーションエラー(): void
+    public function test_マネージャー権限がない講師は更新できない(): void
+    {
+        // Arrange
+        $nonManager = Instructor::factory()->create(['type' => 'instructor']);
+        $this->actingAs($nonManager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => StatusEnum::PRIVATE->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(403);
+        $response->assertJson([
+            'message' => 'Forbidden, not allowed to use manager api.',
+        ]);
+    }
+
+    public function test_バリデーションエラー_statusが未送信(): void
     {
         // Arrange
         $manager = Instructor::factory()->create();
-        Course::factory()->create([
-            'instructor_id' => $manager->id,
-            'status' => CourseStatusEnum::DRAFT->value,
-        ]);
         $this->actingAs($manager, 'instructor');
 
         // Act
@@ -136,7 +186,7 @@ class PutStatusTest extends TestCase
         $response->assertJsonValidationErrors(['status']);
     }
 
-    public function test_ステータスが文字列でない_バリデーションエラー(): void
+    public function test_バリデーションエラー_statusが文字列でない(): void
     {
         // Arrange
         $manager = Instructor::factory()->create();
@@ -152,7 +202,7 @@ class PutStatusTest extends TestCase
         $response->assertJsonValidationErrors(['status']);
     }
 
-    public function test_ステータスがdraft_バリデーションエラー(): void
+    public function test_バリデーションエラー_statusが下書き(): void
     {
         // Arrange
         $manager = Instructor::factory()->create();
@@ -160,7 +210,23 @@ class PutStatusTest extends TestCase
 
         // Act
         $response = $this->putJson(route('manager.course.put-status'), [
-            'status' => 'draft',
+            'status' => StatusEnum::DRAFT->value,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_バリデーションエラー_statusが許容外の文字列(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => 'invalid_status',
         ]);
 
         // Assert

--- a/tests/Feature/Api/Manager/Course/PutStatusTest.php
+++ b/tests/Feature/Api/Manager/Course/PutStatusTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Feature\Api\Manager\Course;
+
+use App\Enums\Course\StatusEnum as CourseStatusEnum;
+use App\Model\Course;
+use App\Model\Instructor;
+use App\Model\ManageInstructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PutStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_複数講座ステータス一括更新_成功(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $course1 = Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => CourseStatusEnum::PUBLIC->value,
+        ]);
+        $course2 = Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => CourseStatusEnum::PRIVATE->value,
+        ]);
+        $course3 = Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => CourseStatusEnum::DRAFT->value,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => 'public',
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(['result' => true]);
+        $this->assertEqualsCanonicalizing(
+            [$course1->id, $course2->id],
+            $response->json('updated_ids')
+        );
+        $this->assertDatabaseHas('courses', [
+            'id' => $course1->id,
+            'status' => CourseStatusEnum::PUBLIC->value,
+        ]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $course2->id,
+            'status' => CourseStatusEnum::PUBLIC->value,
+        ]);
+    }
+
+    public function test_配下講師の講座も一括更新される_成功(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        ManageInstructor::factory()->create([
+            'manager_id' => $manager->id,
+            'instructor_id' => $instructor->id,
+        ]);
+        $managerCourse = Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => CourseStatusEnum::PUBLIC->value,
+        ]);
+        $subordinateCourse = Course::factory()->create([
+            'instructor_id' => $instructor->id,
+            'status' => CourseStatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => 'private',
+        ]);
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson(['result' => 'true']);
+        $this->assertEqualsCanonicalizing(
+            [$managerCourse->id, $subordinateCourse->id],
+            $response->json('updated_ids')
+        );
+        $this->assertDatabaseHas('courses', [
+            'id' => $subordinateCourse->id,
+            'status' => CourseStatusEnum::PRIVATE->value,
+        ]);
+    }    
+
+    public function test_権限がないマネージャーが講座ステータス一括更新_失敗(): void
+    {
+        // Arrange
+        $ownerManager = Instructor::factory()->create();
+        $otherManager = Instructor::factory()->create();
+        $ownerCourse = Course::factory()->create([
+            'instructor_id' => $ownerManager->id,
+            'status' => CourseStatusEnum::PUBLIC->value,
+        ]);
+        $this->actingAs($otherManager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => 'private',
+        ]);
+
+        // Assert — スコープ外の講座は対象外のため403ではなく200
+        $response->assertStatus(200);
+        $response->assertJson([
+            'result' => 'true',
+            'updated_ids' => [],
+        ]);
+        $this->assertDatabaseHas('courses', [
+            'id' => $ownerCourse->id,
+            'status' => CourseStatusEnum::PUBLIC->value,
+        ]);
+    }
+
+    public function test_ステータスが未送信_バリデーションエラー(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        Course::factory()->create([
+            'instructor_id' => $manager->id,
+            'status' => CourseStatusEnum::DRAFT->value,
+        ]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), []);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_ステータスが文字列でない_バリデーションエラー(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => 123,
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_ステータスがdraft_バリデーションエラー(): void
+    {
+        // Arrange
+        $manager = Instructor::factory()->create();
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->putJson(route('manager.course.put-status'), [
+            'status' => 'draft',
+        ]);
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
+    }
+}

--- a/tests/Feature/Service/Course/PutStatusServiceTest.php
+++ b/tests/Feature/Service/Course/PutStatusServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Service\Course;
+
+use App\Enums\Course\StatusEnum;
+use App\Model\Course;
+use App\Services\Course\PutStatusService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class PutStatusServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array<int, array{0: string, 1: string}>
+     */
+    public static function allowedStatusProvider(): array
+    {
+        return [
+            [StatusEnum::DRAFT->value, StatusEnum::PUBLIC->value],
+            [StatusEnum::PUBLIC->value, StatusEnum::PRIVATE->value],
+            [StatusEnum::PRIVATE->value, StatusEnum::PUBLIC->value],
+            [StatusEnum::PUBLIC->value, StatusEnum::PUBLIC->value],
+            [StatusEnum::PRIVATE->value, StatusEnum::PRIVATE->value],
+        ];
+    }
+
+    /**
+     * @return array<int, array{0: string, 1: string}>
+     */
+    public static function disallowedStatusProvider(): array
+    {
+        return [
+            [StatusEnum::DRAFT->value, StatusEnum::DRAFT->value],
+            [StatusEnum::DRAFT->value, StatusEnum::PRIVATE->value],
+            [StatusEnum::PUBLIC->value, StatusEnum::DRAFT->value],
+            [StatusEnum::PRIVATE->value, StatusEnum::DRAFT->value],
+        ];
+    }
+
+    #[DataProvider('allowedStatusProvider')]
+    public function test_講座ステータス一括更新_許容する組み合わせ_成功(string $currentStatus, string $targetStatus): void
+    {
+        // Arrange
+        $service = new PutStatusService();
+        $course = Course::factory()->create([
+            'status' => $currentStatus,
+        ]);
+
+        // Act
+        $service(collect([$course]), $targetStatus);
+
+        // Assert
+        $this->assertDatabaseHas('courses', [
+            'id' => $course->id,
+            'status' => $targetStatus,
+        ]);
+    }
+
+    #[DataProvider('disallowedStatusProvider')]
+    public function test_講座ステータス一括更新_許容しない組み合わせ_失敗(string $currentStatus, string $targetStatus): void
+    {
+        // Arrange
+        $service = new PutStatusService();
+        $course = Course::factory()->create([
+            'status' => $currentStatus,
+        ]);
+
+        // Act
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage($currentStatus.'は、'.$targetStatus.'に変更できません。');
+        $service(collect([$course]), $targetStatus);
+
+        // Assert
+        $this->assertDatabaseHas('courses', [
+            'id' => $course->id,
+            'status' => $currentStatus,
+        ]);
+    }
+}

--- a/tests/Feature/Service/Course/PutStatusServiceTest.php
+++ b/tests/Feature/Service/Course/PutStatusServiceTest.php
@@ -45,7 +45,7 @@ class PutStatusServiceTest extends TestCase
     public function test_講座ステータス一括更新_許容する組み合わせ_成功(string $currentStatus, string $targetStatus): void
     {
         // Arrange
-        $service = new PutStatusService();
+        $service = new PutStatusService;
         $course = Course::factory()->create([
             'status' => $currentStatus,
         ]);
@@ -64,7 +64,7 @@ class PutStatusServiceTest extends TestCase
     public function test_講座ステータス一括更新_許容しない組み合わせ_失敗(string $currentStatus, string $targetStatus): void
     {
         // Arrange
-        $service = new PutStatusService();
+        $service = new PutStatusService;
         $course = Course::factory()->create([
             'status' => $currentStatus,
         ]);

--- a/tests/Feature/Service/Course/PutStatusServiceTest.php
+++ b/tests/Feature/Service/Course/PutStatusServiceTest.php
@@ -34,10 +34,7 @@ class PutStatusServiceTest extends TestCase
     public static function disallowedStatusProvider(): array
     {
         return [
-            [StatusEnum::DRAFT->value, StatusEnum::DRAFT->value],
             [StatusEnum::DRAFT->value, StatusEnum::PRIVATE->value],
-            [StatusEnum::PUBLIC->value, StatusEnum::DRAFT->value],
-            [StatusEnum::PRIVATE->value, StatusEnum::DRAFT->value],
         ];
     }
 
@@ -69,9 +66,11 @@ class PutStatusServiceTest extends TestCase
             'status' => $currentStatus,
         ]);
 
-        // Act
+        // Assert
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage($currentStatus.'は、'.$targetStatus.'に変更できません。');
+
+        // Act
         $service(collect([$course]), $targetStatus);
 
         // Assert


### PR DESCRIPTION
## Issue
講座ステータス更新APIの状態遷移バリデーション

## 対応内容
1. リクエスト値の制限
app/Rules/CourseStatusRule.phpに、リクエストとして受け取る status の許容値を public または private のみとするルールを追加

2. サービスへの状態遷移バリデーション追加
app/Services/Course/PutStatusService.phpに、DB更新処理の前に更新前後のstatusの組み合わせの検証処理を追加
許容されない組み合わせの場合、例外をスローする

3. マネージャー側の更新対象の絞り込み
app/Http/Controllers/Api/Manager/CourseController.php(putStatus メソッド)の中の、講座取得クエリに` ->whereIn('status', [StatusEnum::PUBLIC->value, StatusEnum::PRIVATE->value]) `を追加する


【変更】
app/Http/Controllers/Api/Manager/CourseController.php：更新対象の講座の取得条件を追加
app/Rules/CourseStatusRule.php：status の許容値を public または privateに限定
app/Services/Course/PutStatusService.php：許容するstatusの組み合わせの検証を追加
【新規】
tests/Feature/Api/Instructor/Course/PutStatusTest.php
tests/Feature/Api/Manager/Course/PutStatusTest.php
tests/Feature/Service/Course/PutStatusServiceTest.php

## 確認方法
`1. リクエスト値の制限`の対応に対して、バリデーションエラーになるパターンをPostmanで動作確認
それ以外は、ユニットテストで確認

## 関連資料(任意)
なし

## スクショ(任意)
Postmanで動作確認時のスクショ
★リクエストのバリデーションエラー
<img width="961" height="450" alt="image" src="https://github.com/user-attachments/assets/2e3b108e-18ea-4f51-9433-2a7b6047c241" />

ユニットテスト（コントローラークラスのputStatusメソッド）実行結果のスクショ
★マネージャー側
<img width="1405" height="322" alt="image" src="https://github.com/user-attachments/assets/e93ea1f0-a911-4963-9cfe-1e9f10d73acd" />
★講師側
<img width="1401" height="300" alt="image" src="https://github.com/user-attachments/assets/45756afa-1649-4e24-ac5f-b5d0435acfb4" />

ユニットテスト（サービスクラス）実行結果のスクショ
<img width="1402" height="385" alt="image" src="https://github.com/user-attachments/assets/9dd5fd31-8962-483a-a4c5-d0d4b7f19984" />

## 質問(任意)
なし

## その他(任意)
なし