### PR TITLE
JKA-1757 講師側 チャプター作成APIの初期状態を draft に変更(大川)

### DIFF
--- a/app/Services/Chapter/CreateChapterService.php
+++ b/app/Services/Chapter/CreateChapterService.php
@@ -21,7 +21,7 @@ class CreateChapterService
             'course_id' => $course->id,
             'title' => $title,
             'order' => $newOrder,
-            'status' => ChapterStatusEnum::PUBLIC->value,
+            'status' => ChapterStatusEnum::DRAFT->value,
         ]);
     }
 }

--- a/tests/Feature/Api/Instructor/Chapter/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Chapter/StoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Instructor\Chapter;
 
+use App\Enums\Chapter\StatusEnum;
 use App\Model\Course;
 use App\Model\Instructor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -32,6 +33,7 @@ class StoreTest extends TestCase
         $this->assertDatabaseHas('chapters', [
             'course_id' => $course->id,
             'title' => 'title',
+            'status' => StatusEnum::DRAFT->value,
         ]);
     }
 


### PR DESCRIPTION
## Issue
チャプターを新規作成したときの初期状態を public から draft に変更する。
## 対応内容

## 確認方法
講師でログインし、新規にチャプターを作成した結果、レスポンスおよび データベースのstatus が 'draft' になっていることを確認
## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)