### PR TITLE
JKA-1679　レッスン削除APIの削除制約整備 (西尾)　

### DIFF
--- a/app/Http/Controllers/Api/Instructor/LessonController.php
+++ b/app/Http/Controllers/Api/Instructor/LessonController.php
@@ -84,7 +84,7 @@ class LessonController extends Controller
             : $lesson->status;
 
         // UpdateLessonServiceを呼び出し更新処理
-        DB::transaction(fn () => $service($lesson, $request->title, $request->url, $request->remarks, $status));
+        DB::transaction(fn() => $service($lesson, $request->title, $request->url, $request->remarks, $status));
 
         return response()->json([
             'result' => true,
@@ -102,11 +102,6 @@ class LessonController extends Controller
 
             // ログイン講師のidと削除レッスンの講師IDが一致しないと削除できない
             $this->authorize('delete', $lesson);
-
-            // 受講情報が登録されている場合は削除を許可しない
-            if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
-                throw new AuthorizationException('Forbidden, this lesson has attendance.');
-            }
 
             $deleteLessonService($lesson);
 
@@ -144,10 +139,6 @@ class LessonController extends Controller
                 if ((int) $chapterId !== $lesson->chapter_id) {
                     throw new AuthorizationException('Invalid chapter.');
                 }
-                // 受講情報が登録されている場合は許可しない
-                if ($lesson->lessonAttendances->isNotEmpty()) {
-                    throw new AuthorizationException('This lesson has attendance.');
-                }
             });
 
             // サービスクラスで対象レッスンの削除処理を実行
@@ -182,7 +173,7 @@ class LessonController extends Controller
         $status = StatusEnum::from((string) $request->validated()['status']);
 
         // UpdateLessonStatusServiceを呼び出し更新処理
-        DB::transaction(fn () => $service($lesson, $status));
+        DB::transaction(fn() => $service($lesson, $status));
 
         return response()->json([
             'result' => true,

--- a/app/Services/Lesson/BulkDeleteLessonsService.php
+++ b/app/Services/Lesson/BulkDeleteLessonsService.php
@@ -3,6 +3,9 @@
 namespace App\Services\Lesson;
 
 use App\Model\Lesson;
+use App\Model\LessonAttendance;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\DB;
 
 class BulkDeleteLessonsService
 {
@@ -10,20 +13,29 @@ class BulkDeleteLessonsService
      * 複数レッスンの削除
      *
      * @param  array<int>  $lessonIds
+     * @param int $chapterId
+     * @throws AuthorizationException
      */
     public function __invoke(array $lessonIds, int $chapterId): void
     {
-        // 削除対象レッスンのorderカラムを0に設定する
-        Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
-        // 対象レッスンの削除
-        Lesson::whereIn('id', $lessonIds)->delete();
+        // 指定されたレッスンの中に受講状況が存在するかチェック
+        if (LessonAttendance::whereIn('lesson_id', $lessonIds)->exists()) {
+            throw new AuthorizationException('Forbidden, this lesson has attendance.');
+        }
 
-        // レッスン順序の更新
-        Lesson::where('chapter_id', $chapterId)
-            ->orderBy('order')
-            ->get()
-            ->each(function (Lesson $lesson, int $index) {
-                $lesson->update(['order' => $index + 1]);
-            });
+        DB::transaction(function () use ($lessonIds, $chapterId) {
+            // 削除対象レッスンのorderカラムを0に設定する
+            Lesson::whereIn('id', $lessonIds)->update(['order' => 0]);
+            // 対象レッスンの削除
+            Lesson::whereIn('id', $lessonIds)->delete();
+
+            // レッスン順序の更新
+            Lesson::where('chapter_id', $chapterId)
+                ->orderBy('order')
+                ->get()
+                ->each(function (Lesson $lesson, int $index) {
+                    $lesson->update(['order' => $index + 1]);
+                });
+        });
     }
 }

--- a/app/Services/Lesson/DeleteAllLessonsService.php
+++ b/app/Services/Lesson/DeleteAllLessonsService.php
@@ -19,7 +19,7 @@ class DeleteAllLessonsService
         // 出席済みのレッスンがあれば削除不可
         $attendedLessonIds = LessonAttendance::whereIn('lesson_id', $lessonIds)->pluck('lesson_id');
         if ($attendedLessonIds->isNotEmpty()) {
-            throw new AuthorizationException('This lessons contains attendance.');
+            throw new AuthorizationException('Forbidden, this lesson has attendance.');
         }
 
         // レッスン削除

--- a/app/Services/Lesson/DeleteLessonService.php
+++ b/app/Services/Lesson/DeleteLessonService.php
@@ -3,19 +3,32 @@
 namespace App\Services\Lesson;
 
 use App\Model\Lesson;
+use App\Model\LessonAttendance;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\DB;
 
 class DeleteLessonService
 {
+    /**
+     * @param Lesson $lesson
+     * @throws AuthorizationException
+     */
     public function __invoke(Lesson $lesson): void
     {
-        $lesson->update(['order' => 0]);
+        // 受講状況の存在チェック
+        if (LessonAttendance::where('lesson_id', $lesson->id)->exists()) {
+            throw new AuthorizationException('Forbidden, this lesson has attendance.');
+        }
 
-        $lesson->delete();
+        DB::transaction(function () use ($lesson) {
+            $lesson->update(['order' => 0]);
 
-        Lesson::where('chapter_id', $lesson->chapter_id)
-            ->orderBy('order')
-            ->get()
-            ->each(fn (Lesson $lesson, int $index): bool => (bool) $lesson->update(['order' => $index + 1])
-            );
+            $lesson->delete();
+
+            Lesson::where('chapter_id', $lesson->chapter_id)
+                ->orderBy('order')
+                ->get()
+                ->each(fn(Lesson $lesson, int $index): bool => (bool) $lesson->update(['order' => $index + 1]));
+        });
     }
 }


### PR DESCRIPTION
## Issue
- JKA-1679 講師側 レッスン削除APIの削除制約整備

## 対応内容
- **サービス層への制約ロジックの集約・完結**
  - `DeleteLessonService` に対象レッスン受講状況（LessonAttendance）のチェック処理を追加し、存在する場合は `AuthorizationException` を投げるように変更
  - `BulkDeleteLessonsService` に複数レッスン一括削除時の受講状況チェック処理を追加（講師側・マネージャー側の双方から共通で制約が効く仕様に統一）
  - `DeleteAllLessonsService` の例外メッセージを他のサービスと統一
 - **エラーメッセージの統一**
  - 受講状況保護による削除拒否時のメッセージを `'Forbidden, this lesson has attendance.'` に統一
- **コントローラー側の整理**
  - コントローラー層（`Instructor\LessonController` の delete / bulkDelete メソッド）に重複して存在していた受講状況の存在チェックを削除し、サービス層へ委譲する形に修正

## 確認方法
- **Tinkerによるサービス単体テスト**
  - Tinkerにて、`DeleteLessonService` や `BulkDeleteLessonsService` を直接インスタンス化して実行
- **Postmanによる各APIエンドポイントの疎通確認**
  - 講師側の単一削除API、一括削除API、全削除API、およびマネージャー側の一括削除APIに対し、受講状況が存在するレッスンを削除するリクエストを送信
  - すべてのエンドポイントで、削除が `403 Forbidden`（メッセージ：`Forbidden, this lesson has attendance.`）として正しく拒否されることを確認

