### PR TITLE
生徒ログアウト失敗(remember_token欠落)の修正とログアウトテスト追加

### DIFF
--- a/app/Model/Student.php
+++ b/app/Model/Student.php
@@ -44,6 +44,35 @@ class Student extends Authenticatable
     ];
 
     /**
+     * Get the remember token value.
+     */
+    #[\Override]
+    public function getRememberToken(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Set the remember token value.
+     *
+     * @param  string  $value
+     */
+    #[\Override]
+    public function setRememberToken($value): void
+    {
+        // Do nothing.
+    }
+
+    /**
+     * Get the name of the remember token.
+     */
+    #[\Override]
+    public function getRememberTokenName(): string
+    {
+        return '';
+    }
+
+    /**
      * 講座を取得
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany

--- a/tests/Feature/Auth/InstructorLogoutTest.php
+++ b/tests/Feature/Auth/InstructorLogoutTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Model\Instructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InstructorLogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ログアウト_成功(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create();
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->postJson(route('instructor.logout'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Unauthenticated.',
+        ]);
+        $this->assertGuest('instructor');
+    }
+
+    public function test_未認証時_ログアウト(): void
+    {
+        // Act
+        $response = $this->postJson(route('instructor.logout'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Already Unauthenticated.',
+        ]);
+    }
+}

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Model\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ログアウト_成功(): void
+    {
+        // Arrange
+        $student = Student::factory()->create();
+        $this->actingAs($student);
+
+        // Act
+        $response = $this->postJson(route('logout'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Unauthenticated.',
+        ]);
+        $this->assertGuest();
+    }
+
+    public function test_未認証時_ログアウト(): void
+    {
+        // Act
+        $response = $this->postJson(route('logout'));
+
+        // Assert
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Already Unauthenticated.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Issue
生徒のログアウトが `MissingAttributeException: The attribute [remember_token] ...` で失敗する不具合の修正。

`students` テーブルに `remember_token` カラムが存在せず、開発環境で有効な `Model::shouldBeStrict()` 下で `Auth::logout()` が `remember_token` 属性へアクセスした際に例外が発生していた。

## 対応内容
- `App\Model\Student` に remember token 関連の3メソッド（`getRememberToken` / `setRememberToken` / `getRememberTokenName`）をオーバーライドし、remember token 機能を無効化（既存の `App\Model\Instructor` と同一パターン）。
- 回帰防止として生徒ログアウトの Feature テストを追加（`tests/Feature/Auth/LogoutTest.php`）。
- 対称性のため講師ログアウトの Feature テストも追加（`tests/Feature/Auth/InstructorLogoutTest.php`）。

## 確認方法
```bash
docker compose exec app bash -c 'cd laravelapp && php artisan test tests/Feature/Auth/'
```
- 全 13 件パスすることを確認。
- 修正前の状態（`Student.php` の修正を外した状態）では `LogoutTest::test_ログアウト_成功` が本不具合と同じ例外で失敗することを確認済み。

## 関連資料(任意)

## スクショ(任意)

## 質問(任意)

## その他(任意)
- DB スキーマ変更（マイグレーション追加）は行わず、既存の講師モデルと同じ実装方針に合わせています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
