### PR TITLE
JKA-1785 Instructor/AttendanceControllerのloginRateメソッドの認可処理と動作確認

### DIFF
--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -111,14 +111,10 @@ class AttendanceController extends Controller
      */
     public function loginRate(LoginRateRequest $request): JsonResponse
     {
-        $instructorId = Course::findOrFail($request->course_id)->instructor_id;
-        $loginId = Auth::guard('instructor')->user()->id;
-
-        if ($instructorId !== $loginId) {
-            throw new AuthorizationException(
-                'Forbidden, not allowed to access this course.'
-            );
-        }
+        $courseId = $request->course_id;
+        $course = Course::findOrFail($courseId);
+        // ログインしている講師の講座でない場合は403エラーを返す
+        $this->authorize('view', $course);
 
         $nowDate = new Carbon;
 

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -111,7 +111,7 @@ class AttendanceController extends Controller
     {
         $courseId = $request->course_id;
         $course = Course::findOrFail($courseId);
-        // ログインしている講師の講座でない場合は403エラーを返す
+        // 担当講師またはマネージャー権限のある講師以外は403エラーを返す
         $this->authorize('view', $course);
 
         $nowDate = new Carbon;

--- a/app/Http/Controllers/Api/Instructor/AttendanceController.php
+++ b/app/Http/Controllers/Api/Instructor/AttendanceController.php
@@ -28,11 +28,9 @@ use App\Services\Attendance\ShowService;
 use App\Services\Attendance\StoreService;
 use App\Services\Attendance\StuckPointsService;
 use Exception;
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 

--- a/tests/Feature/Api/Instructor/Attendance/LoginRateTest.php
+++ b/tests/Feature/Api/Instructor/Attendance/LoginRateTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\Api\Instructor\Attendance;
+
+use App\Model\Course;
+use App\Model\Instructor;
+use App\Model\ManageInstructor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LoginRateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_担当講師はログイン率を取得できる_成功(): void
+    {
+        // Arrange — 自分の講座のログイン率を取得する
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $instructor->id]);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.courses.attendances.login-rate', [
+            'course_id' => $course->id,
+            'period' => 'week',
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+    }
+
+    public function test_配下講師の講座はマネージャーがログイン率を取得できる_成功(): void
+    {
+        // Arrange — マネージャーが配下講師の講座のログイン率を取得する
+        $manager = Instructor::factory()->create();
+        $subordinate = Instructor::factory()->create(['type' => 'instructor']);
+        ManageInstructor::factory()->create([
+            'manager_id' => $manager->id,
+            'instructor_id' => $subordinate->id,
+        ]);
+        $course = Course::factory()->create(['instructor_id' => $subordinate->id]);
+        $this->actingAs($manager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.courses.attendances.login-rate', [
+            'course_id' => $course->id,
+            'period' => 'week',
+        ]));
+
+        // Assert
+        $response->assertStatus(200);
+    }
+
+    public function test_担当外の講師はログイン率を取得できない_失敗(): void
+    {
+        // Arrange — 他の講師の講座を指定する
+        $ownerInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $ownerInstructor->id]);
+        $otherInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        $this->actingAs($otherInstructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.courses.attendances.login-rate', [
+            'course_id' => $course->id,
+            'period' => 'week',
+        ]));
+
+        // Assert
+        $response->assertStatus(403);
+    }
+
+    public function test_配下でないマネージャーはログイン率を取得できない_失敗(): void
+    {
+        // Arrange — 配下ではない講師の講座を指定する
+        $ownerInstructor = Instructor::factory()->create(['type' => 'instructor']);
+        $course = Course::factory()->create(['instructor_id' => $ownerInstructor->id]);
+        $otherManager = Instructor::factory()->create();
+        $this->actingAs($otherManager, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.courses.attendances.login-rate', [
+            'course_id' => $course->id,
+            'period' => 'week',
+        ]));
+
+        // Assert
+        $response->assertStatus(403);
+    }
+
+    public function test_バリデーションエラー(): void
+    {
+        // Arrange
+        $instructor = Instructor::factory()->create(['type' => 'instructor']);
+        $this->actingAs($instructor, 'instructor');
+
+        // Act
+        $response = $this->getJson(route('instructor.courses.attendances.login-rate', [
+            'course_id' => 'aaa',
+            'period' => 'bbb',
+        ]));
+
+        // Assert
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'course_id',
+            'period',
+        ]);
+    }
+}


### PR DESCRIPTION
## Issue
・JKA-1785 Instructor/AttendanceControllerのloginRateメソッドの認可処理と動作確認
## 対応内容
Instructor/AttendanceControllerのloginRateメソッドに認可処理を追加し、ログインしている講師のみがアクセスできる状態とする。

## 確認方法
Postmanで以下のリクエストを送信

Method: GET
Endpoint: http://localhost:8080/api/v1/instructor/courses/:course_id/attendances/:period

パラメータにてcouse_IDを指定
担当講師もしくはマネージャー権限のある講師の場合はログイン率を取得できることを確認。
非担当講師、マネージャー権限を持たない講師、生徒の場合は403エラーが返されることを確認。