### PR TITLE
JKA-1767 受講生向け受講一覧APIの階層的可視性対応

### DIFF
--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -4,6 +4,8 @@ namespace App\Services\Student\Attendance;
 
 use App\Dto\Student\Attendance\IndexDto;
 use App\Enums\Course\StatusEnum as CourseStatusEnum;
+use App\Enums\Chapter\StatusEnum as ChapterStatusEnum;
+use App\Enums\Lesson\StatusEnum as LessonStatusEnum;
 use App\Model\Attendance;
 use App\Model\Chapter;
 use App\Model\Lesson;
@@ -22,22 +24,22 @@ class IndexService
         // 受講情報を関連情報と一緒に取得
         $attendances = Attendance::with([
             'course.instructor',
-            'course.chapters.lessons',
+            'course.chapters' => fn ($q) => $q->where('status', ChapterStatusEnum::PUBLIC->value),
+            'course.chapters.lessons' => fn ($q) => $q->where('status', LessonStatusEnum::PUBLIC->value),
             'lessonAttendances',
             'course.tags',
             'course.courseDeadline',
         ])
             ->where('student_id', $indexDto->getStudentId())
             ->whereHas('course', function (Builder $query) use ($indexDto) {
-                $query->when(! $indexDto->getSearchWord(), function (Builder $query) {
-                    $query->where('status', CourseStatusEnum::PUBLIC->value);
-                })->when($indexDto->getSearchWord(), function (Builder $query) use ($indexDto) {
-                    $query->where('title', 'like', "%{$indexDto->getSearchWord()}%")
-                        ->orWhereHas('tags', function (Builder $query) use ($indexDto) {
-                            $query->where('content', 'like', "%{$indexDto->getSearchWord()}%");
-                        })
-                        ->where('status', CourseStatusEnum::PUBLIC->value);
-                });
+                $query->where('status', CourseStatusEnum::PUBLIC->value);
+                if ($indexDto->getSearchWord()) {
+                    $word = $indexDto->getSearchWord();
+                    $query->where(function (Builder $q) use ($word) {
+                        $q->where('title', 'like', "%{$word}%")
+                            ->orWhereHas('tags', fn ($tagQuery) => $tagQuery->where('content', 'like', "%{$word}%"));
+                    });
+                }
             })
             ->when($tagId, function (Builder $query) use ($tagId) {
                 $query->whereHas('course.tags', function (Builder $query) use ($tagId) {
@@ -62,8 +64,13 @@ class IndexService
      */
     private function getCompletedChaptersCount(Attendance $attendance): int
     {
-        return $attendance->course->chapters->filter(fn (Chapter $chapter) => $chapter->lessons->every(function (Lesson $lesson) use ($attendance) {
-            $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
+        return $attendance->course->chapters->filter(fn (Chapter $chapter) =>
+            $chapter->status === ChapterStatusEnum::PUBLIC->value &&
+            $chapter->lessons->filter(
+                fn (Lesson $lesson) => $lesson->status === LessonStatusEnum::PUBLIC->value
+            )
+            ->every(function (Lesson $lesson) use ($attendance) {
+                $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
 
             return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
         }))->count();
@@ -74,6 +81,10 @@ class IndexService
      */
     private function getTotalChaptersCount(Attendance $attendance): int
     {
-        return $attendance->course->chapters->count();
+        return $attendance->course->chapters
+            ->filter(fn (Chapter $chapter) =>
+                    $chapter->status === ChapterStatusEnum::PUBLIC->value
+            )
+            ->count();
     }
 }

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -65,7 +65,7 @@ class IndexService
     private function getCompletedChaptersCount(Attendance $attendance): int
     {
         return $attendance->course->chapters->filter(fn (Chapter $chapter) =>
-            $chapter->status === ChapterStatusEnum::PUBLIC->value &&
+            $chapter->status === ChapterStatusEnum::PUBLIC &&   //
             $chapter->lessons->filter(
                 fn (Lesson $lesson) => $lesson->status === LessonStatusEnum::PUBLIC->value
             )

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -3,8 +3,8 @@
 namespace App\Services\Student\Attendance;
 
 use App\Dto\Student\Attendance\IndexDto;
-use App\Enums\Course\StatusEnum as CourseStatusEnum;
 use App\Enums\Chapter\StatusEnum as ChapterStatusEnum;
+use App\Enums\Course\StatusEnum as CourseStatusEnum;
 use App\Enums\Lesson\StatusEnum as LessonStatusEnum;
 use App\Model\Attendance;
 use App\Model\Chapter;
@@ -64,16 +64,15 @@ class IndexService
      */
     private function getCompletedChaptersCount(Attendance $attendance): int
     {
-        return $attendance->course->chapters->filter(fn (Chapter $chapter) =>
-            $chapter->status === ChapterStatusEnum::PUBLIC &&
+        return $attendance->course->chapters->filter(fn (Chapter $chapter) => $chapter->status === ChapterStatusEnum::PUBLIC &&
             $chapter->lessons->filter(
                 fn (Lesson $lesson) => $lesson->status === LessonStatusEnum::PUBLIC
             )
-            ->every(function (Lesson $lesson) use ($attendance) {
-                $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
+                ->every(function (Lesson $lesson) use ($attendance) {
+                    $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
 
-            return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
-        }))->count();
+                    return $lessonAttendance && $lessonAttendance->status === LessonAttendance::STATUS_COMPLETED_ATTENDANCE;
+                }))->count();
     }
 
     /**
@@ -82,8 +81,7 @@ class IndexService
     private function getTotalChaptersCount(Attendance $attendance): int
     {
         return $attendance->course->chapters
-            ->filter(fn (Chapter $chapter) =>
-                    $chapter->status === ChapterStatusEnum::PUBLIC
+            ->filter(fn (Chapter $chapter) => $chapter->status === ChapterStatusEnum::PUBLIC
             )
             ->count();
     }

--- a/app/Services/Student/Attendance/IndexService.php
+++ b/app/Services/Student/Attendance/IndexService.php
@@ -65,9 +65,9 @@ class IndexService
     private function getCompletedChaptersCount(Attendance $attendance): int
     {
         return $attendance->course->chapters->filter(fn (Chapter $chapter) =>
-            $chapter->status === ChapterStatusEnum::PUBLIC &&   //
+            $chapter->status === ChapterStatusEnum::PUBLIC &&
             $chapter->lessons->filter(
-                fn (Lesson $lesson) => $lesson->status === LessonStatusEnum::PUBLIC->value
+                fn (Lesson $lesson) => $lesson->status === LessonStatusEnum::PUBLIC
             )
             ->every(function (Lesson $lesson) use ($attendance) {
                 $lessonAttendance = $attendance->lessonAttendances->firstWhere('lesson_id', $lesson->id);
@@ -83,7 +83,7 @@ class IndexService
     {
         return $attendance->course->chapters
             ->filter(fn (Chapter $chapter) =>
-                    $chapter->status === ChapterStatusEnum::PUBLIC->value
+                    $chapter->status === ChapterStatusEnum::PUBLIC
             )
             ->count();
     }


### PR DESCRIPTION
## Issue
・JKA-1767 受講生向け受講一覧APIの階層的可視性対応

## 対応内容
受講生向け受講一覧APIに講座・チャプター・レッスンの状態（下書きdraft、公開中public、非公開private）を反映させる。下書きまたは非公開の項目は受講一覧に表示されない。

## 確認方法
Postmanで以下のリクエストを送信
＜受講一覧取得＞
Method: GET
Endpoint
http://localhost:8080/api/v1/student/attendances/index?per_page=6&page=1

Adminerでcouse、chapter、lessonの状態（draft、public、privete）を変更し、状態に応じてcontinue_fromに表示される項目が変わることを確認。
