### PR TITLE
JKA-1761 レッスン作成APIの初期状態を draft に変更(大川)

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -54,7 +54,6 @@ class LessonController extends Controller
                 courseId: $request->course_id,
                 chapterId: $request->chapter_id,
                 title: $request->title,
-                status: LessonStatusEnum::PRIVATE->value
             );
 
             DB::commit();

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -51,7 +51,6 @@ class LessonController extends Controller
         DB::beginTransaction();
         try {
             $lesson = $service(
-                courseId: $request->course_id,
                 chapterId: $request->chapter_id,
                 title: $request->title,
             );

--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api\Instructor;
 
-use App\Enums\Lesson\StatusEnum as LessonStatusEnum;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Instructor\Lesson\BulkDeleteRequest;
 use App\Http\Requests\Instructor\Lesson\DeleteAllRequest;

--- a/app/Services/Lesson/StoreLessonService.php
+++ b/app/Services/Lesson/StoreLessonService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Lesson;
 
+use App\Enums\Lesson\StatusEnum;
 use App\Model\Attendance;
 use App\Model\Lesson;
 use App\Model\LessonAttendance;
@@ -12,26 +13,15 @@ class StoreLessonService
         int $courseId,
         int $chapterId,
         string $title,
-        string $status
     ): Lesson {
         $nextOrder = Lesson::where('chapter_id', $chapterId)->max('order') + 1;
 
         $lesson = Lesson::create([
             'chapter_id' => $chapterId,
             'title' => $title,
-            'status' => $status,
+            'status' => StatusEnum::DRAFT->value,
             'order' => $nextOrder,
         ]);
-
-        $attendances = Attendance::where('course_id', $courseId)->get();
-        foreach ($attendances as $attendance) {
-            LessonAttendance::create([
-                'attendance_id' => $attendance->id,
-                'lesson_id' => $lesson->id,
-                'status' => LessonAttendance::STATUS_BEFORE_ATTENDANCE,
-            ]);
-        }
-
         return $lesson;
     }
 }

--- a/app/Services/Lesson/StoreLessonService.php
+++ b/app/Services/Lesson/StoreLessonService.php
@@ -13,12 +13,11 @@ class StoreLessonService
     ): Lesson {
         $nextOrder = Lesson::where('chapter_id', $chapterId)->max('order') + 1;
 
-        $lesson = Lesson::create([
+        return Lesson::create([
             'chapter_id' => $chapterId,
             'title' => $title,
             'status' => StatusEnum::DRAFT->value,
             'order' => $nextOrder,
         ]);
-        return $lesson;
     }
 }

--- a/app/Services/Lesson/StoreLessonService.php
+++ b/app/Services/Lesson/StoreLessonService.php
@@ -3,9 +3,7 @@
 namespace App\Services\Lesson;
 
 use App\Enums\Lesson\StatusEnum;
-use App\Model\Attendance;
 use App\Model\Lesson;
-use App\Model\LessonAttendance;
 
 class StoreLessonService
 {

--- a/app/Services/Lesson/StoreLessonService.php
+++ b/app/Services/Lesson/StoreLessonService.php
@@ -10,7 +10,6 @@ use App\Model\LessonAttendance;
 class StoreLessonService
 {
     public function __invoke(
-        int $courseId,
         int $chapterId,
         string $title,
     ): Lesson {

--- a/tests/Feature/Api/Instructor/Lesson/StoreTest.php
+++ b/tests/Feature/Api/Instructor/Lesson/StoreTest.php
@@ -2,9 +2,12 @@
 
 namespace Tests\Feature\Api\Instructor\Lesson;
 
+use App\Enums\Lesson\StatusEnum as LessonStatusEnum;
+use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Course;
 use App\Model\Instructor;
+use App\Model\Student;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -37,6 +40,36 @@ class StoreTest extends TestCase
         $this->assertDatabaseHas('lessons', [
             'chapter_id' => $chapter->id,
             'title' => 'title',
+            'status' => LessonStatusEnum::DRAFT->value,
+        ]);
+    }
+
+    public function test_受講者がいる講座でレッスンを作成しても受講状況は作成されない(): void
+    {
+        // Arrange — すでに受講者がいる講座
+        $instructor = Instructor::factory()->create();
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $chapter = Chapter::factory()->create(['course_id' => $course->id]);
+        $student = Student::factory()->create();
+        $attendance = Attendance::factory()->create([
+            'course_id' => $course->id,
+            'student_id' => $student->id,
+        ]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->postJson(route('instructor.lesson.store', [
+            'course_id' => $course->id,
+            'chapter_id' => $chapter->id,
+        ]), [
+            'title' => 'title',
+        ]);
+
+        // Assert — 作成したレッスンに対する受講状況は作られない
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('lesson_attendances', [
+            'attendance_id' => $attendance->id,
+            'lesson_id' => $response->json('lesson_id'),
         ]);
     }
 


### PR DESCRIPTION
## Issue
レッスンを新規作成したときの初期状態を private から draft に変更する。
## 対応内容
講師でログインし、新規にレッスンを作成した結果、レスポンスおよび データベースのstatus が 'draft' になっていることを確認
## 確認方法

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)
受け入れ基準において、レッスン作成時に lesson_attendances テーブルへ新規レコードが作成されないことは確認できました。しかし、対象講座にすでに受講者がいる場合でも、作成されないことを確認する方法が分かりません。確認する方法はありますでしょうか？
## その他(任意)