### PR TITLE
JKA-1777 Instructor/AttendanceControllerのshowStatusメソッドの認可処理(policyパターン)の導入と動作確認

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -154,10 +154,10 @@ class AttendanceController extends Controller
     {
         $courseId = $request->course_id;
         $course = Course::findOrFail($courseId);
-        
+
         // ログインしている講師の講座でない場合は403エラーを返す
         $this->authorize('view', $course);
-        
+
         $attendances = Attendance::with([
             'lessonAttendances.lesson.chapter.course',
             'lessonAttendances.lesson.chapter.lessons',

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -155,11 +155,10 @@ class AttendanceController extends Controller
         $instructorId = Auth::guard('instructor')->user()->id;
         $courseId = $request->course_id;
         $course = Course::findOrFail($courseId);
-
-        if ($course->instructor_id !== $instructorId) {
-            // ログインしている講師の講座でない場合はエラーを返す
-            throw new AuthorizationException('Forbidden, invalid instructor_id.');
-        }
+        
+        // ログインしている講師の講座でない場合は403エラーを返す
+        $this->authorize('view', $course);
+        
 
         $attendances = Attendance::with([
             'lessonAttendances.lesson.chapter.course',

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -152,14 +152,12 @@ class AttendanceController extends Controller
      */
     public function showStatus(ShowStatusRequest $request): JsonResponse
     {
-        $instructorId = Auth::guard('instructor')->user()->id;
         $courseId = $request->course_id;
         $course = Course::findOrFail($courseId);
         
         // ログインしている講師の講座でない場合は403エラーを返す
         $this->authorize('view', $course);
         
-
         $attendances = Attendance::with([
             'lessonAttendances.lesson.chapter.course',
             'lessonAttendances.lesson.chapter.lessons',


### PR DESCRIPTION
## Issue
- Closes #JKA-1777

## 概要
- 講師側の「出席管理アプリ」において、講座の状況取得API（ `showStatus` メソッド）に認可処理（Policyパターン）を導入しました。
- ログインしている講師が、自分が担当していない「他人の講座」の情報を不正に取得できないようにセキュリティブロックをかけています。
- 既存のコントローラ内にあった手動の `if` 文によるID比較ロジックを削り、 `$this->authorize('view', $course);` を用いたLaravel標準のPolicy認証へリファクタリングを行いました。

## 動作確認手順
1. ログインしている講師が担当している講座のIDを指定して `showStatus` API（または該当画面）を呼び出した際、正常に200レスポンス（講座状況のJSONデータ）が返ってくることを確認。
2. 別の講師が担当している（自分に権限がない）講座のIDを故意に指定してアクセスを試みた際、その場で処理が強制終了し、適切に `403 Forbidden` エラーが返ってくることを確認。

## 考慮して欲しいこと
- コントローラ側で元々手動で取得していた `$instructorId` や比較用の `if` 文は、 `authorize` メソッドが裏側で自動的にログインユーザーを識別して Policy に渡してくれる仕様を活かし、すべて綺麗に削除して共通化しています。

## 確認してほしいこと
- `AttendanceController` 側での `$this->authorize('view', $course);` の呼び出し方、155行目のコードは不要か自信が持てないので確認お願いいたします。

